### PR TITLE
feat(mod): enhance mod info to support paths and fix content_path bug

### DIFF
--- a/src/lola/cli/mod.py
+++ b/src/lola/cli/mod.py
@@ -905,9 +905,7 @@ def module_info(module_name_or_path: str):
     else:
         from lola.frontmatter import parse_file as fm_parse_file
 
-        commands_dir = module.path / "commands"
-        for cmd_name in module.commands:
-            cmd_path = commands_dir / f"{cmd_name}.md"
+        for cmd_name, cmd_path in zip(module.commands, module.get_command_paths()):
             if cmd_path.exists():
                 console.print(f"  [green]/{module.name}.{cmd_name}[/green]")
                 # Show description from frontmatter
@@ -926,9 +924,7 @@ def module_info(module_name_or_path: str):
     else:
         from lola.frontmatter import parse_file as fm_parse_file
 
-        agents_dir = module.path / "agents"
-        for agent_name in module.agents:
-            agent_path = agents_dir / f"{agent_name}.md"
+        for agent_name, agent_path in zip(module.agents, module.get_agent_paths()):
             if agent_path.exists():
                 console.print(f"  [green]@{module.name}.{agent_name}[/green]")
                 # Show description from frontmatter

--- a/tests/test_cli_mod.py
+++ b/tests/test_cli_mod.py
@@ -707,6 +707,38 @@ class TestModInfoAdvanced:
         assert result.exit_code == 1
         assert "Path not found" in result.output
 
+    def test_info_module_subdir_shows_descriptions(self, cli_runner, tmp_path):
+        """Show descriptions for commands/agents in module/ subdirectory structure."""
+        # Create module with module/ subdirectory structure
+        module_dir = tmp_path / "test-mod"
+        module_dir.mkdir()
+        content_dir = module_dir / "module"
+        content_dir.mkdir()
+
+        # Create command with description
+        commands_dir = content_dir / "commands"
+        commands_dir.mkdir()
+        (commands_dir / "my-cmd.md").write_text(
+            "---\ndescription: My command description\n---\n\nCommand content"
+        )
+
+        # Create agent with description
+        agents_dir = content_dir / "agents"
+        agents_dir.mkdir()
+        (agents_dir / "my-agent.md").write_text(
+            "---\ndescription: My agent description\n---\n\nAgent content"
+        )
+
+        with patch("lola.cli.mod.ensure_lola_dirs"):
+            result = cli_runner.invoke(mod, ["info", str(module_dir)])
+
+        assert result.exit_code == 0
+        assert "/test-mod.my-cmd" in result.output
+        assert "My command description" in result.output
+        assert "@test-mod.my-agent" in result.output
+        assert "My agent description" in result.output
+        assert "(not found)" not in result.output
+
 
 class TestModUpdate:
     """Tests for mod update command."""


### PR DESCRIPTION
## Summary

- Allow `lola mod info` to accept both registered module names and local paths (e.g., `.`, `./my-module`, or absolute paths), enabling inspection of modules during development without requiring registration first
- Fix bug where commands and agents showed "(not found)" for modules using the `module/` subdirectory structure by using `content_path` instead of `path`

## Test plan

- [x] Existing tests pass (56 tests)
- [x] New tests added for path-based module info (`.`, relative paths, absolute paths, non-existent paths)
- [x] New test for module/ subdirectory structure verifying descriptions display correctly
- [x] Manual verification with reproduction steps from bug report

## AI Disclosure

Assisted-by: Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)