### PR TITLE
fix: properly remove instructions when AGENTS.md is deleted

### DIFF
--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -489,8 +489,8 @@ def _update_instructions(ctx: UpdateContext, verbose: bool) -> bool:
     from lola.models import INSTRUCTIONS_FILE
 
     if not ctx.has_instructions or not ctx.inst.project_path:
-        # If module no longer has instructions but installation did, remove them
-        if ctx.inst.has_instructions and ctx.inst.project_path:
+        # Always attempt removal - handles stale installation records
+        if ctx.inst.project_path:
             instructions_dest = ctx.target.get_instructions_path(ctx.inst.project_path)
             ctx.target.remove_instructions(instructions_dest, ctx.inst.module_name)
             if verbose:

--- a/src/lola/targets/base.py
+++ b/src/lola/targets/base.py
@@ -628,12 +628,21 @@ class ManagedInstructionsTarget:
             # Clean up extra newlines
             section_content = re.sub(r"\n{3,}", "\n\n", section_content)
 
-        new_section = (
-            self.INSTRUCTIONS_START_MARKER
-            + section_content
-            + self.INSTRUCTIONS_END_MARKER
-        )
-        content = content[:start_idx] + new_section + content[end_idx:]
+        # Check if any module blocks remain
+        remaining_blocks = self._extract_module_blocks(section_content)
+        if remaining_blocks:
+            new_section = (
+                self.INSTRUCTIONS_START_MARKER
+                + section_content
+                + self.INSTRUCTIONS_END_MARKER
+            )
+            content = content[:start_idx] + new_section + content[end_idx:]
+        else:
+            # No modules left - remove the entire managed section and leading newlines
+            prefix = content[:start_idx].rstrip("\n")
+            suffix = content[end_idx:]
+            content = prefix + suffix
+
         dest_path.write_text(content)
         return True
 


### PR DESCRIPTION
## Summary

- Fixes `remove_instructions()` to completely remove the managed section when there are no more module blocks (instead of leaving empty markers)
- Fixes `_update_instructions()` to always attempt removal when a module no longer has instructions, handling stale installation records

## Related Issues

<!-- No specific issue, discovered during testing -->

## Test Plan

- [x] Added regression test for empty section cleanup (`test_remove_last_module_cleans_up_markers`)
- [x] Added regression test for stale installation record removal (`test_update_removes_instructions_with_stale_registry`)
- [x] All 508 tests pass

## Checklist

- [x] Tests pass (`pytest`)
- [x] Linting passes (`ruff check src tests`)
- [x] Type checking passes (`ty check`)

## AI Disclosure

AI-assisted with Claude Code (Claude Opus 4.5)