### PR TITLE
chore: bumping lola release to v0.4.2 .lola-req

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lola"
-version = "0.4.1"
+version = "0.4.2"
 description = "AI Skills Package Manager"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
- Bumping lola release to v0.4.2
- Tagging current change for release

## Summary

<!-- Describe what changed and why (1-3 bullet points) -->

- Chore commit with proper bump release to align with next tag

## Checklist

- [x] Tests pass (`pytest`)
- [x] Linting passes (`ruff check src tests`)
- [x] Type checking passes (`ty check`)
