### PR TITLE
feat(market): add marketplace management commands

### DIFF
--- a/src/lola/cli/market.py
+++ b/src/lola/cli/market.py
@@ -73,3 +73,25 @@ def market_rm(name: str):
     """
     registry = MarketplaceRegistry(MARKET_DIR, CACHE_DIR)
     registry.remove(name)
+
+
+@market.command(name="update")
+@click.argument("name", required=False)
+@click.option("--all", "update_all", is_flag=True, help="Update all marketplaces")
+def market_update(name: str, update_all: bool):
+    """
+    Update marketplace cache.
+
+    NAME: Marketplace name (optional, updates all if not specified)
+    """
+    if name and update_all:
+        click.echo("Error: Cannot specify both NAME and --all")
+        raise SystemExit(1)
+
+    registry = MarketplaceRegistry(MARKET_DIR, CACHE_DIR)
+
+    if name:
+        registry.update(name)
+        return
+
+    registry.update()


### PR DESCRIPTION
## Summary

- Add marketplace list command to display registered marketplaces
- Add enable/disable functionality for marketplace control
- Add remove command to delete marketplaces
- Add update command to refresh marketplace caches

## Related Issues

N/A

## Test Plan

- Run `pytest tests/test_cli_market.py -v` to verify all commands
- Test list: `lola market ls`
- Test enable/disable: `lola market set <name> --enable|--disable`
- Test remove: `lola market rm <name>`
- Test update: `lola market update [name]`
- Verify marketplace state persistence across operations

## Checklist

- [x] Tests pass (`pytest`)
- [x] Linting passes (`ruff check src tests`)
- [x] Type checking passes (`ty check`)

## AI Disclosure

AI-assisted with Claude Code (Sonnet 4.5)