### PR TITLE
ci: add workflow_dispatch and self-trigger to docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,12 +1,14 @@
 name: Docs
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:
       - docs/**
       - mkdocs.yml
       - README.md
+      - .github/workflows/docs.yml
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` trigger to enable manual docs deployment from GitHub Actions UI
- Add `.github/workflows/docs.yml` to trigger paths so workflow changes also trigger a deployment

## Test Plan

- [ ] After merge, manually trigger docs workflow via Actions > Docs > Run workflow
- [ ] Verify docs site deploys successfully to GitHub Pages