### PR TITLE
ci: add PyPI/TestPyPI publish workflow, rename package to lola-ai

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,86 @@
+name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Compute version for workflow_dispatch
+        if: github.event_name == 'workflow_dispatch'
+        id: version
+        run: |
+          # Get base version from git describe (e.g., 0.4.3.dev17)
+          TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
+          TAG="${TAG#v}"
+          DISTANCE=$(git rev-list "${TAG:+v}${TAG}..HEAD" --count 2>/dev/null || echo "0")
+          VERSION="${TAG}.dev${DISTANCE}.post${GITHUB_RUN_NUMBER}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Building version: ${VERSION}"
+
+      - name: Build package
+        run: uv build
+        env:
+          SETUPTOOLS_SCM_LOCAL_SCHEME: no-local-version
+          SETUPTOOLS_SCM_PRETEND_VERSION: ${{ steps.version.outputs.version || '' }}
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-testpypi:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs: build
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    if: github.event_name == 'release' && github.event.action == 'published'
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
-name = "lola"
+name = "lola-ai"
 dynamic = ["version"]
 description = "AI Skills Package Manager"
 readme = "README.md"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ cfgv==3.5.0 \
 click==8.3.1 \
     --hash=sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a \
     --hash=sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6
-    # via lola
+    # via lola-ai
 colorama==0.4.6 ; sys_platform == 'win32' \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
@@ -104,7 +104,7 @@ iniconfig==2.3.0 \
 inquirerpy==0.3.4 \
     --hash=sha256:89d2ada0111f337483cb41ae31073108b2ec1e618a49d7110b0d7ade89fc197e \
     --hash=sha256:c65fdfbac1fa00e3ee4fb10679f4d3ed7a012abf4833910e63c295827fe2a7d4
-    # via lola
+    # via lola-ai
 librt==0.8.1 ; platform_python_implementation != 'PyPy' \
     --hash=sha256:01170b6729a438f0dedc4a26ed342e3dc4f02d1000b4b19f980e1877f0c297e6 \
     --hash=sha256:086a32dbb71336627e78cc1d6ee305a68d038ef7d4c39aaff41ae8c9aa46e91a \
@@ -182,7 +182,7 @@ packaging==26.0 \
     --hash=sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4 \
     --hash=sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529
     # via
-    #   lola
+    #   lola-ai
     #   pytest
 pathspec==1.0.4 \
     --hash=sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645 \
@@ -231,7 +231,7 @@ python-discovery==1.1.0 \
 python-frontmatter==1.1.0 \
     --hash=sha256:335465556358d9d0e6c98bbeb69b1c969f2a4a21360587b9873bfc3b213407c1 \
     --hash=sha256:7118d2bd56af9149625745c58c9b51fb67e8d1294a0c76796dafdc72c36e5f6d
-    # via lola
+    # via lola-ai
 pyyaml==6.0.3 \
     --hash=sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c \
     --hash=sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3 \
@@ -264,7 +264,7 @@ pyyaml==6.0.3 \
     --hash=sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6
     # via
     #   bandit
-    #   lola
+    #   lola-ai
     #   pre-commit
     #   python-frontmatter
 rich==14.3.3 \
@@ -272,7 +272,7 @@ rich==14.3.3 \
     --hash=sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b
     # via
     #   bandit
-    #   lola
+    #   lola-ai
 ruff==0.15.4 \
     --hash=sha256:04196ad44f0df220c2ece5b0e959c2f37c777375ec744397d21d15b50a75264f \
     --hash=sha256:291258c917539e18f6ba40482fe31d6f5ac023994ee11d7bdafd716f2aab8a68 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 click==8.3.1 \
     --hash=sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a \
     --hash=sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6
-    # via lola
+    # via lola-ai
 colorama==0.4.6 ; sys_platform == 'win32' \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
@@ -12,7 +12,7 @@ colorama==0.4.6 ; sys_platform == 'win32' \
 inquirerpy==0.3.4 \
     --hash=sha256:89d2ada0111f337483cb41ae31073108b2ec1e618a49d7110b0d7ade89fc197e \
     --hash=sha256:c65fdfbac1fa00e3ee4fb10679f4d3ed7a012abf4833910e63c295827fe2a7d4
-    # via lola
+    # via lola-ai
 markdown-it-py==4.0.0 \
     --hash=sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147 \
     --hash=sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3
@@ -24,7 +24,7 @@ mdurl==0.1.2 \
 packaging==26.0 \
     --hash=sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4 \
     --hash=sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529
