### PR TITLE
docs: add PyPI install options for lola-ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,15 @@ Lola is a universal AI Package Manager. If an agent's skills were an RPM, Lola i
 ## Installation
 
 ```bash
-uv tool install git+https://github.com/RedHatProductSecurity/lola
+# Recommended: install from PyPI
+uv tool install lola-ai
+
+# Or with pip
+pip install lola-ai
 ```
+
+> **Want the latest dev version?**
+> `uv tool install git+https://github.com/RedHatProductSecurity/lola`
 
 ## Quick Start
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -5,7 +5,19 @@
 - Python 3.13 or later
 - [uv](https://docs.astral.sh/uv/) (recommended) or pip
 
-## Install with uv (recommended)
+## Install from PyPI (recommended)
+
+```bash
+uv tool install lola-ai
+```
+
+Or with pip:
+
+```bash
+pip install lola-ai
+```
+
+## Install latest dev version from Git
 
 ```bash
 uv tool install git+https://github.com/RedHatProductSecurity/lola


### PR DESCRIPTION
## Summary
- Lola is now published to PyPI as `lola-ai`: https://pypi.org/project/lola-ai/
- Updated README and installation docs to lead with `uv tool install lola-ai` / `pip install lola-ai` as the recommended install method
- Kept git-based and source install options for users who want the latest dev version

## Test plan
- [ ] `uv tool install lola-ai` installs the published package correctly
- [ ] Docs render correctly on the docs site
- [ ] README looks correct on GitHub