### PR TITLE
feat(targets): add Cursor 2.4 skills and subagent support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,12 +105,13 @@ Defined in `targets.py` TARGETS dict. Each assistant has different output format
 | Assistant | Skills | Commands | Agents |
 |-----------|--------|----------|--------|
 | claude-code | `.claude/skills/<module>-<skill>/SKILL.md` | `.claude/commands/<module>-<cmd>.md` | `.claude/agents/<module>-<agent>.md` |
-| cursor | `.cursor/rules/<module>-<skill>.mdc` | `.cursor/commands/<module>-<cmd>.md` | N/A |
+| cursor | `.cursor/skills/<module>-<skill>/SKILL.md` | `.cursor/commands/<module>-<cmd>.md` | `.cursor/agents/<module>-<agent>.md` |
 | gemini-cli | `GEMINI.md` (managed section) | `.gemini/commands/<module>-<cmd>.toml` | N/A |
 | opencode | `AGENTS.md` (managed section) | `.opencode/commands/<module>-<cmd>.md` | `.opencode/agent/<module>-<agent>.md` |
 
 Agent frontmatter is modified during generation:
-- Claude Code: `model: inherit` is added
+- Claude Code: `name` and `model: inherit` are added
+- Cursor: `name` and `model: inherit` are added
 - OpenCode: `mode: subagent` is added
 
 ### Source Handlers

--- a/src/lola/targets/__init__.py
+++ b/src/lola/targets/__init__.py
@@ -29,7 +29,7 @@ from lola.targets.base import (
 
 # Concrete target implementations
 from lola.targets.claude_code import ClaudeCodeTarget
-from lola.targets.cursor import CursorTarget, _rewrite_relative_paths
+from lola.targets.cursor import CursorTarget
 from lola.targets.gemini import GeminiTarget, _convert_to_gemini_args
 from lola.targets.opencode import OpenCodeTarget
 
@@ -90,7 +90,6 @@ __all__ = [
     "_get_content_path",
     "_get_skill_description",
     "_skill_source_dir",
-    "_rewrite_relative_paths",
     "_convert_to_gemini_args",
     "_generate_passthrough_command",
     "_generate_agent_with_frontmatter",

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -163,10 +163,10 @@ class TestAgentConfig:
         target = get_target("claude-code")
         assert target.supports_agents is True
 
-    def test_cursor_does_not_support_agents(self):
-        """Cursor does not support agents."""
+    def test_cursor_supports_agents(self):
+        """Cursor 2.4+ supports subagents."""
         target = get_target("cursor")
-        assert target.supports_agents is False
+        assert target.supports_agents is True
 
     def test_gemini_does_not_support_agents(self):
         """Gemini doesn't support agents."""
@@ -178,6 +178,12 @@ class TestAgentConfig:
         target = get_target("claude-code")
         path = target.get_agent_path(str(tmp_path))
         assert path == tmp_path / ".claude" / "agents"
+
+    def test_get_agent_path_cursor_project(self, tmp_path):
+        """Get Cursor project agent path (2.4+)."""
+        target = get_target("cursor")
+        path = target.get_agent_path(str(tmp_path))
+        assert path == tmp_path / ".cursor" / "agents"
 
     def test_get_agent_path_gemini_returns_none(self):
         """Gemini's get_agent_path returns None."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -120,11 +120,11 @@ class TestGetSkillPath:
         assert "GEMINI.md" in str(path)
 
     def test_cursor_project(self, tmp_path):
-        """Get cursor project skill path."""
+        """Get cursor project skill path (Cursor 2.4+)."""
         target = get_target("cursor")
         path = target.get_skill_path(str(tmp_path))
         assert isinstance(path, Path)
-        assert "rules" in str(path)
+        assert "skills" in str(path)
 
     def test_unknown_assistant(self):
         """Raise error for unknown assistant."""

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -51,10 +51,10 @@ Do things.
         assert result == skill_content
 
     def test_cursor_skill_generation(self, tmp_path):
-        """Generate skill for Cursor (MDC format)."""
+        """Generate skill for Cursor (2.4+ SKILL.md format)."""
         skill_dir = tmp_path / "myskill"
         skill_dir.mkdir()
-        (skill_dir / "SKILL.md").write_text("""---
+        skill_content = """---
 name: myskill
 description: Test skill for cursor
 ---
@@ -62,19 +62,19 @@ description: Test skill for cursor
 # My Skill
 
 Content.
-""")
+"""
+        (skill_dir / "SKILL.md").write_text(skill_content)
 
         target = get_target("cursor")
         dest = tmp_path / "dest"
         success = target.generate_skill(skill_dir, dest, "test-myskill", str(tmp_path))
 
         assert success
-        mdc_file = dest / "test-myskill.mdc"
-        assert mdc_file.exists()
-        result = mdc_file.read_text()
-        assert "description: Test skill for cursor" in result
-        assert "globs:" in result
-        assert "alwaysApply: false" in result
+        skill_dest = dest / "test-myskill"
+        assert skill_dest.exists()
+        assert (skill_dest / "SKILL.md").exists()
+        result = (skill_dest / "SKILL.md").read_text()
+        assert result == skill_content
 
 
 class TestCommandConverters:


### PR DESCRIPTION
## Summary

- Update CursorTarget for Cursor 2.4 release features (https://cursor.com/changelog/2-4)
- Skills now use Agent Skills standard (`.cursor/skills/<name>/SKILL.md`) instead of MDC rules format
- Add subagent support (`.cursor/agents/<name>.md`) with `model: inherit` frontmatter
- Remove unused `_rewrite_relative_paths` helper
- Simplify implementation by reusing `BaseAssistantTarget.remove_skill`

## Changes

| Feature | Before (Cursor < 2.4) | After (Cursor 2.4+) |
|---------|----------------------|---------------------|
| Skills | `.cursor/rules/<name>.mdc` | `.cursor/skills/<name>/SKILL.md` |
| Agents | Not supported | `.cursor/agents/<name>.md` |
| Skill format | MDC with alwaysApply | Standard SKILL.md with supporting files |

## Test plan

- [x] All 502 existing tests pass
- [x] Linting passes (`ruff check src tests`)
- [x] Type checking passes (`ty check`)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)