### PR TITLE
docs: add missing mcpServers wrapper to MCP config examples

### DIFF
--- a/docs/user-guide/mcp-servers.md
+++ b/docs/user-guide/mcp-servers.md
@@ -10,9 +10,11 @@ Lola supports both local and remote MCP servers:
 
 ```json
 {
-  "filesystem": {
-    "command": "npx",
-    "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+    }
   }
 }
 ```
@@ -21,9 +23,11 @@ Lola supports both local and remote MCP servers:
 
 ```json
 {
-  "my-remote-server": {
-    "type": "http",
-    "url": "https://mcp.example.com/sse"
+  "mcpServers": {
+    "my-remote-server": {
+      "type": "http",
+      "url": "https://mcp.example.com/sse"
+    }
   }
 }
 ```


### PR DESCRIPTION
The JSON examples in the MCP servers documentation were missing the required top-level "mcpServers" key. Without it, configurations would not be recognized by lola during installation.

## Summary

<!-- Describe what changed and why (1-3 bullet points) -->

- Improve documentation for MCP servers as the example missed required "mcpServers" field.

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->

## Test Plan

- [ ] Check the documentation
- [ ] Verify the new documented behavior is correct

## Checklist

- [x] Tests pass (`pytest`)
- [x] Linting passes (`ruff check src tests`)
- [-] Type checking passes (`ty check`)
  -  Bunch of errors but in unrelated parts 

## AI Disclosure

<!-- If you used AI tools, mention them here or in your commit message -->
<!-- Examples: "AI-assisted with Claude Code", "Used GitHub Copilot" -->
<!-- Delete this section if not applicable -->
