### PR TITLE
fix: remove default module-name prefix from command and agent display

### DIFF
--- a/src/lola/cli/mod.py
+++ b/src/lola/cli/mod.py
@@ -276,13 +276,13 @@ def add_module(source: str, module_name: str, module_content_dirname: str):
         console.print()
         console.print("[bold]Commands[/bold]")
         for cmd in module.commands:
-            console.print(f"  /{module.name}.{cmd}")
+            console.print(f"  /{cmd}")
 
     if module.agents:
         console.print()
         console.print("[bold]Agents[/bold]")
         for agent in module.agents:
-            console.print(f"  @{module.name}.{agent}")
+            console.print(f"  @{agent}")
 
     console.print()
     console.print("[bold]Next steps:[/bold]")
@@ -555,11 +555,11 @@ description: [REPLACE: Brief description of what this agent does and when to del
                 )
             if final_command_name:
                 when_to_use_items.append(
-                    f"- **{_title_case(final_command_name)}**: Use `/{module_name}.{final_command_name}` to [REPLACE: describe what it does]"
+                    f"- **{_title_case(final_command_name)}**: Use `/{final_command_name}` to [REPLACE: describe what it does]"
                 )
             if final_agent_name:
                 when_to_use_items.append(
-                    f"- **{_title_case(final_agent_name)}**: Delegate to `@{module_name}.{final_agent_name}` for [REPLACE: describe when to use]"
+                    f"- **{_title_case(final_agent_name)}**: Delegate to `@{final_agent_name}` for [REPLACE: describe when to use]"
                 )
 
             if not when_to_use_items:
@@ -863,11 +863,11 @@ def list_modules(verbose: bool):
             if module.commands:
                 console.print("  [bold]Commands:[/bold]")
                 for cmd in module.commands:
-                    console.print(f"    /{module.name}.{cmd}")
+                    console.print(f"    /{cmd}")
             if module.agents:
                 console.print("  [bold]Agents:[/bold]")
                 for agent in module.agents:
-                    console.print(f"    @{module.name}.{agent}")
+                    console.print(f"    @{agent}")
 
         console.print()
 
@@ -977,7 +977,7 @@ def module_info(module_name_or_path: str | None):
 
         for cmd_name, cmd_path in zip(module.commands, module.get_command_paths()):
             if cmd_path.exists():
-                console.print(f"  [green]/{module.name}.{cmd_name}[/green]")
+                console.print(f"  [green]/{cmd_name}[/green]")
                 # Show description from frontmatter
                 frontmatter, _ = fm_parse_file(cmd_path)
                 desc = frontmatter.get("description", "")
@@ -996,7 +996,7 @@ def module_info(module_name_or_path: str | None):
 
         for agent_name, agent_path in zip(module.agents, module.get_agent_paths()):
             if agent_path.exists():
-                console.print(f"  [green]@{module.name}.{agent_name}[/green]")
+                console.print(f"  [green]@{agent_name}[/green]")
                 # Show description from frontmatter
                 frontmatter, _ = fm_parse_file(agent_path)
                 desc = frontmatter.get("description", "")

--- a/tests/test_cli_mod.py
+++ b/tests/test_cli_mod.py
@@ -590,12 +590,12 @@ class TestModInit:
 
             # Should mention the skill
             assert "my-skill" in content.lower() or "My Skill" in content
-            # Should mention the command (now uses dot notation)
+            # Should mention the command (unprefixed)
             assert "my-cmd" in content.lower() or "My Cmd" in content
-            assert "mymod.my-cmd" in content
-            # Should mention the agent (now uses dot notation)
+            assert "/my-cmd" in content
+            # Should mention the agent (unprefixed)
             assert "my-agent" in content.lower() or "My Agent" in content
-            assert "mymod.my-agent" in content
+            assert "@my-agent" in content
         finally:
             os.chdir(original_dir)
 
@@ -733,9 +733,9 @@ class TestModInfoAdvanced:
             result = cli_runner.invoke(mod, ["info", str(module_dir)])
 
         assert result.exit_code == 0
-        assert "/test-mod.my-cmd" in result.output
+        assert "/my-cmd" in result.output
         assert "My command description" in result.output
-        assert "@test-mod.my-agent" in result.output
+        assert "@my-agent" in result.output
         assert "My agent description" in result.output
         assert "(not found)" not in result.output
 
@@ -967,8 +967,8 @@ class TestModInitModuleSubdir:
             assert result.exit_code == 0
             agents_md = (tmp_path / "my-mod" / "module" / "AGENTS.md").read_text()
             # Should use dot-separated notation
-            assert "/my-mod.my-cmd" in agents_md
-            assert "@my-mod.my-agent" in agents_md
+            assert "/my-cmd" in agents_md
+            assert "@my-agent" in agents_md
         finally:
             os.chdir(original_dir)
 


### PR DESCRIPTION
## Summary
- Removes the automatic `{module-name}.` prefix from command and agent names in all CLI output (`mod add`, `mod ls -v`, `mod info`, `mod init` template)
- Commands/agents now display unprefixed (e.g., `/finalize-tm` instead of `/module.finalize-tm`)
- Prefixing only occurs as a conflict resolution option during `lola install` when the user explicitly chooses "rename"

## Test plan
- [x] All 768 existing tests pass
- [ ] Verify `lola mod add .` shows unprefixed command/agent names
- [ ] Verify `lola mod ls -v` shows unprefixed names
- [ ] Verify `lola mod info <module>` shows unprefixed names
- [ ] Verify `lola mod init` generates AGENTS.md with unprefixed references
- [ ] Verify install conflict flow still offers rename with prefix as an option

🤖 Generated with [Claude Code](https://claude.com/claude-code)