### PR TITLE
build: switch to git tag-based versioning with hatch-vcs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ venv/
 # jj
 .jj/
 
+# hatch-vcs generated version file
+src/lola/_version.py
+
 # Test coverage
 .coverage
 htmlcov/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "lola"
-version = "0.4.2"
+dynamic = ["version"]
 description = "AI Skills Package Manager"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -26,6 +26,12 @@ dependencies = [
 
 [project.scripts]
 lola = "lola.__main__:main"
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/lola/_version.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/lola"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,9 @@ docs = [
     "mkdocs-awesome-pages-plugin>=2.9.0",
 ]
 
+[tool.ruff]
+extend-exclude = ["src/lola/_version.py"]
+
 [tool.basedpyright]
 pythonVersion = "3.13"
 typeCheckingMode = "standard"

--- a/sbom.json
+++ b/sbom.json
@@ -2,21 +2,20 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
-  "serialNumber": "urn:uuid:04b42031-0359-430f-857f-5d32e03379f0",
+  "serialNumber": "urn:uuid:c6ad3530-32d8-4547-9e4a-27fedc9c2af4",
   "metadata": {
-    "timestamp": "2026-03-25T19:55:10.662171489Z",
+    "timestamp": "2026-03-27T18:00:17.728808000Z",
     "tools": [
       {
         "vendor": "Astral Software Inc.",
         "name": "uv",
-        "version": "0.10.9"
+        "version": "0.10.5"
       }
     ],
     "component": {
       "type": "library",
-      "bom-ref": "lola-1@0.4.2",
+      "bom-ref": "lola-1",
       "name": "lola",
-      "version": "0.4.2",
       "properties": [
         {
           "name": "uv:package:is_project_root",
@@ -143,7 +142,7 @@
       ]
     },
     {
-      "ref": "lola-1@0.4.2",
+      "ref": "lola-1",
       "dependsOn": [
         "click-2@8.3.1",
         "inquirerpy-4@0.3.4",

--- a/uv.lock
+++ b/uv.lock
@@ -380,7 +380,6 @@ wheels = [
 
 [[package]]
 name = "lola"
-version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Replace static `version = "0.4.2"` in `pyproject.toml` with `dynamic = ["version"]` powered by `hatch-vcs`
- Versions are now derived from git tags automatically — tagged commits produce clean versions (e.g., `0.4.2`), untagged commits produce dev versions (e.g., `0.4.3.dev17+ge4f74c8ab`)
- Add `src/lola/_version.py` to `.gitignore` (generated at build time)

## Test plan

- [x] `uv sync` succeeds and installs with correct dev version
- [x] `lola --version` outputs the git-derived version
- [x] All 768 tests pass
- [x] Ruff linting passes

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)