### PR TITLE
feat: Add marketplace module search

### DIFF
--- a/src/lola/market/manager.py
+++ b/src/lola/market/manager.py
@@ -56,3 +56,35 @@ class MarketplaceRegistry:
             )
         except ValueError as e:
             self.console.print(f"[red]Error: {e}[/red]")
+
+    def search_module(self, module_name: str) -> tuple[dict, str] | None:
+        """
+        Search for a module by name across all enabled marketplaces.
+
+        Args:
+            module_name: Name of the module to search for
+
+        Returns:
+            Tuple of (module_dict, marketplace_name) if found, None otherwise
+        """
+        # Iterate through all marketplace reference files
+        for ref_file in self.market_dir.glob("*.yml"):
+            # Load reference to check if marketplace is enabled
+            marketplace_ref = Marketplace.from_reference(ref_file)
+
+            if not marketplace_ref.enabled:
+                continue
+
+            # Load cache to get modules
+            cache_file = self.cache_dir / ref_file.name
+            if not cache_file.exists():
+                continue
+
+            marketplace = Marketplace.from_cache(cache_file)
+
+            # Search for module in this marketplace
+            for module in marketplace.modules:
+                if module.get("name") == module_name:
+                    return module, marketplace_ref.name
+
+        return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -360,3 +360,86 @@ def registered_module_with_module_subdir(
     shutil.copytree(sample_module_with_module_subdir, dest)
 
     return dest
+
+
+@pytest.fixture
+def marketplace_with_modules(tmp_path):
+    """Create a marketplace with test modules."""
+    import yaml
+
+    market_dir = tmp_path / "market"
+    cache_dir = market_dir / "cache"
+    market_dir.mkdir(parents=True)
+    cache_dir.mkdir(parents=True)
+
+    ref_data = {
+        "name": "official",
+        "url": "https://example.com/market.yml",
+        "enabled": True,
+    }
+    cache_data = {
+        "name": "Official Marketplace",
+        "description": "Official catalog",
+        "version": "1.0.0",
+        "url": "https://example.com/market.yml",
+        "enabled": True,
+        "modules": [
+            {
+                "name": "git-tools",
+                "description": "Git utilities",
+                "version": "1.0.0",
+                "repository": "https://github.com/test/git-tools.git",
+            },
+            {
+                "name": "python-utils",
+                "description": "Python utilities",
+                "version": "1.2.0",
+                "repository": "https://github.com/test/python-utils.git",
+            },
+        ],
+    }
+
+    with open(market_dir / "official.yml", "w") as f:
+        yaml.dump(ref_data, f)
+    with open(cache_dir / "official.yml", "w") as f:
+        yaml.dump(cache_data, f)
+
+    return {"market_dir": market_dir, "cache_dir": cache_dir}
+
+
+@pytest.fixture
+def marketplace_disabled(tmp_path):
+    """Create a disabled marketplace."""
+    import yaml
+
+    market_dir = tmp_path / "market"
+    cache_dir = market_dir / "cache"
+    market_dir.mkdir(parents=True)
+    cache_dir.mkdir(parents=True)
+
+    ref_data = {
+        "name": "disabled-market",
+        "url": "https://example.com/disabled.yml",
+        "enabled": False,
+    }
+    cache_data = {
+        "name": "Disabled Marketplace",
+        "version": "1.0.0",
+        "url": "https://example.com/disabled.yml",
+        "enabled": False,
+        "modules": [
+            {
+                "name": "test-module",
+                "description": "Test module",
+                "version": "1.0.0",
+                "repository": "https://github.com/test/test.git",
+            }
+        ],
+    }
+
+    with open(market_dir / "disabled-market.yml", "w") as f:
+        yaml.dump(ref_data, f)
+    with open(cache_dir / "disabled-market.yml", "w") as f:
+        yaml.dump(cache_data, f)
+
+    return {"market_dir": market_dir, "cache_dir": cache_dir}

--- a/tests/test_market_manager.py
+++ b/tests/test_market_manager.py
@@ -107,3 +107,42 @@ class TestMarketplaceRegistryAdd:
             # Verify error message was printed
             captured = capsys.readouterr()
             assert "Error:" in captured.out
+
+
+class TestMarketplaceRegistrySearchModule:
+    """Tests for MarketplaceRegistry.search_module()."""
+
+    def test_search_module_success(self, marketplace_with_modules):
+        """Search module in marketplace successfully."""
+        market_dir = marketplace_with_modules["market_dir"]
+        cache_dir = marketplace_with_modules["cache_dir"]
+
+        registry = MarketplaceRegistry(market_dir, cache_dir)
+        result = registry.search_module("git-tools")
+
+        assert result is not None
+        module, marketplace_name = result
+        assert module["name"] == "git-tools"
+        assert module["repository"] == "https://github.com/test/git-tools.git"
+        assert marketplace_name == "official"
+
+    def test_search_module_not_found(self, marketplace_with_modules):
+        """Module not found in any marketplace."""
+        market_dir = marketplace_with_modules["market_dir"]
+        cache_dir = marketplace_with_modules["cache_dir"]
+
+        registry = MarketplaceRegistry(market_dir, cache_dir)
+        result = registry.search_module("nonexistent-module")
+
+        assert result is None
+
+    def test_search_module_disabled_marketplace(self, marketplace_disabled):
+        """Skip disabled marketplaces when searching."""
+        market_dir = marketplace_disabled["market_dir"]
+        cache_dir = marketplace_disabled["cache_dir"]
+
+        registry = MarketplaceRegistry(market_dir, cache_dir)
+        result = registry.search_module("test-module")
+
+        # Should not find module in disabled marketplace
+        assert result is None


### PR DESCRIPTION
## Summary
- Implement MarketplaceRegistry.search_module() to find modules by name
- Search across all enabled marketplaces
- Skip disabled marketplaces when searching
- Add reusable test fixtures (marketplace_with_modules, marketplace_disabled)
- Add comprehensive tests for success, not found, and disabled scenarios

## Test Plan
- Run `pytest tests/test_market_manager.py::TestMarketplaceRegistrySearchModule` - all pass
- Manual test: Create marketplace, then search for module by name
- Verify disabled marketplaces are skipped

## Checklist
- [x] Tests pass (`pytest`)
- [x] Linting passes (`ruff check src tests`)
- [x] Type checking passes (`ty check src/lola/market/`)
- [x] Formatting passes (`ruff format --check`)

## AI Disclosure
Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>