### PR TITLE
fix: strip local version segment for PyPI/TestPyPI uploads

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,14 +34,11 @@ jobs:
           TAG="${TAG#v}"
           DISTANCE=$(git rev-list "${TAG:+v}${TAG}..HEAD" --count 2>/dev/null || echo "0")
           VERSION="${TAG}.dev${DISTANCE}.post${GITHUB_RUN_NUMBER}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}" >> "$GITHUB_ENV"
           echo "Building version: ${VERSION}"
 
       - name: Build package
         run: uv build
-        env:
-          SETUPTOOLS_SCM_LOCAL_SCHEME: no-local-version
-          SETUPTOOLS_SCM_PRETEND_VERSION: ${{ steps.version.outputs.version || '' }}
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ lola = "lola.__main__:main"
 
 [tool.hatch.version]
 source = "vcs"
+raw-options = { local_scheme = "no-local-version" }
 
 [tool.hatch.build.hooks.vcs]
 version-file = "src/lola/_version.py"


### PR DESCRIPTION
## Summary
- Configure `local_scheme = "no-local-version"` in `pyproject.toml` via hatch-vcs `raw-options` so PyPI/TestPyPI don't reject versions with `+gHASH` suffixes
- Move `SETUPTOOLS_SCM_PRETEND_VERSION` to `$GITHUB_ENV` so it's only set on `workflow_dispatch`, avoiding an empty env var on `push`/`release` triggers

## Test plan
- [ ] Verify TestPyPI publish succeeds on merge to main
- [ ] Verify `workflow_dispatch` still produces correct `.dev.post` versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)