### PR TITLE
feat: add --append-context flag for context module installation

### DIFF
--- a/docs/cli-reference/index.md
+++ b/docs/cli-reference/index.md
@@ -31,6 +31,7 @@ Complete command reference for the Lola CLI. Use `lola --help` or `lola <command
 | -------------------------------------- | --------------------------------------------- |
 | `lola install <module>`                | Install to all detected assistants             |
 | `lola install <module> -a <assistant>` | Install to specific assistant                 |
+| `lola install <module> --append-context <path>` | Append context reference                          |
 | `lola uninstall <module>`              | Uninstall module                              |
 | `lola list`                            | List all installations                        |
 | `lola update`                          | Regenerate assistant files                    |

--- a/docs/concepts/skills-and-modules.md
+++ b/docs/concepts/skills-and-modules.md
@@ -52,6 +52,8 @@ AI Context Modules also solve the problem where a developer wants to integrate t
 | **Example** | A code review skill | A full DevSecOps module with review, security, and compliance skills |
 | **Init** | Manual or future `lola skill init` | `lola mod init` |
 
+See [Installing Modules](../user-guide/modules.md) for more details.
+
 ## AI as Code
 
 The vision behind AI Context Modules is **AI as Code**: agent settings, MCP configurations, skills, and context dependencies - all managed as code, versioned, and distributable as packages. With Lola, your entire AI agent context tree can be deployed and shared across teams and tools.

--- a/docs/user-guide/modules.md
+++ b/docs/user-guide/modules.md
@@ -80,6 +80,34 @@ my-module/
       helper.md
 ```
 
+## Appending Context References
+
+When an AI Context Module has files that reference each other, for example an `AGENTS.md` that says:
+
+```markdown
+Follow the coding conventions in `context/conventions.md`
+Run the setup script at `scripts/bootstrap.sh`
+```
+
+You can use `--append-context` so the agent reads the original file where these paths resolve naturally:
+
+```bash
+lola install my-module --append-context module/AGENTS.md
+```
+
+This appends a reference in `CLAUDE.md` pointing to the file inside `.lola/modules/`:
+
+```markdown
+<!-- lola:module:my-module:start -->
+Read the module context from `.lola/modules/my-module/module/AGENTS.md`
+<!-- lola:module:my-module:end -->
+```
+
+Without the flag, the default behavior copies content verbatim, which works well for modules without relative path references.
+
+!!! note
+    Using `--append-context` adds an extra layer of file reading for the agent - it first reads `CLAUDE.md`, then follows the reference to read the appended context file. For best performance, we recommend structuring your module to work with the default installation when possible, using `--append-context` only when your module requires relative path references between context files.
+
 ## Content Path Detection
 
 Lola auto-detects where module content lives. It checks for a `module/` subdirectory first, then falls back to the repository root. Override with `--module-content`:

--- a/docs/user-guide/modules.md
+++ b/docs/user-guide/modules.md
@@ -95,18 +95,15 @@ You can use `--append-context` so the agent reads the original file where these 
 lola install my-module --append-context module/AGENTS.md
 ```
 
-This appends a reference in `CLAUDE.md` pointing to the file inside `.lola/modules/`:
+This appends a reference in the target assistant's instruction file (`CLAUDE.md`, `GEMINI.md`, `AGENTS.md`, etc.) pointing to the file inside `.lola/modules/`:
 
-```markdown
-<!-- lola:module:my-module:start -->
+```
 Read the module context from `.lola/modules/my-module/module/AGENTS.md`
-<!-- lola:module:my-module:end -->
 ```
 
 Without the flag, the default behavior copies content verbatim, which works well for modules without relative path references.
 
-!!! note
-    Using `--append-context` adds an extra layer of file reading for the agent - it first reads `CLAUDE.md`, then follows the reference to read the appended context file. For best performance, we recommend structuring your module to work with the default installation when possible, using `--append-context` only when your module requires relative path references between context files.
+:exclamation: **NOTE** Using `--append-context` adds an extra layer of file reading for the agent - it first reads the assistant's instruction file, then follows the reference to read the appended context file. For best performance, we recommend structuring your module to work with the default installation when possible, using `--append-context` only when your module requires relative path references between context files.
 
 ## Content Path Detection
 

--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -504,12 +504,28 @@ def _update_instructions(ctx: UpdateContext, verbose: bool) -> bool:
                 )
         return False
 
