### PR TITLE
feat: add shell completion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,44 @@ The sync command is **idempotent** - running it multiple times produces the same
 | `lola update`                          | Regenerate assistant files                    |
 | `lola sync`                            | Install modules from `.lola-req`              |
 
+### Shell Completion
+
+Enable tab completion for your shell to auto-complete module names, marketplace names, and command arguments:
+
+```bash
+# Bash - per-user install
+lola completions bash > ~/.local/share/bash-completion/completions/lola
+source ~/.local/share/bash-completion/completions/lola
+
+# Zsh - per-user install
+lola completions zsh > ~/.local/share/zsh/site-functions/_lola
+# Add ~/.local/share/zsh/site-functions to fpath in ~/.zshrc if needed
+
+# Fish - per-user install
+lola completions fish > ~/.config/fish/completions/lola.fish
+
+# Or evaluate in current shell (temporary)
+eval "$(lola completions bash)"
+```
+
+System-wide installation (requires root):
+
+```bash
+# Bash
+sudo lola completions bash > /usr/share/bash-completion/completions/lola
+
+# Zsh
+sudo lola completions zsh > /usr/share/zsh/site-functions/_lola
+
+# Fish
+sudo lola completions fish > /usr/share/fish/vendor_completions.d/lola.fish
+```
+
+Once enabled, you can tab-complete:
+- Module names in `lola install`, `lola mod rm`, `lola mod info`, etc.
+- Marketplace names in `lola market ls`, `lola market set`, etc.
+- Installed module names in `lola uninstall`, `lola update`
+
 ## Creating a Module
 
 ### 1. Initialize

--- a/src/lola/__main__.py
+++ b/src/lola/__main__.py
@@ -7,6 +7,7 @@ import click
 from rich.console import Console
 
 from lola import __version__
