### PR TITLE
fix: extract content subdir at fetch time for module_content handling

### DIFF
--- a/src/lola/models.py
+++ b/src/lola/models.py
@@ -269,10 +269,11 @@ class Module:
 
             # Custom subdirectory path
             custom_subdir = module_path / content_dirname
-            if not custom_subdir.exists() or not custom_subdir.is_dir():
-                return None, False
+            if custom_subdir.exists() and custom_subdir.is_dir():
+                return custom_subdir, True
 
-            return custom_subdir, True
+            # Subdirectory not found — content may have been extracted
+            # at fetch time; fall through to default discovery.
 
         # Default discovery: try module/ then fallback to root
         module_subdir = module_path / MODULE_CONTENT_DIRNAME


### PR DESCRIPTION
## Summary

Source handlers now respect the module_content_dirname parameter by extracting only the specified subdirectory instead of storing the entire repository. Fixes marketplace modules with 'path' field (e.g. path: lola-module) failing to install.


## Test Plan

1. add module using --module-content.
  e.g. lola mod add https://github.com/RedHatProductSecurity/secdevai.git --module-content=lola-module
2. install the module
3. No actual module is created in .cursor or .claude, etc.  (this PR fixes this)

## Checklist

- [x] Tests pass (`pytest`)
- [x] Linting passes (`ruff check src tests`)
- [x] Type checking passes (`ty check`)

## AI Disclosure


Co-authored-by: claude-4.6-opus-high