### PR TITLE
feat(market): add ability to list modules in a marketplace

### DIFF
--- a/src/lola/cli/market.py
+++ b/src/lola/cli/market.py
@@ -35,10 +35,19 @@ def market_add(name: str, url: str):
 
 
 @market.command(name="ls")
-def market_ls():
-    """List all registered marketplaces."""
+@click.argument("name", required=False)
+def market_ls(name: str | None):
+    """
+    List marketplaces or modules in a marketplace.
+
+    Without NAME: lists all registered marketplaces.
+    With NAME: lists all modules in the specified marketplace.
+    """
     registry = MarketplaceRegistry(MARKET_DIR, CACHE_DIR)
-    registry.list()
+    if name:
+        registry.show(name)
+    else:
+        registry.list()
 
 
 @market.command(name="set")

--- a/src/lola/models.py
+++ b/src/lola/models.py
@@ -401,7 +401,7 @@ class Marketplace:
     def to_cache_dict(self) -> dict:
         """Convert to dict for cache file."""
         return {
-            "name": self.description or self.name,
+            "name": self.name,
             "description": self.description,
             "version": self.version,
             "url": self.url,

--- a/tests/test_cli_market.py
+++ b/tests/test_cli_market.py
@@ -145,7 +145,7 @@ class TestMarketLs:
         """Show ls help."""
         result = cli_runner.invoke(market, ["ls", "--help"])
         assert result.exit_code == 0
-        assert "List all registered marketplaces" in result.output
+        assert "List marketplaces or modules" in result.output
 
     def test_ls_empty(self, cli_runner, tmp_path):
         """List when no marketplaces registered."""
@@ -177,6 +177,38 @@ class TestMarketLs:
         assert result.exit_code == 0
         assert "official" in result.output
         assert "enabled" in result.output
+
+    def test_ls_specific_marketplace(self, cli_runner, marketplace_with_modules):
+        """List modules in a specific marketplace."""
+        market_dir = marketplace_with_modules["market_dir"]
+        cache_dir = marketplace_with_modules["cache_dir"]
+
+        with (
+            patch("lola.cli.market.MARKET_DIR", market_dir),
+            patch("lola.cli.market.CACHE_DIR", cache_dir),
+        ):
+            result = cli_runner.invoke(market, ["ls", "official"])
+
+        assert result.exit_code == 0
+        assert "Official Marketplace" in result.output
+        assert "git-tools" in result.output
+        assert "python-utils" in result.output
+
+    def test_ls_specific_marketplace_not_found(self, cli_runner, tmp_path):
+        """Show error when marketplace not found."""
+        market_dir = tmp_path / "market"
+        cache_dir = market_dir / "cache"
+        market_dir.mkdir(parents=True)
+        cache_dir.mkdir(parents=True)
+
+        with (
+            patch("lola.cli.market.MARKET_DIR", market_dir),
+            patch("lola.cli.market.CACHE_DIR", cache_dir),
+        ):
+            result = cli_runner.invoke(market, ["ls", "nonexistent"])
+
+        assert result.exit_code == 0
+        assert "not found" in result.output
 
 
 class TestMarketSet:

--- a/tests/test_marketplace_model.py
+++ b/tests/test_marketplace_model.py
@@ -193,21 +193,16 @@ class TestMarketplaceSerialization:
             "enabled": False,
         }
 
-    @pytest.mark.parametrize(
-        "description,expected_name",
-        [
-            ("Test marketplace", "Test marketplace"),
-            ("", "fallback"),
-        ],
-    )
-    def test_to_cache_dict(self, description, expected_name):
+    def test_to_cache_dict(self):
         """Convert marketplace to cache dict."""
         marketplace = Marketplace(
-            name="fallback",
+            name="test-market",
             url="https://example.com/market.yml",
-            description=description,
+            description="Test marketplace description",
             version="1.0.0",
         )
         cache_dict = marketplace.to_cache_dict()
-        assert cache_dict["name"] == expected_name
+        assert cache_dict["name"] == "test-market"
+        assert cache_dict["description"] == "Test marketplace description"
         assert cache_dict["url"] == "https://example.com/market.yml"
+        assert cache_dict["version"] == "1.0.0"


### PR DESCRIPTION
## Summary
- Add `lola market ls <name>` command to list all modules in a specific marketplace
- Display module name, version, description, and tags in a formatted table
- Fix bug in `to_cache_dict()` where marketplace name was incorrectly set to description

## Test plan
- [x] Run `lola market ls` (without name) - lists all marketplaces
- [x] Run `lola market ls <name>` - lists modules in that marketplace
- [x] Run `lola market ls nonexistent` - shows error message
- [x] All 512 tests pass

## AI Disclosure
AI-assisted with Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)