+from lola.cli.completions import completions_cmd
 from lola.cli.install import (
     install_cmd,
     list_installed_cmd,
@@ -60,6 +61,7 @@ main.add_command(uninstall_cmd)
 main.add_command(update_cmd)
 main.add_command(list_installed_cmd)
 main.add_command(sync_cmd)
+main.add_command(completions_cmd)
 
 
 if __name__ == "__main__":

--- a/src/lola/cli/completions.py
+++ b/src/lola/cli/completions.py
@@ -1,0 +1,100 @@
+"""
+completions:
+    Shell completion support for lola CLI
+"""
+
+import click
+from click.shell_completion import CompletionItem
+
+from lola.config import MODULES_DIR, MARKET_DIR, INSTALLED_FILE
+from lola.models import InstallationRegistry
+
+
+def complete_module_names(ctx, param, incomplete):
+    """Complete registered module names from MODULES_DIR."""
+    if not MODULES_DIR.exists():
+        return []
+
+    try:
+        modules = [
+            CompletionItem(d.name)
+            for d in MODULES_DIR.iterdir()
+            if d.is_dir() and d.name.startswith(incomplete)
+        ]
+        return modules
+    except Exception:
+        return []
+
+
+def complete_marketplace_names(ctx, param, incomplete):
+    """Complete marketplace names from MARKET_DIR/*.yml files."""
+    if not MARKET_DIR.exists():
+        return []
+
+    try:
+        marketplaces = [
+            CompletionItem(f.stem)
+            for f in MARKET_DIR.glob("*.yml")
+            if f.stem.startswith(incomplete)
+        ]
+        return marketplaces
+    except Exception:
+        return []
+
+
+def complete_installed_module_names(ctx, param, incomplete):
+    """Complete installed module names from InstallationRegistry."""
+    if not INSTALLED_FILE.exists():
+        return []
+
+    try:
+        registry = InstallationRegistry(INSTALLED_FILE)
+        # Get unique module names from all installations
+        module_names = set(inst.module_name for inst in registry.all())
+        modules = [
+            CompletionItem(name) for name in module_names if name.startswith(incomplete)
+        ]
+        return modules
+    except Exception:
+        return []
+
+
+@click.command(name="completions")
+@click.argument("shell", type=click.Choice(["bash", "zsh", "fish"]))
+def completions_cmd(shell: str):
+    """
+    Generate shell completion script.
+
+    \b
+    Usage:
+        # System-wide install (for RPM packaging):
+        lola completions bash > /usr/share/bash-completion/completions/lola
+        lola completions zsh  > /usr/share/zsh/site-functions/_lola
+        lola completions fish > /usr/share/fish/vendor_completions.d/lola.fish
+
+        # Per-user install:
+        lola completions bash > ~/.local/share/bash-completion/completions/lola
+
+        # Evaluate in current shell:
+        eval "$(lola completions bash)"
+    """
+    from click.shell_completion import get_completion_class
+
+    # Get the completion class for the specified shell
+    completion_class = get_completion_class(shell)
+
+    if completion_class is None:
+        click.echo(f"Error: Unsupported shell '{shell}'", err=True)
+        raise SystemExit(1)
+
+    # Get the root command (main CLI group)
+    # We need to traverse up to find the root command
+    ctx = click.get_current_context()
+    root_cmd = ctx.find_root().command
+
+    # Create a completion instance
+    completion = completion_class(root_cmd, {}, "lola", "_LOLA_COMPLETE")
+
+    # Generate and output the completion script source
+    script = completion.source()
+    click.echo(script)

--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -12,6 +12,7 @@ from typing import Any, Optional
 import click
 from rich.console import Console
 
+from lola.cli.completions import complete_module_names, complete_installed_module_names
 from lola.config import MODULES_DIR, MARKET_DIR, CACHE_DIR
 from lola.exceptions import (
     ModuleInvalidError,
@@ -633,7 +634,9 @@ def _format_update_summary(result: UpdateResult) -> str:
 
 
 @click.command(name="install")
-@click.argument("module_name", required=False, default=None)
+@click.argument(
+    "module_name", required=False, default=None, shell_complete=complete_module_names
+)
 @click.option(
     "-a",
     "--assistant",
@@ -848,7 +851,12 @@ def install_cmd(
 
 
 @click.command(name="uninstall")
-@click.argument("module_name", required=False, default=None)
+@click.argument(
+    "module_name",
+    required=False,
+    default=None,
+    shell_complete=complete_installed_module_names,
+)
 @click.option(
     "-a",
     "--assistant",
@@ -1103,7 +1111,12 @@ def uninstall_cmd(
 
 
 @click.command(name="update")
-@click.argument("module_name", required=False, default=None)
+@click.argument(
+    "module_name",
+    required=False,
+    default=None,
+    shell_complete=complete_installed_module_names,
+)
 @click.option(
     "-a",
     "--assistant",

--- a/src/lola/cli/market.py
+++ b/src/lola/cli/market.py
@@ -6,6 +6,7 @@ Commands for adding, managing, and searching marketplaces.
 
 import click
 
+from lola.cli.completions import complete_marketplace_names
 from lola.config import MARKET_DIR, CACHE_DIR
 from lola.market.manager import MarketplaceRegistry
 from lola.prompts import is_interactive, select_marketplace_name
@@ -41,7 +42,7 @@ def market_add(name: str, url: str):
 
 
 @market.command(name="ls")
-@click.argument("name", required=False)
+@click.argument("name", required=False, shell_complete=complete_marketplace_names)
 def market_ls(name: str | None):
     """
     List marketplaces or modules in a marketplace.
@@ -57,7 +58,9 @@ def market_ls(name: str | None):
 
 
 @market.command(name="set")
-@click.argument("name", required=False, default=None)
+@click.argument(
+    "name", required=False, default=None, shell_complete=complete_marketplace_names
+)
 @click.option("--enable", "action", flag_value="enable", help="Enable marketplace")
 @click.option("--disable", "action", flag_value="disable", help="Disable marketplace")
 def market_set(name: str | None, action: str):
@@ -97,7 +100,9 @@ def market_set(name: str | None, action: str):
 
 
 @market.command(name="rm")
-@click.argument("name", required=False, default=None)
+@click.argument(
+    "name", required=False, default=None, shell_complete=complete_marketplace_names
+)
 def market_rm(name: str | None):
     """
     Remove a marketplace.
@@ -127,7 +132,7 @@ def market_rm(name: str | None):
 
 
 @market.command(name="update")
-@click.argument("name", required=False)
+@click.argument("name", required=False, shell_complete=complete_marketplace_names)
 @click.option("--all", "update_all", is_flag=True, help="Update all marketplaces")
 def market_update(name: str, update_all: bool):
     """

--- a/src/lola/cli/mod.py
+++ b/src/lola/cli/mod.py
@@ -12,6 +12,7 @@ import click
 from rich.console import Console
 from rich.tree import Tree
 
+from lola.cli.completions import complete_module_names
 from lola.config import MCPS_FILE, MODULES_DIR, INSTALLED_FILE
 from lola.exceptions import (
     LolaError,
@@ -722,7 +723,9 @@ Edit files in `module/` (or `lola-module/`) to customize the content that gets i
 
 
 @mod.command(name="rm")
-@click.argument("module_name", required=False, default=None)
+@click.argument(
+    "module_name", required=False, default=None, shell_complete=complete_module_names
+)
 @click.option("-f", "--force", is_flag=True, help="Force removal without confirmation")
 def remove_module(module_name: str | None, force: bool):
     """
@@ -870,7 +873,12 @@ def list_modules(verbose: bool):
 
 
 @mod.command(name="info")
-@click.argument("module_name_or_path", required=False, default=None)
+@click.argument(
+    "module_name_or_path",
+    required=False,
+    default=None,
+    shell_complete=complete_module_names,
+)
 def module_info(module_name_or_path: str | None):
     """
     Show detailed information about a module.
@@ -1043,7 +1051,9 @@ def module_info(module_name_or_path: str | None):
 
 
 @mod.command(name="update")
-@click.argument("module_name", required=False, default=None)
+@click.argument(
+    "module_name", required=False, default=None, shell_complete=complete_module_names
+)
 def update_module_cmd(module_name: str | None):
     """
     Update module(s) from their original source.

--- a/tests/test_cli_completions.py
+++ b/tests/test_cli_completions.py
@@ -1,0 +1,257 @@
+"""Tests for shell completion support."""
+
+from unittest.mock import patch
+
+from lola.__main__ import main
+from lola.cli.completions import (
+    complete_module_names,
+    complete_marketplace_names,
+    complete_installed_module_names,
+)
+
+
+class TestCompletionsCommand:
+    """Tests for the 'lola completions' command."""
+
+    def test_completions_bash(self, cli_runner):
+        """Generate bash completion script."""
+        result = cli_runner.invoke(main, ["completions", "bash"])
+        assert result.exit_code == 0
+        assert "_LOLA_COMPLETE" in result.output
+        assert "bash" in result.output.lower()
+
+    def test_completions_zsh(self, cli_runner):
+        """Generate zsh completion script."""
+        result = cli_runner.invoke(main, ["completions", "zsh"])
+        assert result.exit_code == 0
+        assert "_LOLA_COMPLETE" in result.output
+        assert "zsh" in result.output.lower()
+
+    def test_completions_fish(self, cli_runner):
+        """Generate fish completion script."""
+        result = cli_runner.invoke(main, ["completions", "fish"])
+        assert result.exit_code == 0
+        assert "lola" in result.output
+
+    def test_completions_invalid_shell(self, cli_runner):
+        """Reject invalid shell argument."""
+        result = cli_runner.invoke(main, ["completions", "powershell"])
+        assert result.exit_code != 0
+        assert (
+            "Invalid value" in result.output
+            or "invalid choice" in result.output.lower()
+        )
+
+    def test_completions_help(self, cli_runner):
+        """Show completions help."""
+        result = cli_runner.invoke(main, ["completions", "--help"])
+        assert result.exit_code == 0
+        assert "Generate shell completion script" in result.output
+        assert "bash" in result.output
+        assert "zsh" in result.output
+        assert "fish" in result.output
+
+
+class TestModuleNamesCompletion:
+    """Tests for complete_module_names callback."""
+
+    def test_complete_module_names_no_modules_dir(self):
+        """Return empty list when MODULES_DIR doesn't exist."""
+        with patch("lola.cli.completions.MODULES_DIR") as mock_dir:
+            mock_dir.exists.return_value = False
+            result = complete_module_names(None, None, "")
+            assert result == []
+
+    def test_complete_module_names_with_modules(self, tmp_path):
+        """Return module names from MODULES_DIR."""
+        modules_dir = tmp_path / "modules"
+        modules_dir.mkdir()
+        (modules_dir / "module-one").mkdir()
+        (modules_dir / "module-two").mkdir()
+        (modules_dir / "other-module").mkdir()
+        # Create a file to ensure only directories are returned
+        (modules_dir / "file.txt").write_text("not a module")
+
+        with patch("lola.cli.completions.MODULES_DIR", modules_dir):
+            result = complete_module_names(None, None, "")
+            assert len(result) == 3
+            names = [item.value for item in result]
+            assert "module-one" in names
+            assert "module-two" in names
+            assert "other-module" in names
+
+    def test_complete_module_names_with_prefix(self, tmp_path):
+        """Filter module names by prefix."""
+        modules_dir = tmp_path / "modules"
+        modules_dir.mkdir()
+        (modules_dir / "module-one").mkdir()
+        (modules_dir / "module-two").mkdir()
+        (modules_dir / "other-module").mkdir()
+
+        with patch("lola.cli.completions.MODULES_DIR", modules_dir):
+            result = complete_module_names(None, None, "module-")
+            assert len(result) == 2
+            names = [item.value for item in result]
+            assert "module-one" in names
+            assert "module-two" in names
+            assert "other-module" not in names
+
+    def test_complete_module_names_handles_exception(self):
+        """Return empty list when MODULES_DIR iteration raises an exception."""
+        with patch("lola.cli.completions.MODULES_DIR") as mock_dir:
+            mock_dir.exists.return_value = True
+            mock_dir.iterdir.side_effect = PermissionError("Access denied")
+            result = complete_module_names(None, None, "")
+            assert result == []
+
+
+class TestMarketplaceNamesCompletion:
+    """Tests for complete_marketplace_names callback."""
+
+    def test_complete_marketplace_names_no_market_dir(self):
+        """Return empty list when MARKET_DIR doesn't exist."""
+        with patch("lola.cli.completions.MARKET_DIR") as mock_dir:
+            mock_dir.exists.return_value = False
+            result = complete_marketplace_names(None, None, "")
+            assert result == []
+
+    def test_complete_marketplace_names_with_marketplaces(self, tmp_path):
+        """Return marketplace names from MARKET_DIR/*.yml files."""
+        market_dir = tmp_path / "market"
+        market_dir.mkdir()
+        (market_dir / "official.yml").write_text(
+            "enabled: true\nurl: http://example.com"
+        )
+        (market_dir / "community.yml").write_text(
+            "enabled: true\nurl: http://example.com"
+        )
+        (market_dir / "test.yml").write_text("enabled: false\nurl: http://example.com")
+        # Create a non-yml file to ensure only .yml files are returned
+        (market_dir / "readme.txt").write_text("not a marketplace")
+
+        with patch("lola.cli.completions.MARKET_DIR", market_dir):
+            result = complete_marketplace_names(None, None, "")
+            assert len(result) == 3
+            names = [item.value for item in result]
+            assert "official" in names
+            assert "community" in names
+            assert "test" in names
+
+    def test_complete_marketplace_names_with_prefix(self, tmp_path):
+        """Filter marketplace names by prefix."""
+        market_dir = tmp_path / "market"
+        market_dir.mkdir()
+        (market_dir / "official.yml").write_text(
+            "enabled: true\nurl: http://example.com"
+        )
+        (market_dir / "community.yml").write_text(
+            "enabled: true\nurl: http://example.com"
+        )
+
+        with patch("lola.cli.completions.MARKET_DIR", market_dir):
+            result = complete_marketplace_names(None, None, "off")
+            assert len(result) == 1
+            assert result[0].value == "official"
+
+    def test_complete_marketplace_names_handles_exception(self):
+        """Return empty list when MARKET_DIR glob raises an exception."""
+        with patch("lola.cli.completions.MARKET_DIR") as mock_dir:
+            mock_dir.exists.return_value = True
+            mock_dir.glob.side_effect = PermissionError("Access denied")
+            result = complete_marketplace_names(None, None, "")
+            assert result == []
+
+
+class TestInstalledModuleNamesCompletion:
+    """Tests for complete_installed_module_names callback."""
+
+    def test_complete_installed_module_names_no_file(self):
+        """Return empty list when INSTALLED_FILE doesn't exist."""
+        with patch("lola.cli.completions.INSTALLED_FILE") as mock_file:
+            mock_file.exists.return_value = False
+            result = complete_installed_module_names(None, None, "")
+            assert result == []
+
+    def test_complete_installed_module_names_with_modules(self, tmp_path):
+        """Return installed module names from InstallationRegistry."""
+        installed_file = tmp_path / "installed.yml"
+        installed_file.write_text("""version: "1.0"
+installations:
+  - module: module-one
+    assistant: claude-code
+    scope: user
+    project_path: /tmp/project
+    skills: []
+    commands: []
+    agents: []
+    mcps: []
+    has_instructions: false
+  - module: module-two
+    assistant: cursor
+    scope: user
+    project_path: /tmp/project
+    skills: []
+    commands: []
+    agents: []
+    mcps: []
+    has_instructions: false
+""")
+
+        with patch("lola.cli.completions.INSTALLED_FILE", installed_file):
+            result = complete_installed_module_names(None, None, "")
+            assert len(result) == 2
+            names = [item.value for item in result]
+            assert "module-one" in names
+            assert "module-two" in names
+
+    def test_complete_installed_module_names_with_prefix(self, tmp_path):
+        """Filter installed module names by prefix."""
+        installed_file = tmp_path / "installed.yml"
+        installed_file.write_text("""version: "1.0"
+installations:
+  - module: module-one
+    assistant: claude-code
+    scope: user
+    project_path: /tmp/project
+    skills: []
+    commands: []
+    agents: []
+    mcps: []
+    has_instructions: false
+  - module: module-two
+    assistant: cursor
+    scope: user
+    project_path: /tmp/project
+    skills: []
+    commands: []
+    agents: []
+    mcps: []
+    has_instructions: false
+  - module: other-module
+    assistant: gemini-cli
+    scope: user
+    project_path: /tmp/project
+    skills: []
+    commands: []
+    agents: []
+    mcps: []
+    has_instructions: false
+""")
+
+        with patch("lola.cli.completions.INSTALLED_FILE", installed_file):
+            result = complete_installed_module_names(None, None, "module-")
+            assert len(result) == 2
+            names = [item.value for item in result]
+            assert "module-one" in names
+            assert "module-two" in names
+            assert "other-module" not in names
+
+    def test_complete_installed_module_names_invalid_file(self, tmp_path):
+        """Return empty list when InstallationRegistry can't be loaded."""
+        installed_file = tmp_path / "installed.yml"
+        installed_file.write_text("invalid yaml content: [")
+
+        with patch("lola.cli.completions.INSTALLED_FILE", installed_file):
+            result = complete_installed_module_names(None, None, "")
+            # Should handle exception gracefully
+            assert result == []

--- a/tests/test_completion_integration.py
+++ b/tests/test_completion_integration.py
@@ -1,0 +1,220 @@
+"""Integration tests to verify completion callbacks are wired correctly."""
+
+import click
+
+from lola.__main__ import main
+from lola.cli.completions import (
+    complete_module_names,
+    complete_marketplace_names,
+    complete_installed_module_names,
+)
+
+
+class TestCompletionIntegration:
+    """Verify completion callbacks are attached to appropriate CLI arguments."""
+
+    def test_mod_commands_have_module_completion(self):
+        """Verify mod commands have module name completion."""
+        # Get the 'mod' command group
+        mod_group = None
+        for cmd in main.commands.values():
+            if isinstance(cmd, click.Group) and cmd.name == "mod":
+                mod_group = cmd
+                break
+
+        assert mod_group is not None, "mod command group not found"
+
+        # Commands that should have module name completion
+        commands_with_module_completion = {
+            "rm": "module_name",
+            "info": "module_name_or_path",
+            "update": "module_name",
+        }
+
+        for cmd_name, arg_name in commands_with_module_completion.items():
+            cmd = mod_group.commands.get(cmd_name)
+            assert cmd is not None, f"mod {cmd_name} command not found"
+
+            # Find the argument with the expected name
+            arg = None
+            for param in cmd.params:
+                if isinstance(param, click.Argument) and param.name == arg_name:
+                    arg = param
+                    break
+
+            assert arg is not None, f"Argument '{arg_name}' not found in mod {cmd_name}"
+            # Click stores the callback in _custom_shell_complete
+            assert hasattr(arg, "_custom_shell_complete"), (
+                f"mod {cmd_name} {arg_name} should have a completion callback"
+            )
+            assert arg._custom_shell_complete == complete_module_names, (
+                f"mod {cmd_name} {arg_name} should have complete_module_names callback"
+            )
+
+    def test_market_commands_have_marketplace_completion(self):
+        """Verify market commands have marketplace name completion."""
+        # Get the 'market' command group
+        market_group = None
+        for cmd in main.commands.values():
+            if isinstance(cmd, click.Group) and cmd.name == "market":
+                market_group = cmd
+                break
+
+        assert market_group is not None, "market command group not found"
+
+        # Commands that should have marketplace name completion
+        commands_with_marketplace_completion = {
+            "ls": "name",
+            "set": "name",
+            "rm": "name",
+            "update": "name",
+        }
+
+        for cmd_name, arg_name in commands_with_marketplace_completion.items():
+            cmd = market_group.commands.get(cmd_name)
+            assert cmd is not None, f"market {cmd_name} command not found"
+
+            # Find the argument with the expected name
+            arg = None
+            for param in cmd.params:
+                if isinstance(param, click.Argument) and param.name == arg_name:
+                    arg = param
+                    break
+
+            assert arg is not None, (
+                f"Argument '{arg_name}' not found in market {cmd_name}"
+            )
+            # Click stores the callback in _custom_shell_complete
+            assert hasattr(arg, "_custom_shell_complete"), (
+                f"market {cmd_name} {arg_name} should have a completion callback"
+            )
+            assert arg._custom_shell_complete == complete_marketplace_names, (
+                f"market {cmd_name} {arg_name} should have complete_marketplace_names callback"
+            )
+
+    def test_install_command_has_module_completion(self):
+        """Verify install command has module name completion."""
+        install_cmd = main.commands.get("install")
+        assert install_cmd is not None, "install command not found"
+
+        # Find the module_name argument
+        arg = None
+        for param in install_cmd.params:
+            if isinstance(param, click.Argument) and param.name == "module_name":
+                arg = param
+                break
+
+        assert arg is not None, "module_name argument not found in install command"
+        # Click stores the callback in _custom_shell_complete
+        assert hasattr(arg, "_custom_shell_complete"), (
+            "install module_name should have a completion callback"
+        )
+        assert arg._custom_shell_complete == complete_module_names, (
+            "install module_name should have complete_module_names callback"
+        )
+
+    def test_uninstall_command_has_installed_module_completion(self):
+        """Verify uninstall command has installed module name completion."""
+        uninstall_cmd = main.commands.get("uninstall")
+        assert uninstall_cmd is not None, "uninstall command not found"
+
+        # Find the module_name argument
+        arg = None
+        for param in uninstall_cmd.params:
+            if isinstance(param, click.Argument) and param.name == "module_name":
+                arg = param
+                break
+
+        assert arg is not None, "module_name argument not found in uninstall command"
+        # Click stores the callback in _custom_shell_complete
+        assert hasattr(arg, "_custom_shell_complete"), (
+            "uninstall module_name should have a completion callback"
+        )
+        assert arg._custom_shell_complete == complete_installed_module_names, (
+            "uninstall module_name should have complete_installed_module_names callback"
+        )
+
+    def test_update_command_has_installed_module_completion(self):
+        """Verify update command has installed module name completion."""
+        update_cmd = main.commands.get("update")
+        assert update_cmd is not None, "update command not found"
+
+        # Find the module_name argument
+        arg = None
+        for param in update_cmd.params:
+            if isinstance(param, click.Argument) and param.name == "module_name":
+                arg = param
+                break
+
+        assert arg is not None, "module_name argument not found in update command"
+        # Click stores the callback in _custom_shell_complete
+        assert hasattr(arg, "_custom_shell_complete"), (
+            "update module_name should have a completion callback"
+        )
+        assert arg._custom_shell_complete == complete_installed_module_names, (
+            "update module_name should have complete_installed_module_names callback"
+        )
+
+    def test_all_completion_callbacks_are_used(self):
+        """Verify all defined completion callbacks are actually used in the CLI."""
+        # This is a reverse check - ensure we didn't create callbacks that aren't used
+        completion_callbacks = {
+            complete_module_names,
+            complete_marketplace_names,
+            complete_installed_module_names,
+        }
+
+        used_callbacks = set()
+
+        def collect_callbacks(command):
+            """Recursively collect all shell_complete callbacks from a command."""
+            for param in command.params:
+                # Click stores custom callbacks in _custom_shell_complete
+                if hasattr(param, "_custom_shell_complete"):
+                    used_callbacks.add(param._custom_shell_complete)
+
+            if isinstance(command, click.Group):
+                for subcmd in command.commands.values():
+                    collect_callbacks(subcmd)
+
+        collect_callbacks(main)
+
+        # All our completion callbacks should be used
+        for callback in completion_callbacks:
+            assert callback in used_callbacks, (
+                f"{callback.__name__} is defined but not used in CLI"
+            )
+
+    def test_completion_callbacks_have_correct_signature(self):
+        """Verify all completion callbacks have the correct signature for Click."""
+        # Click shell_complete callbacks should accept (ctx, param, incomplete)
+        import inspect
+
+        callbacks = [
+            complete_module_names,
+            complete_marketplace_names,
+            complete_installed_module_names,
+        ]
+
+        for callback in callbacks:
+            sig = inspect.signature(callback)
+            params = list(sig.parameters.keys())
+            assert len(params) == 3, f"{callback.__name__} should have 3 parameters"
+            assert params == [
+                "ctx",
+                "param",
+                "incomplete",
+            ], f"{callback.__name__} parameters should be (ctx, param, incomplete)"
+
+    def test_completion_callbacks_return_completion_items(self):
+        """Verify completion callbacks return CompletionItem objects."""
+        from click.shell_completion import CompletionItem
+
+        # Test with mock data
+        result = complete_module_names(None, None, "test")
+        assert isinstance(result, list), "Callbacks should return a list"
+        # Can be empty if no matches, but if non-empty, should be CompletionItem
+        if result:
+            assert all(isinstance(item, CompletionItem) for item in result), (
+                "All items should be CompletionItem instances"
+            )


### PR DESCRIPTION
  ## Summary

  <!-- Describe what changed and why (1-3 bullet points) -->

  - Added shell completion support for bash, zsh, and fish shells via `lola completions <shell>` command
  - Implemented dynamic completion callbacks that auto-complete module names, marketplace names, and installed modules from the user's filesystem at completion time


  ## Related Issues

  <!-- Link any related issues: Fixes #123, Relates to #456 -->

  None

  ## Test Plan

  <!-- How can reviewers verify this works? -->

  **Automated tests:**
  - [x] All 757 tests pass including 17 new unit tests and 8 integration tests
  - [x] Unit tests verify completion script generation for bash/zsh/fish
  - [x] Unit tests verify completion callbacks handle missing directories, prefix filtering, and exceptions
  - [x] Integration tests verify all CLI commands have appropriate completion callbacks wired

  **Manual testing:**
  ```bash
  # Generate and test bash completion
  lola completions bash > /tmp/lola-completion.bash
  source /tmp/lola-completion.bash

  # Try tab completion (should show registered modules)
  lola install <TAB>
  lola mod rm <TAB>

  # Try marketplace completion
  lola market ls <TAB>

  # Try installed module completion
  lola uninstall <TAB>
```

  Checklist

  - Tests pass (pytest)
  - Linting passes (ruff check src tests)
  - Type checking passes (ty check)

  AI Disclosure

  AI-assisted with Claude Sonnet 4.5 via Claude Code