+    instructions_dest = ctx.target.get_instructions_path(ctx.inst.project_path)
+
+    # Respect --append-context from the original installation
+    if ctx.inst.append_context:
+        from lola.targets.install import _install_instructions
+
+        success = _install_instructions(
+            ctx.target,
+            ctx.global_module,
+            ctx.source_module,
+            ctx.inst.project_path,
+            ctx.inst.append_context,
+        )
+        if success and verbose:
+            console.print("      [green]instructions (appended)[/green]")
+        return success
+
     content_path = _get_content_path(ctx.source_module)
     instructions_source = content_path / INSTRUCTIONS_FILE
     if not instructions_source.exists():
         return False
 
-    instructions_dest = ctx.target.get_instructions_path(ctx.inst.project_path)
     success = ctx.target.generate_instructions(
         instructions_source, instructions_dest, ctx.inst.module_name
     )

--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -668,6 +668,14 @@ def _format_update_summary(result: UpdateResult) -> str:
     default=None,
     help="Run script after installing (use instead of module's hook)",
 )
+@click.option(
+    "--append-context",
+    type=str,
+    default=None,
+    help="Append a context reference instead of copying instructions verbatim. "
+    "Pass the path to the main context file relative to the module root "
+    "(e.g., module/AGENTS.md).",
+)
 @click.argument("project_path", required=False, default="./")
 def install_cmd(
     module_name: Optional[str],
@@ -676,6 +684,7 @@ def install_cmd(
     force: bool,
     pre_install: Optional[str],
     post_install: Optional[str],
+    append_context: Optional[str],
     project_path: str,
 ):
     """
@@ -691,6 +700,7 @@ def install_cmd(
         lola install my-module                         # Pick assistants interactively
         lola install my-module -a claude-code          # Specific assistant, no prompt
         lola install my-module ./my-project            # Install in a specific project directory
+        lola install my-module --append-context module/AGENTS.md   # Append context reference
     """
     ensure_lola_dirs()
 
@@ -828,6 +838,7 @@ def install_cmd(
             force,
             effective_pre_install,
             effective_post_install,
+            append_context,
         )
 
     # Update installation records with version from marketplace metadata

--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -1316,4 +1316,10 @@ def list_installed_cmd(assistant: Optional[str]):
             if project_path:
                 console.print(f'  [dim]path:[/dim] "{project_path}"')
             console.print(f"  [dim]assistants:[/dim] \\[{assistants_str}]")
+
+            for inst in scope_insts:
+                if inst.append_context:
+                    console.print(
+                        f"  [dim]append-context ({inst.assistant}):[/dim] {inst.append_context}"
+                    )
         console.print()

--- a/src/lola/models.py
+++ b/src/lola/models.py
@@ -550,6 +550,7 @@ class Installation:
     agents: list[str] = field(default_factory=list)
     mcps: list[str] = field(default_factory=list)
     has_instructions: bool = False
+    append_context: Optional[str] = None
 
     def to_dict(self) -> dict:
         """Convert to dictionary for YAML serialization."""
@@ -567,6 +568,8 @@ class Installation:
             result["project_path"] = self.project_path
         if self.version:
             result["version"] = self.version
+        if self.append_context:
+            result["append_context"] = self.append_context
         return result
 
     @classmethod
@@ -583,6 +586,7 @@ class Installation:
             agents=data.get("agents", []),
             mcps=data.get("mcps", []),
             has_instructions=data.get("has_instructions", False),
+            append_context=data.get("append_context"),
         )
 
 

--- a/src/lola/targets/base.py
+++ b/src/lola/targets/base.py
@@ -25,6 +25,17 @@ import yaml
 import lola.frontmatter as fm
 
 
+def _resolve_source_content(source: Path | str) -> str | None:
+    """Resolve source to string content. Returns None if Path doesn't exist."""
+    if isinstance(source, Path):
+        if not source.exists():
+            return None
+        return source.read_text().strip()
+    elif isinstance(source, str):
+        return source.strip()
+    return None
+
+
 # =============================================================================
 # AssistantTarget ABC
 # =============================================================================
@@ -95,11 +106,15 @@ class AssistantTarget(ABC):
     @abstractmethod
     def generate_instructions(
         self,
-        source_path: Path,
+        source: Path | str,
         dest_path: Path,
         module_name: str,
     ) -> bool:
