### PR TITLE
feat: add GitHub issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,93 @@
+name: "Bug Report"
+description: Report a bug or unexpected behavior in lola
+title: "[BUG] - "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the form below to help us diagnose and fix the issue.
+
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: "Bug Description"
+      description: A clear and concise description of what the bug is
+      placeholder: "Describe what happened and what you expected to happen..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: "Steps to Reproduce"
+      description: Steps to reproduce the behavior
+      placeholder: |
+        1. Run 'lola install ...'
+        2. Execute 'lola ...'
+        3. See error
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: "Component"
+      description: Which part of lola is affected?
+      options:
+        - CLI commands (install, mod, market, etc.)
+        - Module management
+        - Marketplace
+        - Target assistants (Claude Code, Cursor, etc.)
+        - Parsers (git, zip, tar sources)
+        - Skills/Commands/Agents
+        - Other
+    validations:
+      required: false
+
+  - type: input
+    id: lola-version
+    attributes:
+      label: "Lola Version"
+      description: Run `lola --version` to get the version
+      placeholder: "e.g., 0.1.0"
+    validations:
+      required: false
+
+  - type: input
+    id: python-version
+    attributes:
+      label: "Python Version"
+      description: Run `python --version` to get the version
+      placeholder: "e.g., Python 3.13.0"
+    validations:
+      required: false
+
+  - type: input
+    id: os
+    attributes:
+      label: "Operating System"
+      description: What OS are you using?
+      placeholder: "e.g., Fedora 43, Ubuntu 24.04, macOS 15"
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: "Logs and Error Messages"
+      description: |
+        Please include any relevant log output or error messages.
+        Drag and drop log files or paste the output here.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: "Additional Context"
+      description: Any other information that might be helpful
+      placeholder: "Screenshots, configuration files, related issues, etc."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discussions
+    url: https://github.com/RedHatProductSecurity/lola/discussions
+    about: Ask questions, share ideas, and discuss lola with the community
+  - name: Documentation
+    url: https://github.com/RedHatProductSecurity/lola/blob/main/README.md
+    about: Read the documentation to learn more about lola
+  - name: Security Issue
+    url: https://github.com/RedHatProductSecurity/lola/security/advisories/new
+    about: Report security vulnerabilities privately

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,85 @@
+name: "Feature Request"
+description: Suggest a new feature or enhancement for lola
+title: "[FEATURE] - "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a new feature! Please describe your idea below.
+
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: "Feature Description"
+      description: A clear and concise description of the feature you'd like to see
+      placeholder: "Describe the feature and how it would work..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem-solution
+    attributes:
+      label: "Problem or Use Case"
+      description: What problem does this feature solve? What use case does it enable?
+      placeholder: "I'm always frustrated when... / This would help me..."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: feature-category
+    attributes:
+      label: "Category"
+      description: Which area of lola does this feature relate to?
+      options:
+        - CLI/UX improvements
+        - Module management
+        - Marketplace
+        - New target assistant support
+        - Skills/Commands/Agents
+        - Installation/Update workflow
+        - Security/Safety
+        - Documentation
+        - Other
+    validations:
+      required: false
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: "Proposed Solution"
+      description: How would you like to see this implemented?
+      placeholder: "I'd like to see a command like 'lola xyz' that..."
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: "Alternatives Considered"
+      description: Have you considered any alternative solutions or workarounds?
+      placeholder: "I could work around this by..., but..."
+    validations:
+      required: false
+
+  - type: dropdown
+    id: complexity
+    attributes:
+      label: "Complexity Estimate"
+      description: How complex do you think this feature would be to implement?
+      options:
+        - "Simple (good first issue)"
+        - "Medium"
+        - "Complex"
+        - "I don't know"
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: "Additional Context"
+      description: Any other information, mockups, or examples that might be helpful
+      placeholder: "Related projects, examples from other tools, screenshots, etc."
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
Issues without templates make it difficult to gather structured information and properly prioritize work. New YAML-based templates guide contributors through reporting bugs and requesting features with lola-specific fields.

- bug_report.yml: structured form with reproduction steps, component selector (CLI, marketplace, target assistants, etc.), version info, and logs
- feature_request.yml: captures problem/use case, proposed solution, category, and complexity estimate (includes "good first issue" option)
- config.yml: template chooser with quick links to Discussions, Documentation, and Security reporting; allows blank issues for flexibility

Templates based on [konflux-ci/support](https://github.com/konflux-ci/support/tree/main/.github/ISSUE_TEMPLATE) style adapted for lola's workflow.


## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->

## Test Plan

<!-- How can reviewers verify this works? -->

- [ ]

## Checklist

- [ ] Tests pass (`pytest`)
- [ ] Linting passes (`ruff check src tests`)
- [ ] Type checking passes (`ty check`)

## AI Disclosure

Assisted-by: Cursor

<!-- If you used AI tools, mention them here or in your commit message -->
<!-- Examples: "AI-assisted with Claude Code", "Used GitHub Copilot" -->
<!-- Delete this section if not applicable -->
