### PR TITLE
docs: promote official Lola Marketplace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,6 +191,28 @@ PRs will be closed if they:
 Good AI-assisted contributions are thoughtful, tested, and show
 human understanding. We value your work!
 
+## Contributing to the Official Marketplace
+
+Beyond contributing to Lola itself, you can share your modules with the community through the [Official Lola Marketplace](https://github.com/RedHatProductSecurity/lola-market).
+
+### Why Contribute Modules?
+
+- **Share your skills**: Help others benefit from your AI workflows
+- **Get feedback**: Improve your modules through community input
+- **Build reputation**: Showcase your expertise in AI-assisted development
+
+### How to Add Your Module
+
+1. **Create your module**: Follow Lola's module structure (skills/, commands/, agents/)
+2. **Fork the marketplace**: https://github.com/RedHatProductSecurity/lola-market
+3. **Add your module**: Edit `general-market.yml` with your module entry
+4. **Update catalog**: Add your module to `docs/modules-catalog.md`
+5. **Submit PR**: We'll review and merge!
+
+See the [marketplace contributing guide](https://github.com/RedHatProductSecurity/lola-market/blob/main/CONTRIBUTING.md) for detailed instructions.
+
+**All contributions welcome!** Whether it's a productivity booster, code quality checker, or creative demo - the community wants to see it.
+
 ## Testing Guidelines
 
 ### Running Tests

--- a/README.md
+++ b/README.md
@@ -77,11 +77,27 @@ lola update
 
 Marketplaces let you discover and install modules from curated catalogs without manually finding repository URLs.
 
+### Official Lola Marketplace
+
+We maintain an official, community-driven marketplace with curated modules at [github.com/RedHatProductSecurity/lola-market](https://github.com/RedHatProductSecurity/lola-market).
+
+**Quick setup:**
+```bash
+lola market add general https://raw.githubusercontent.com/RedHatProductSecurity/lola-market/main/general-market.yml
+```
+
+This gives you instant access to community modules like workflow automation, code quality tools, and more. **We highly encourage you to:**
+- Use modules from the official marketplace
+- Contribute your own modules
+- Share feedback and improvements
+
+All contributions are welcome! See the [marketplace contributing guide](https://github.com/RedHatProductSecurity/lola-market/blob/main/CONTRIBUTING.md).
+
 ### Register a marketplace
 
 ```bash
 # Add a marketplace from a URL
-lola market add official https://example.com/marketplace.yml
+lola market add general https://raw.githubusercontent.com/RedHatProductSecurity/lola-market/main/general-market.yml
 
 # List registered marketplaces
 lola market ls
@@ -103,19 +119,19 @@ When a module exists in multiple marketplaces, Lola prompts you to select which 
 
 ```bash
 # Update marketplace cache
-lola market update official
+lola market update general
 
 # Update all marketplaces
 lola market update
 
 # Disable a marketplace (keeps it registered but excludes from search)
-lola market set --disable official
+lola market set --disable general
 
 # Re-enable a marketplace
-lola market set --enable official
+lola market set --enable general
 
 # Remove a marketplace
-lola market rm official
+lola market rm general
 ```
 
 ### Marketplace YAML format


### PR DESCRIPTION
## Summary

- Add prominent official marketplace callout in README
- Replace placeholder URLs with real marketplace URL
- Add marketplace contribution section to CONTRIBUTING
- Encourage community participation and module sharing

## Related Issues

Promotes the official Lola Marketplace at https://github.com/RedHatProductSecurity/lola-market

## Test Plan

- Documentation reviewed for accuracy
- All links verified and working
- Marketplace URL tested and functional

## Checklist

- [x] Tests pass (`pytest`)
- [x] Linting passes (`ruff check src tests`)
- [x] Type checking passes (`ty check`)

## AI Disclosure

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>