-        """Generate/update module instructions in the assistant's instruction file."""
+        """Generate/update module instructions in the assistant's instruction file.
+
+        Args:
+            source: Path to read content from, or string content directly.
+        """
         ...
 
     @abstractmethod
@@ -234,7 +249,7 @@ class BaseAssistantTarget(AssistantTarget):
 
     def generate_instructions(
         self,
-        source_path: Path,  # noqa: ARG002
+        source: Path | str,  # noqa: ARG002
         dest_path: Path,  # noqa: ARG002
         module_name: str,  # noqa: ARG002
     ) -> bool:
@@ -534,15 +549,12 @@ class ManagedInstructionsTarget:
 
     def generate_instructions(
         self,
-        source_path: Path,
+        source: Path | str,
         dest_path: Path,
         module_name: str,
     ) -> bool:
         """Generate/update module instructions in a managed section."""
-        if not source_path.exists():
-            return False
-
-        instructions_content = source_path.read_text().strip()
+        instructions_content = _resolve_source_content(source)
         if not instructions_content:
             return False
 

--- a/src/lola/targets/cursor.py
+++ b/src/lola/targets/cursor.py
@@ -114,15 +114,14 @@ class CursorTarget(MCPSupportMixin, BaseAssistantTarget):
 
     def generate_instructions(
         self,
-        source_path: Path,
+        source: Path | str,
         dest_path: Path,
         module_name: str,
     ) -> bool:
         """Generate .mdc file with alwaysApply: true for module instructions."""
-        if not source_path.exists():
-            return False
+        from .base import _resolve_source_content
 
-        content = source_path.read_text().strip()
+        content = _resolve_source_content(source)
         if not content:
             return False
 

