### PR TITLE
fix(ci): correct deploy-pages action SHA in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,4 +43,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac2b3c603fc # v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
## Summary

- Fix incorrect pinned SHA for `actions/deploy-pages@v4` in the docs deployment workflow
- The wrong SHA caused the workflow to fail with "action could not be found" error

## Test Plan

- [ ] Docs workflow runs successfully after merge