-    # via lola
+    # via lola-ai
 pfzy==0.3.4 \
     --hash=sha256:5f50d5b2b3207fa72e7ec0ef08372ef652685470974a107d0d4999fc5a903a96 \
     --hash=sha256:717ea765dd10b63618e7298b2d98efd819e0b30cd5905c9707223dceeb94b3f1
@@ -40,7 +40,7 @@ pygments==2.19.2 \
 python-frontmatter==1.1.0 \
     --hash=sha256:335465556358d9d0e6c98bbeb69b1c969f2a4a21360587b9873bfc3b213407c1 \
     --hash=sha256:7118d2bd56af9149625745c58c9b51fb67e8d1294a0c76796dafdc72c36e5f6d
-    # via lola
+    # via lola-ai
 pyyaml==6.0.3 \
     --hash=sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c \
     --hash=sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3 \
@@ -72,12 +72,12 @@ pyyaml==6.0.3 \
     --hash=sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c \
     --hash=sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6
     # via
-    #   lola
+    #   lola-ai
     #   python-frontmatter
 rich==14.3.3 \
     --hash=sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d \
     --hash=sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b
-    # via lola
+    # via lola-ai
 wcwidth==0.6.0 \
     --hash=sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad \
     --hash=sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159

--- a/sbom.json
+++ b/sbom.json
@@ -2,9 +2,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
-  "serialNumber": "urn:uuid:c6ad3530-32d8-4547-9e4a-27fedc9c2af4",
+  "serialNumber": "urn:uuid:00ee8d3c-3866-4b98-93f0-be46ed6b7643",
   "metadata": {
-    "timestamp": "2026-03-27T18:00:17.728808000Z",
+    "timestamp": "2026-03-27T19:48:26.511286000Z",
     "tools": [
       {
         "vendor": "Astral Software Inc.",
@@ -14,8 +14,8 @@
     ],
     "component": {
       "type": "library",
-      "bom-ref": "lola-1",
-      "name": "lola",
+      "bom-ref": "lola-ai-1",
+      "name": "lola-ai",
       "properties": [
         {
           "name": "uv:package:is_project_root",
@@ -142,7 +142,7 @@
       ]
     },
     {
-      "ref": "lola-1",
+      "ref": "lola-ai-1",
       "dependsOn": [
         "click-2@8.3.1",
         "inquirerpy-4@0.3.4",

--- a/src/lola/__init__.py
+++ b/src/lola/__init__.py
@@ -1,6 +1,6 @@
 from importlib.metadata import version, PackageNotFoundError
 
 try:
-    __version__ = version("lola")
+    __version__ = version("lola-ai")
 except PackageNotFoundError:
     __version__ = "unknown"

--- a/uv.lock
+++ b/uv.lock
@@ -379,7 +379,7 @@ wheels = [
 ]
 
 [[package]]
-name = "lola"
+name = "lola-ai"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Rename distribution from `lola` to `lola-ai` since `lola` is taken on PyPI (import name stays `lola`)
- Add `publish.yml` workflow using trusted publishing (OIDC) with two publish targets:
  - **TestPyPI**: on push to `main` or `workflow_dispatch`
  - **PyPI**: on GitHub release published
- `workflow_dispatch` appends `.post{run_number}` for unique versions on TestPyPI
- All actions pinned to commit SHAs; minimal permissions per job

Closes #77

## Setup required

- [x] Create `pypi` environment with required reviewers
- [x] Create `testpypi` environment
- [x] Configure trusted publisher on [PyPI](https://pypi.org/manage/account/publishing/) for `lola-ai` (workflow: `publish.yml`, environment: `pypi`)
- [x] Configure trusted publisher on [TestPyPI](https://test.pypi.org/manage/account/publishing/) for `lola-ai` (workflow: `publish.yml`, environment: `testpypi`)

## Version strategy

| Trigger | Version example | Target |
|---|---|---|
| push to main | `0.4.3.dev18` (hatch-vcs) | TestPyPI |
| workflow_dispatch | `0.4.3.dev18.post42` (+ run number) | TestPyPI |
| release published | `0.5.0` (clean tag) | PyPI |

## Test plan

- [ ] Merge to main triggers TestPyPI publish
- [ ] Manual workflow_dispatch publishes to TestPyPI with unique version
- [ ] `pip install --index-url https://test.pypi.org/simple/ lola-ai` works
- [ ] Creating a GitHub release publishes to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)