--- a/src/lola/targets/install.py
+++ b/src/lola/targets/install.py
@@ -358,7 +358,7 @@ def _install_instructions(
 
     instructions_dest = target.get_instructions_path(project_path)
 
-    # --context-append: insert a reference instead of verbatim copy
+    # --append-context: insert a reference instead of verbatim copy
     if append_context:
         context_file = local_module_path / append_context
         if not context_file.exists():
@@ -372,18 +372,8 @@ def _install_instructions(
         except ValueError:
             relative_path = context_file.resolve()
 
-        import tempfile
-
         reference = f"Read the module context from `{relative_path}`"
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as tmp:
-            tmp.write(reference)
-            tmp_path = Path(tmp.name)
-        try:
-            return target.generate_instructions(
-                tmp_path, instructions_dest, module.name
-            )
-        finally:
-            tmp_path.unlink(missing_ok=True)
+        return target.generate_instructions(reference, instructions_dest, module.name)
 
     # Default: verbatim copy of AGENTS.md
     if not module.has_instructions:

--- a/src/lola/targets/install.py
+++ b/src/lola/targets/install.py
@@ -348,11 +348,45 @@ def _install_instructions(
     module: Module,
     local_module_path: Path,
     project_path: str | None,
+    append_context: str | None = None,
 ) -> bool:
     """Install module instructions for a target. Returns True if installed."""
     from lola.models import INSTRUCTIONS_FILE
 
-    if not module.has_instructions or not project_path:
+    if not project_path:
+        return False
+
+    instructions_dest = target.get_instructions_path(project_path)
+
+    # --context-append: insert a reference instead of verbatim copy
+    if append_context:
+        context_file = local_module_path / append_context
+        if not context_file.exists():
+            console.print(f"  [red]Context file not found: {append_context}[/red]")
+            return False
+
+        try:
+            relative_path = context_file.resolve().relative_to(
+                Path(project_path).resolve()
+            )
+        except ValueError:
+            relative_path = context_file.resolve()
+
+        import tempfile
+
+        reference = f"Read the module context from `{relative_path}`"
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as tmp:
+            tmp.write(reference)
+            tmp_path = Path(tmp.name)
+        try:
+            return target.generate_instructions(
+                tmp_path, instructions_dest, module.name
+            )
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    # Default: verbatim copy of AGENTS.md
+    if not module.has_instructions:
         return False
 
     content_dirname = _get_content_dirname(module)
@@ -361,7 +395,6 @@ def _install_instructions(
     if not instructions_source.exists():
         return False
 
-    instructions_dest = target.get_instructions_path(project_path)
     return target.generate_instructions(
         instructions_source, instructions_dest, module.name
     )
@@ -482,6 +515,7 @@ def install_to_assistant(
     force: bool = False,
     pre_install_script: Optional[str] = None,
     post_install_script: Optional[str] = None,
+    append_context: Optional[str] = None,
 ) -> int:
     """Install module to a specific assistant."""
     # Late import to avoid circular imports - get_target is defined in __init__.py
@@ -523,7 +557,7 @@ def install_to_assistant(
         target, module, local_module_path, project_path
     )
     instructions_installed = _install_instructions(
-        target, module, local_module_path, project_path
+        target, module, local_module_path, project_path, append_context
     )
 
     _print_summary(

--- a/src/lola/targets/install.py
+++ b/src/lola/targets/install.py
@@ -593,6 +593,7 @@ def install_to_assistant(
                 agents=installed_agents,
                 mcps=installed_mcps,
                 has_instructions=instructions_installed,
+                append_context=append_context,
             )
         )
 

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -854,3 +854,140 @@ class TestInstructionsRegressions:
         assert "Old Instructions" not in content
         # Original content should be preserved
         assert "# My Project" in content
+
+
+# =============================================================================
+# --append-context Tests
+# =============================================================================
+
+
+class TestAppendContext:
+    """Tests for --append-context flag."""
+
+    def test_append_context_creates_reference(self, tmp_path):
+        """--append-context inserts a reference instead of verbatim content."""
+        from lola.targets.install import _install_instructions
+
+        target = ClaudeCodeTarget()
+        module_dir = tmp_path / "test-module"
+        module_dir.mkdir()
+        context_dir = module_dir / "module"
+        context_dir.mkdir()
+        (context_dir / "AGENTS.md").write_text("# Instructions\nRead context/foo.md")
+
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+
+        local_module = project_dir / ".lola" / "modules" / "test-module"
+        local_module.mkdir(parents=True)
+        shutil.copytree(module_dir, local_module, dirs_exist_ok=True)
+
+        module = Module.from_path(module_dir)
+        assert module is not None
+
+        result = _install_instructions(
+            target,
+            module,
+            local_module,
+            str(project_dir),
+            append_context="module/AGENTS.md",
+        )
+
+        assert result is True
+        claude_md = project_dir / "CLAUDE.md"
+        assert claude_md.exists()
+        content = claude_md.read_text()
+        assert "Read the module context from" in content
+        assert ".lola/modules/test-module/module/AGENTS.md" in content
+        assert "<!-- lola:module:test-module:start -->" in content
+
+    def test_append_context_missing_file_returns_false(self, tmp_path):
+        """--append-context returns False when the context file doesn't exist."""
+        from lola.targets.install import _install_instructions
+
+        target = ClaudeCodeTarget()
+        module_dir = tmp_path / "test-module"
+        module_dir.mkdir()
+        (module_dir / "AGENTS.md").write_text("# Instructions")
+
+        module = Module.from_path(module_dir)
+        assert module is not None
+
+        result = _install_instructions(
+            target,
+            module,
+            module_dir,
+            str(tmp_path),
+            append_context="nonexistent/FILE.md",
+        )
+
+        assert result is False
+
+    def test_append_context_preserves_existing_claude_md(self, tmp_path):
+        """--append-context preserves existing content in CLAUDE.md."""
+        from lola.targets.install import _install_instructions
+
+        target = ClaudeCodeTarget()
+        module_dir = tmp_path / "test-module"
+        module_dir.mkdir()
+        context_dir = module_dir / "module"
+        context_dir.mkdir()
+        (context_dir / "AGENTS.md").write_text("# Module context")
+
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+
+        local_module = project_dir / ".lola" / "modules" / "test-module"
+        local_module.mkdir(parents=True)
+        shutil.copytree(module_dir, local_module, dirs_exist_ok=True)
+
+        claude_md = project_dir / "CLAUDE.md"
+        claude_md.write_text("# My Project\n\nExisting content.\n")
+
+        module = Module.from_path(module_dir)
+        assert module is not None
+
+        result = _install_instructions(
+            target,
+            module,
+            local_module,
+            str(project_dir),
+            append_context="module/AGENTS.md",
+        )
+
+        assert result is True
+        content = claude_md.read_text()
+        assert "# My Project" in content
+        assert "Existing content." in content
+        assert "Read the module context from" in content
+
+    def test_default_behavior_unchanged_without_flag(self, tmp_path):
+        """Without --append-context, verbatim copy still works."""
+        from lola.targets.install import _install_instructions
+
+        target = ClaudeCodeTarget()
+        module_dir = tmp_path / "test-module"
+        module_dir.mkdir()
+        (module_dir / "AGENTS.md").write_text("# Verbatim Instructions")
+        skills_dir = module_dir / "skills" / "s1"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text("---\ndescription: T\n---\nC")
+
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+
+        module = Module.from_path(module_dir)
+        assert module is not None
+
+        result = _install_instructions(
+            target,
+            module,
+            module_dir,
+            str(project_dir),
+        )
+
+        assert result is True
+        claude_md = project_dir / "CLAUDE.md"
+        content = claude_md.read_text()
+        assert "# Verbatim Instructions" in content
+        assert "Read the module context from" not in content

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -695,6 +695,74 @@ class TestUpdateWithInstructions:
         updated = registry.find("test-module")[0]
         assert updated.has_instructions is True
 
+    def test_update_preserves_append_context(self, tmp_path):
+        """Update respects append_context from installation record."""
+        from lola.cli.install import update_cmd
+
+        modules_dir = tmp_path / ".lola" / "modules"
+        modules_dir.mkdir(parents=True)
+        installed_file = tmp_path / ".lola" / "installed.yml"
+
+        # Create module with context file
+        module_dir = modules_dir / "test-module"
+        context_dir = module_dir / "module"
+        context_dir.mkdir(parents=True)
+        (context_dir / "AGENTS.md").write_text("# Context\nRead context/foo.md")
+
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+
+        # Create registry with append_context set
+        registry = InstallationRegistry(installed_file)
+        inst = Installation(
+            module_name="test-module",
+            assistant="claude-code",
+            scope="project",
+            project_path=str(project_dir),
+            has_instructions=True,
+            append_context="module/AGENTS.md",
+        )
+        registry.add(inst)
+
+        # Create local module copy
+        local_modules = project_dir / ".lola" / "modules"
+        local_modules.mkdir(parents=True)
+        shutil.copytree(module_dir, local_modules / "test-module")
+
+        # Use real ClaudeCodeTarget for instructions
+        real_target = ClaudeCodeTarget()
+        mock_target = MagicMock()
+        mock_target.uses_managed_section = False
+        mock_target.supports_agents = True
+        mock_target.get_skill_path.return_value = project_dir / ".claude" / "skills"
+        mock_target.get_command_path.return_value = project_dir / ".claude" / "commands"
+        mock_target.get_agent_path.return_value = None
+        mock_target.get_mcp_path.return_value = None
+        mock_target.get_instructions_path = real_target.get_instructions_path
+        mock_target.generate_instructions = real_target.generate_instructions
+        mock_target.remove_instructions = real_target.remove_instructions
+
+        runner = CliRunner()
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry", return_value=registry),
+            patch(
+                "lola.cli.install.get_local_modules_path", return_value=local_modules
+            ),
+            patch("lola.cli.install.get_target", return_value=mock_target),
+        ):
+            result = runner.invoke(update_cmd, ["test-module"])
+
+        assert result.exit_code == 0
+
+        # Verify CLAUDE.md has a reference, not verbatim content
+        claude_md = project_dir / "CLAUDE.md"
+        content = claude_md.read_text()
+        assert "Read the module context from" in content
+        assert "module/AGENTS.md" in content
+        assert "Read context/foo.md" not in content
+
 
 # =============================================================================
 # ManagedInstructionsTarget Mixin Tests

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -128,6 +128,50 @@ class TestInstallationHasInstructions:
         inst = Installation.from_dict(data)
         assert inst.has_instructions is False
 
+    def test_to_dict_includes_append_context(self):
+        """Installation.to_dict() includes append_context when set."""
+        inst = Installation(
+            module_name="test",
+            assistant="claude-code",
+            scope="project",
+            project_path="/test",
+            append_context="module/AGENTS.md",
+        )
+        data = inst.to_dict()
+        assert data["append_context"] == "module/AGENTS.md"
+
+    def test_to_dict_omits_append_context_when_none(self):
+        """Installation.to_dict() omits append_context when not set."""
+        inst = Installation(
+            module_name="test",
+            assistant="claude-code",
+            scope="project",
+            project_path="/test",
+        )
+        data = inst.to_dict()
+        assert "append_context" not in data
+
+    def test_from_dict_reads_append_context(self):
+        """Installation.from_dict() reads append_context."""
+        data = {
+            "module": "test",
+            "assistant": "claude-code",
+            "scope": "project",
+            "append_context": "module/AGENTS.md",
+        }
+        inst = Installation.from_dict(data)
+        assert inst.append_context == "module/AGENTS.md"
+
+    def test_from_dict_defaults_append_context_to_none(self):
+        """Installation.from_dict() defaults append_context to None."""
+        data = {
+            "module": "test",
+            "assistant": "claude-code",
+            "scope": "project",
+        }
+        inst = Installation.from_dict(data)
+        assert inst.append_context is None
+
 
 # =============================================================================
 # Claude Code Target Tests

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -1103,3 +1103,65 @@ class TestAppendContext:
         content = claude_md.read_text()
         assert "# Verbatim Instructions" in content
         assert "Read the module context from" not in content
+
+
+class TestListWithAppendContext:
+    """Tests for lola list showing append_context."""
+
+    def test_list_shows_append_context(self, tmp_path):
+        """lola list displays append-context when set."""
+        from lola.cli.install import list_installed_cmd
+
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        installed_file.parent.mkdir(parents=True)
+
+        registry = InstallationRegistry(installed_file)
+        registry.add(
+            Installation(
+                module_name="test-module",
+                assistant="claude-code",
+                scope="project",
+                project_path=str(tmp_path),
+                has_instructions=True,
+                append_context="module/AGENTS.md",
+            )
+        )
+
+        runner = CliRunner()
+        with (
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry", return_value=registry),
+        ):
+            result = runner.invoke(list_installed_cmd)
+
+        assert result.exit_code == 0
+        assert "append-context" in result.output
+        assert "module/AGENTS.md" in result.output
+
+    def test_list_hides_append_context_when_not_set(self, tmp_path):
+        """lola list omits append-context when not set."""
+        from lola.cli.install import list_installed_cmd
+
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        installed_file.parent.mkdir(parents=True)
+
+        registry = InstallationRegistry(installed_file)
+        registry.add(
+            Installation(
+                module_name="test-module",
+                assistant="claude-code",
+                scope="project",
+                project_path=str(tmp_path),
+                has_instructions=True,
+            )
+        )
+
+        runner = CliRunner()
+        with (
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry", return_value=registry),
+        ):
+            result = runner.invoke(list_installed_cmd)
+
+        assert result.exit_code == 0
+        assert "append-context" not in result.output

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -12,6 +12,7 @@ from lola.targets import (
     GeminiTarget,
     OpenCodeTarget,
 )
+from lola.targets.base import _resolve_source_content
 
 
 # =============================================================================
@@ -171,6 +172,33 @@ class TestInstallationHasInstructions:
         }
         inst = Installation.from_dict(data)
         assert inst.append_context is None
+
+
+# =============================================================================
+# _resolve_source_content Tests
+# =============================================================================
+
+
+class TestResolveSourceContent:
+    """Tests for _resolve_source_content helper."""
+
+    def test_resolves_string(self):
+        """String source returns stripped content."""
+        assert _resolve_source_content("  hello  ") == "hello"
+
+    def test_resolves_path(self, tmp_path):
+        """Path source reads and strips file content."""
+        f = tmp_path / "test.md"
+        f.write_text("  file content  ")
+        assert _resolve_source_content(f) == "file content"
+
+    def test_missing_path_returns_none(self, tmp_path):
+        """Non-existent path returns None."""
+        assert _resolve_source_content(tmp_path / "missing.md") is None
+
+    def test_empty_string_returns_empty(self):
+        """Empty string returns empty string."""
+        assert _resolve_source_content("   ") == ""
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Add `--append-context` flag to `lola install` that appends a context reference in the target's instruction file instead of copying content verbatim. This preserves relative paths in AI Context Modules that reference `context/`, `scripts/`, or other assets.

```bash
lola install foo-module --append-context module/AGENTS.md
```

Produces in `CLAUDE.md`:
```markdown
<!-- lola:module:foo-module:start -->
Read the module context from `.lola/modules/foo-module/module/AGENTS.md`
<!-- lola:module:foo-module:end -->
```

Without the flag, existing default behavior (verbatim copy) is unchanged.

## Related

- Closes #86

## Test Plan

- [x] `--append-context` creates reference with correct relative path
- [x] Missing context file returns error
- [x] Preserves existing CLAUDE.md content
- [x] Default verbatim behavior unchanged without flag
- [x] All 36 existing + new tests pass
- [x] Type checkers (ty, mypy) pass