### PR TITLE
Add installation scope support (project/user) 

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,40 @@ lola install <module> -a claude-code
 4. **Marketplace Registration**: `lola market add <name> <url>` fetches marketplace catalogs to `~/.lola/market/` (reference) and `~/.lola/market/cache/` (full catalog)
 5. **Module Discovery**: `lola mod search <query>` searches across enabled marketplace caches; `lola install <module>` auto-adds from marketplace if not in registry
 
+### Installation Scopes
+
+Lola supports two installation scopes:
+
+- **Project scope** (default): Installs to project directories (`.claude/`, `.cursor/`, etc.)
+- **User scope**: Installs to user home directories (`~/.claude/`, `~/.cursor/`, etc.)
+
+#### Examples
+
+Install to current project (default):
+```bash
+lola install my-module
+```
+
+Install globally for your user:
+```bash
+lola install my-module --scope user
+```
+
+Install to specific project:
+```bash
+lola install my-module /path/to/project
+```
+
+List all installations:
+```bash
+lola list
+```
+
+Uninstall from user scope only:
+```bash
+lola uninstall my-module --scope user
+```
+
 ### Key Source Files
 
 - `src/lola/main.py` - CLI entry point, registers all commands

--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -190,13 +190,13 @@ def _validate_installation_for_update(inst: Installation) -> tuple[bool, str | N
     Returns (is_valid, error_message).
     """
     # Check if project path still exists for project-scoped installations
-    if inst.scope == "project" and inst.project_path:
-        if not Path(inst.project_path).exists():
+    if inst.scope == "project":
+        if inst.project_path and not Path(inst.project_path).exists():
             return False, "project path no longer exists"
 
-    # For project scope, project_path is required
-    if inst.scope == "project" and not inst.project_path:
-        return False, "project scope requires project path"
+        # For project scope, project_path is required
+        if not inst.project_path:
+            return False, "project scope requires project path"
 
     # Get the global module to refresh from
     global_module_path = MODULES_DIR / inst.module_name
@@ -228,7 +228,13 @@ def _build_update_context(
     if not global_module:
         return None
 
-    local_modules = get_local_modules_path(inst.project_path)
+    # For user scope, use current directory for local_modules symlink
+    # For project scope, use the installation's project_path
+    if inst.scope == "user":
+        local_modules = get_local_modules_path(str(Path.cwd()))
+    else:
+        local_modules = get_local_modules_path(inst.project_path)
+
     target = get_target(inst.assistant)
 
     # Refresh the local copy from global module
@@ -284,7 +290,9 @@ def _remove_orphaned_commands(ctx: UpdateContext, verbose: bool) -> int:
         return 0
 
     removed = 0
-    command_dest = ctx.target.get_command_path(ctx.inst.project_path or "")
+    path_context = ctx.inst.project_path or ""
+    scope = ctx.inst.scope
+    command_dest = ctx.target.get_command_path(path_context, scope)
     for cmd_name in ctx.orphaned_commands:
         if ctx.target.remove_command(command_dest, cmd_name, ctx.inst.module_name):
             removed += 1
@@ -300,7 +308,9 @@ def _remove_orphaned_agents(ctx: UpdateContext, verbose: bool) -> int:
     if not ctx.orphaned_agents:
         return 0
 
-    agent_dest = ctx.target.get_agent_path(ctx.inst.project_path or "")
+    path_context = ctx.inst.project_path or ""
+    scope = ctx.inst.scope
+    agent_dest = ctx.target.get_agent_path(path_context, scope)
     if not agent_dest:
         return 0
 
@@ -320,7 +330,9 @@ def _remove_orphaned_mcps(ctx: UpdateContext, verbose: bool) -> int:
     if not ctx.orphaned_mcps:
         return 0
 
-    mcp_dest = ctx.target.get_mcp_path(ctx.inst.project_path or "")
+    path_context = ctx.inst.project_path or ""
+    scope = ctx.inst.scope
+    mcp_dest = ctx.target.get_mcp_path(path_context, scope)
     if not mcp_dest:
         return 0
 
@@ -441,7 +453,9 @@ def _update_commands(ctx: UpdateContext, verbose: bool) -> tuple[int, int]:
     commands_ok = 0
     commands_failed = 0
 
-    command_dest = ctx.target.get_command_path(ctx.inst.project_path or "")
+    path_context = ctx.inst.project_path or ""
+    scope = ctx.inst.scope
+    command_dest = ctx.target.get_command_path(path_context, scope)
     content_path = _get_content_path(ctx.source_module)
     commands_dir = content_path / "commands"
 
@@ -474,7 +488,9 @@ def _update_agents(ctx: UpdateContext, verbose: bool) -> tuple[int, int]:
     if not ctx.global_module.agents or not ctx.target.supports_agents:
         return 0, 0
 
-    agent_dest = ctx.target.get_agent_path(ctx.inst.project_path or "")
+    path_context = ctx.inst.project_path or ""
+    scope = ctx.inst.scope
+    agent_dest = ctx.target.get_agent_path(path_context, scope)
     if not agent_dest:
         return 0, 0
 
@@ -511,18 +527,18 @@ def _update_instructions(ctx: UpdateContext, verbose: bool) -> bool:
     """
     from lola.models import INSTRUCTIONS_FILE
 
-    if not ctx.has_instructions or not ctx.inst.project_path:
+    path_context = ctx.inst.project_path or ""
+    scope = ctx.inst.scope
+
+    if not ctx.has_instructions:
         # Always attempt removal - handles stale installation records
-        if ctx.inst.project_path:
-            instructions_dest = ctx.target.get_instructions_path(ctx.inst.project_path)
-            ctx.target.remove_instructions(instructions_dest, ctx.inst.module_name)
-            if verbose:
-                console.print(
-                    "      [yellow]- instructions[/yellow] [dim](removed)[/dim]"
-                )
+        instructions_dest = ctx.target.get_instructions_path(path_context, scope)
+        ctx.target.remove_instructions(instructions_dest, ctx.inst.module_name)
+        if verbose:
+            console.print("      [yellow]- instructions[/yellow] [dim](removed)[/dim]")
         return False
 
-    instructions_dest = ctx.target.get_instructions_path(ctx.inst.project_path)
+    instructions_dest = ctx.target.get_instructions_path(path_context, scope)
 
     # Respect --append-context from the original installation
     if ctx.inst.append_context:
@@ -534,6 +550,7 @@ def _update_instructions(ctx: UpdateContext, verbose: bool) -> bool:
             ctx.source_module,
             ctx.inst.project_path,
             ctx.inst.append_context,
+            scope,
         )
         if success and verbose:
             console.print("      [green]instructions (appended)[/green]")
@@ -563,10 +580,12 @@ def _update_mcps(ctx: UpdateContext, verbose: bool) -> tuple[int, int]:
     import json
     from lola.config import MCPS_FILE
 
-    if not ctx.global_module.mcps or not ctx.inst.project_path:
+    if not ctx.global_module.mcps:
         return 0, 0
 
-    mcp_dest = ctx.target.get_mcp_path(ctx.inst.project_path)
+    path_context = ctx.inst.project_path or ""
+    scope = ctx.inst.scope
+    mcp_dest = ctx.target.get_mcp_path(path_context, scope)
     if not mcp_dest:
         return 0, 0
 
@@ -599,7 +618,12 @@ def _process_single_installation(ctx: UpdateContext, verbose: bool) -> UpdateRes
     Removes orphaned items and regenerates all skills, commands, agents, MCPs, and instructions.
     """
     result = UpdateResult()
-    skill_dest = ctx.target.get_skill_path(ctx.inst.project_path or "")
+
+    # Get scope-aware paths
+    path_context = ctx.inst.project_path or ""
+    scope = ctx.inst.scope
+
+    skill_dest = ctx.target.get_skill_path(path_context, scope)
 
     # Remove orphaned items
     result.orphans_removed += _remove_orphaned_skills(ctx, skill_dest, verbose)
@@ -718,6 +742,12 @@ def _format_update_summary(result: UpdateResult) -> str:
     "Defaults to ~/.openclaw/workspace. "
     "Pass a name like 'work' to target ~/.openclaw/workspace-work.",
 )
+@click.option(
+    "--scope",
+    type=click.Choice(["project", "user"]),
+    default="project",
+    help="Installation scope: project (default) or user",
+)
 @click.argument("project_path", required=False, default="./")
 def install_cmd(
     module_name: Optional[str],
@@ -728,6 +758,7 @@ def install_cmd(
     post_install: Optional[str],
     append_context: Optional[str],
     workspace: Optional[str],
+    scope: str,
     project_path: str,
 ):
     """
@@ -770,11 +801,28 @@ def install_cmd(
             console.print("[yellow]Cancelled[/yellow]")
             raise SystemExit(130)
 
-    # Validate project path
-    scope = "project"
-    project_path = str(Path(project_path).resolve())
-    if not Path(project_path).exists():
-        handle_lola_error(PathNotFoundError(project_path, "Project path"))
+    # Validation: user scope and explicit project path are mutually exclusive
+    if scope == "user" and project_path != "./":
+        console.print(
+            "[red]Error: --scope user cannot be used with a project path argument[/red]"
+        )
+        console.print(
+            "[dim]Use 'lola install <module> --scope user' for user-wide installation[/dim]"
+        )
+        raise SystemExit(1)
+
+    # For user scope, set project_path to None for Installation record
+    if scope == "user":
+        install_project_path = None
+        # Still need current directory for symlink creation
+        current_dir = str(Path.cwd().resolve())
+        local_modules = get_local_modules_path(current_dir)
+    else:
+        # Project scope: validate and resolve project path
+        install_project_path = str(Path(project_path).resolve())
+        if not Path(install_project_path).exists():
+            handle_lola_error(PathNotFoundError(install_project_path, "Project path"))
+        local_modules = get_local_modules_path(install_project_path)
 
     # Default to global registry
     module_path = MODULES_DIR / module_name
@@ -843,8 +891,7 @@ def install_cmd(
         )
         return
 
-    # Get paths and registry
-    local_modules = get_local_modules_path(project_path)
+    # Get registry
     registry = get_registry()
 
     # Determine which assistants to install to
@@ -870,7 +917,8 @@ def install_cmd(
         or marketplace_hooks.get("post-install")
     )
 
-    console.print(f"\n[bold]Installing {module_name} -> {project_path}[/bold]")
+    display_path = install_project_path or "~/.lola (user scope)"
+    console.print(f"\n[bold]Installing {module_name} -> {display_path}[/bold]")
     console.print()
 
     total_installed = 0
@@ -879,7 +927,7 @@ def install_cmd(
             module,
             asst,
             scope,
-            project_path,
+            install_project_path,
             local_modules,
             registry,
             verbose,
@@ -898,7 +946,7 @@ def install_cmd(
                 if (
                     inst.assistant == asst
                     and inst.scope == scope
-                    and inst.project_path == project_path
+                    and inst.project_path == install_project_path
                 ):
                     inst.version = version
                     registry.add(inst)  # Update the record
@@ -930,12 +978,19 @@ def install_cmd(
 @click.option(
     "-f", "--force", is_flag=True, help="Force uninstall without confirmation"
 )
+@click.option(
+    "--scope",
+    type=click.Choice(["project", "user"]),
+    default=None,
+    help="Filter by installation scope",
+)
 def uninstall_cmd(
     module_name: Optional[str],
     assistant: Optional[str],
     verbose: bool,
     project_path: Optional[str],
     force: bool,
+    scope: Optional[str],
 ):
     """
     Uninstall a module's skills from AI assistants.
@@ -975,32 +1030,49 @@ def uninstall_cmd(
 
     if not installations:
         console.print(f"[yellow]No installations found for '{module_name}'[/yellow]")
+        console.print("[dim]Use 'lola list' to see all installed modules[/dim]")
         return
 
-    # Filter by assistant/project_path if provided
+    # Filter by assistant/project_path/scope if provided
+    original_count = len(installations)
     if assistant:
         installations = [i for i in installations if i.assistant == assistant]
     if project_path:
         project_path = str(Path(project_path).resolve())
         installations = [i for i in installations if i.project_path == project_path]
+    if scope:
+        installations = [i for i in installations if i.scope == scope]
 
     if not installations:
-        console.print("[yellow]No matching installations found[/yellow]")
+        # Show more helpful error based on what filters were applied
+        if scope:
+            console.print(
+                f"[yellow]'{module_name}' is installed but not with --scope {scope}[/yellow]"
+            )
+            console.print(
+                f"[dim]Found {original_count} installation(s) with other scope(s). Use 'lola list' to see all.[/dim]"
+            )
+        else:
+            console.print("[yellow]No matching installations found[/yellow]")
         return
 
     # Show what will be uninstalled
     console.print(f"\n[bold]Uninstalling {module_name}[/bold]")
     console.print()
 
-    # Group installations by project for cleaner display
-    by_project: dict[str, list[Installation]] = {}
+    # Group installations by (scope, project) for cleaner display
+    by_scope_project: dict[str, list[Installation]] = {}
     for inst in installations:
-        key = inst.project_path or "~/.lola (user scope)"
-        if key not in by_project:
-            by_project[key] = []
-        by_project[key].append(inst)
+        # For user scope, show "user scope" instead of path
+        if inst.scope == "user":
+            key = "user scope"
+        else:
+            key = inst.project_path or "project (no path)"
+        if key not in by_scope_project:
+            by_scope_project[key] = []
+        by_scope_project[key].append(inst)
 
-    for project, insts in by_project.items():
+    for location, insts in by_scope_project.items():
         assistants = [i.assistant for i in insts]
         skill_count = len(insts[0].skills) if insts[0].skills else 0
         cmd_count = len(insts[0].commands) if insts[0].commands else 0
@@ -1021,7 +1093,7 @@ def uninstall_cmd(
             parts.append("instructions")
 
         summary = ", ".join(parts) if parts else "no items"
-        console.print(f"  [dim]{project}[/dim]")
+        console.print(f"  [dim]{location}[/dim]")
         console.print(f"    {', '.join(assistants)} [dim]({summary})[/dim]")
 
     console.print()
@@ -1058,25 +1130,15 @@ def uninstall_cmd(
     # Uninstall each
     removed_count = 0
     for inst in installations:
-        # Skip installations without project_path (legacy user-scope entries)
-        if not inst.project_path:
-            console.print(
-                f"  [yellow]Skipping {inst.assistant}: no project path (legacy entry)[/yellow]"
-            )
-            # Still remove from registry to clean up
-            registry.remove(
-                module_name,
-                assistant=inst.assistant,
-                scope=inst.scope,
-                project_path=inst.project_path,
-            )
-            continue
-
         target = get_target(inst.assistant)
+
+        # Get scope-aware paths for removal
+        path_context = inst.project_path or ""
+        inst_scope = inst.scope
 
         # Remove skill files
         if inst.skills:
-            skill_dest = target.get_skill_path(inst.project_path)
+            skill_dest = target.get_skill_path(path_context, inst_scope)
 
             if target.uses_managed_section:
                 # Managed section targets: remove module section from GEMINI.md/AGENTS.md
@@ -1095,7 +1157,7 @@ def uninstall_cmd(
 
         # Remove command files
         if inst.commands:
-            command_dest = target.get_command_path(inst.project_path)
+            command_dest = target.get_command_path(path_context, inst_scope)
 
             for cmd_name in inst.commands:
                 if target.remove_command(command_dest, cmd_name, module_name):
@@ -1108,7 +1170,7 @@ def uninstall_cmd(
 
         # Remove agent files
         if inst.agents:
-            agent_dest = target.get_agent_path(inst.project_path)
+            agent_dest = target.get_agent_path(path_context, inst_scope)
 
             if agent_dest:
                 for agent_name in inst.agents:
@@ -1124,7 +1186,7 @@ def uninstall_cmd(
 
         # Remove instructions
         if inst.has_instructions:
-            instructions_dest = target.get_instructions_path(inst.project_path)
+            instructions_dest = target.get_instructions_path(path_context, inst_scope)
             if target.remove_instructions(instructions_dest, module_name):
                 removed_count += 1
                 if verbose:
@@ -1134,14 +1196,14 @@ def uninstall_cmd(
 
         # Remove MCP servers
         if inst.mcps:
-            mcp_dest = target.get_mcp_path(inst.project_path)
+            mcp_dest = target.get_mcp_path(path_context, inst_scope)
             if mcp_dest and target.remove_mcps(mcp_dest, module_name, list(inst.mcps)):
                 removed_count += len(inst.mcps)
                 if verbose:
                     console.print(f"  [green]Removed MCPs from {mcp_dest}[/green]")
 
         # Also remove the project-local module copy
-        if inst.scope == "project":
+        if inst.scope == "project" and inst.project_path:
             local_modules = get_local_modules_path(inst.project_path)
             source_module = local_modules / module_name
             if source_module.is_symlink():
@@ -1155,6 +1217,15 @@ def uninstall_cmd(
                 removed_count += 1
                 if verbose:
                     console.print(f"  [green]Removed {source_module}[/green]")
+        elif inst.scope == "user":
+            # For user scope, use current directory for symlink
+            local_modules = get_local_modules_path(str(Path.cwd()))
+            source_module = local_modules / module_name
+            if source_module.is_symlink():
+                source_module.unlink()
+                removed_count += 1
+                if verbose:
+                    console.print(f"  [green]Removed symlink {source_module}[/green]")
 
         # Remove from registry
         registry.remove(
@@ -1344,14 +1415,14 @@ def list_installed_cmd(assistant: Optional[str]):
             assistants = sorted(set(inst.assistant for inst in scope_insts))
             assistants_str = ", ".join(assistants)
 
-            console.print(f"- [dim]scope:[/dim] {scope}")
+            console.print(f"  - [dim]scope:[/dim] {scope}")
             if project_path:
-                console.print(f'  [dim]path:[/dim] "{project_path}"')
-            console.print(f"  [dim]assistants:[/dim] \\[{assistants_str}]")
+                console.print(f'    [dim]path:[/dim] "{project_path}"')
+            console.print(f"    [dim]assistants:[/dim] \\[{assistants_str}]")
 
             for inst in scope_insts:
                 if inst.append_context:
                     console.print(
-                        f"  [dim]append-context ({inst.assistant}):[/dim] {inst.append_context}"
+                        f"    [dim]append-context ({inst.assistant}):[/dim] {inst.append_context}"
                     )
         console.print()

--- a/src/lola/models.py
+++ b/src/lola/models.py
@@ -578,7 +578,7 @@ class Installation:
         return cls(
             module_name=data.get("module", ""),
             assistant=data.get("assistant", ""),
-            scope=data.get("scope", "user"),
+            scope=data.get("scope", "project"),
             project_path=data.get("project_path"),
             version=data.get("version"),
             skills=data.get("skills", []),

--- a/src/lola/parsers.py
+++ b/src/lola/parsers.py
@@ -18,7 +18,7 @@ import tempfile
 import zipfile
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Optional
+from typing import Optional, cast
 from urllib.error import URLError
 from urllib.parse import urlparse
 from urllib.request import urlopen
@@ -166,9 +166,9 @@ class GitSourceHandler(SourceHandler):
             if result.returncode != 0:
                 raise RuntimeError(f"Git clone failed: {result.stderr}")
 
-            # Checkout the specific commit (ref is guaranteed non-None here)
-            ref_value: str = ref  # type: ignore[assignment]
-            checkout_cmd = ["git", "-C", str(module_dir), "checkout", ref_value]
+            # Checkout the specific commit
+            # Type checker: is_commit=True guarantees ref is not None
+            checkout_cmd = ["git", "-C", str(module_dir), "checkout", cast(str, ref)]
             result = subprocess.run(  # nosec B603 B607 - list args (no shell), git from PATH is intentional
                 checkout_cmd,
                 capture_output=True,

--- a/src/lola/targets/base.py
+++ b/src/lola/targets/base.py
@@ -51,23 +51,43 @@ class AssistantTarget(ABC):
     )
 
     @abstractmethod
-    def get_skill_path(self, project_path: str) -> Path:
-        """Get the skill output path for this assistant."""
+    def get_skill_path(self, project_path: str, scope: str = "project") -> Path:
+        """Get the skill output path for this assistant.
+
+        Args:
+            project_path: Project directory path (ignored for user scope)
+            scope: "project" for project-local, "user" for user-global
+        """
         ...
 
     @abstractmethod
-    def get_command_path(self, project_path: str) -> Path:
-        """Get the command output path for this assistant."""
+    def get_command_path(self, project_path: str, scope: str = "project") -> Path:
+        """Get the command output path for this assistant.
+
+        Args:
+            project_path: Project directory path (ignored for user scope)
+            scope: "project" for project-local, "user" for user-global
+        """
         ...
 
     @abstractmethod
-    def get_agent_path(self, project_path: str) -> Path | None:
-        """Get the agent output path. Returns None if agents not supported."""
+    def get_agent_path(self, project_path: str, scope: str = "project") -> Path | None:
+        """Get the agent output path. Returns None if agents not supported.
+
+        Args:
+            project_path: Project directory path (ignored for user scope)
+            scope: "project" for project-local, "user" for user-global
+        """
         ...
 
     @abstractmethod
-    def get_instructions_path(self, project_path: str) -> Path:
-        """Get the instructions file path for this assistant."""
+    def get_instructions_path(self, project_path: str, scope: str = "project") -> Path:
+        """Get the instructions file path for this assistant.
+
+        Args:
+            project_path: Project directory path (ignored for user scope)
+            scope: "project" for project-local, "user" for user-global
+        """
         ...
 
     @abstractmethod
@@ -149,8 +169,13 @@ class AssistantTarget(ABC):
         ...
 
     @abstractmethod
-    def get_mcp_path(self, project_path: str) -> Path | None:
-        """Get the MCP config file path for this assistant. Returns None if not supported."""
+    def get_mcp_path(self, project_path: str, scope: str = "project") -> Path | None:
+        """Get the MCP config file path for this assistant. Returns None if not supported.
+
+        Args:
+            project_path: Project directory path (ignored for user scope)
+            scope: "project" for project-local, "user" for user-global
+        """
         ...
 
     @abstractmethod
@@ -227,11 +252,11 @@ class BaseAssistantTarget(AssistantTarget):
     supports_agents: bool = True
     uses_managed_section: bool = False
 
-    def get_agent_path(self, project_path: str) -> Path | None:  # noqa: ARG002
+    def get_agent_path(self, project_path: str, scope: str = "project") -> Path | None:  # noqa: ARG002
         """Default: no agent support. Override in subclasses."""
         return None
 
-    def get_instructions_path(self, project_path: str) -> Path:  # noqa: ARG002
+    def get_instructions_path(self, project_path: str, scope: str = "project") -> Path:  # noqa: ARG002
         """Default: no instructions path. Override in subclasses."""
         raise NotImplementedError(
             f"{self.__class__.__name__} must implement get_instructions_path()"
@@ -290,7 +315,7 @@ class BaseAssistantTarget(AssistantTarget):
         """Default: batch generation not supported."""
         return False
 
-    def get_mcp_path(self, project_path: str) -> Path | None:  # noqa: ARG002
+    def get_mcp_path(self, project_path: str, scope: str = "project") -> Path | None:  # noqa: ARG002
         """Default: MCP not supported. Override in subclasses."""
         return None
 
@@ -399,7 +424,9 @@ to learn the detailed instructions and workflows.
 
 """
 
-    def get_skill_path(self, project_path: str) -> Path:
+    def get_skill_path(self, project_path: str, scope: str = "project") -> Path:
+        if scope == "user":
+            return Path.home() / self.MANAGED_FILE
         return Path(project_path) / self.MANAGED_FILE
 
     def generate_skill(
@@ -892,8 +919,9 @@ def _remove_mcps_from_file(
     for name in mcp_names:
         existing_config["mcpServers"].pop(name, None)
 
-    # Write back (or delete if mcpServers is empty and no other keys)
-    if not existing_config["mcpServers"] and len(existing_config) == 1:
+    # Write back (or delete if mcpServers is empty and only $schema remains)
+    remaining_keys = {k for k in existing_config.keys() if k != "$schema"}
+    if not existing_config["mcpServers"] and remaining_keys == {"mcpServers"}:
         dest_path.unlink()
     else:
         dest_path.write_text(json.dumps(existing_config, indent=2) + "\n")

--- a/src/lola/targets/claude_code.py
+++ b/src/lola/targets/claude_code.py
@@ -22,20 +22,26 @@ class ClaudeCodeTarget(MCPSupportMixin, ManagedInstructionsTarget, BaseAssistant
     supports_agents = True
     INSTRUCTIONS_FILE = "CLAUDE.md"
 
-    def get_skill_path(self, project_path: str) -> Path:
-        return Path(project_path) / ".claude" / "skills"
+    def get_skill_path(self, project_path: str, scope: str = "project") -> Path:
+        base = Path.home() if scope == "user" else Path(project_path)
+        return base / ".claude" / "skills"
 
-    def get_command_path(self, project_path: str) -> Path:
-        return Path(project_path) / ".claude" / "commands"
+    def get_command_path(self, project_path: str, scope: str = "project") -> Path:
+        base = Path.home() if scope == "user" else Path(project_path)
+        return base / ".claude" / "commands"
 
-    def get_agent_path(self, project_path: str) -> Path:
-        return Path(project_path) / ".claude" / "agents"
+    def get_agent_path(self, project_path: str, scope: str = "project") -> Path:
+        base = Path.home() if scope == "user" else Path(project_path)
+        return base / ".claude" / "agents"
 
-    def get_instructions_path(self, project_path: str) -> Path:
+    def get_instructions_path(self, project_path: str, scope: str = "project") -> Path:
+        if scope == "user":
+            return Path.home() / ".claude" / self.INSTRUCTIONS_FILE
         return Path(project_path) / self.INSTRUCTIONS_FILE
 
-    def get_mcp_path(self, project_path: str) -> Path:
-        return Path(project_path) / ".mcp.json"
+    def get_mcp_path(self, project_path: str, scope: str = "project") -> Path:
+        base = Path.home() if scope == "user" else Path(project_path)
+        return base / ".mcp.json"
 
     def generate_skill(
         self,

--- a/src/lola/targets/cursor.py
+++ b/src/lola/targets/cursor.py
@@ -27,20 +27,25 @@ class CursorTarget(MCPSupportMixin, BaseAssistantTarget):
     name = "cursor"
     supports_agents = True
 
-    def get_skill_path(self, project_path: str) -> Path:
-        return Path(project_path) / ".cursor" / "skills"
+    def get_skill_path(self, project_path: str, scope: str = "project") -> Path:
+        base = Path.home() if scope == "user" else Path(project_path)
+        return base / ".cursor" / "skills"
 
-    def get_command_path(self, project_path: str) -> Path:
-        return Path(project_path) / ".cursor" / "commands"
+    def get_command_path(self, project_path: str, scope: str = "project") -> Path:
+        base = Path.home() if scope == "user" else Path(project_path)
+        return base / ".cursor" / "commands"
 
-    def get_agent_path(self, project_path: str) -> Path:
-        return Path(project_path) / ".cursor" / "agents"
+    def get_agent_path(self, project_path: str, scope: str = "project") -> Path:
+        base = Path.home() if scope == "user" else Path(project_path)
+        return base / ".cursor" / "agents"
 
-    def get_instructions_path(self, project_path: str) -> Path:
-        return Path(project_path) / ".cursor" / "rules"
+    def get_instructions_path(self, project_path: str, scope: str = "project") -> Path:
+        base = Path.home() if scope == "user" else Path(project_path)
+        return base / ".cursor" / "rules"
 
-    def get_mcp_path(self, project_path: str) -> Path:
-        return Path(project_path) / ".cursor" / "mcp.json"
+    def get_mcp_path(self, project_path: str, scope: str = "project") -> Path:
+        base = Path.home() if scope == "user" else Path(project_path)
+        return base / ".cursor" / "mcp.json"
 
     def generate_skill(
         self,

--- a/src/lola/targets/gemini.py
+++ b/src/lola/targets/gemini.py
@@ -28,14 +28,17 @@ class GeminiTarget(MCPSupportMixin, ManagedInstructionsTarget, ManagedSectionTar
     MANAGED_FILE = "GEMINI.md"
     INSTRUCTIONS_FILE = "GEMINI.md"
 
-    def get_command_path(self, project_path: str) -> Path:
-        return Path(project_path) / ".gemini" / "commands"
+    def get_command_path(self, project_path: str, scope: str = "project") -> Path:
+        base = Path.home() if scope == "user" else Path(project_path)
+        return base / ".gemini" / "commands"
 
-    def get_instructions_path(self, project_path: str) -> Path:
-        return Path(project_path) / self.INSTRUCTIONS_FILE
+    def get_instructions_path(self, project_path: str, scope: str = "project") -> Path:
+        base = Path.home() if scope == "user" else Path(project_path)
+        return base / self.INSTRUCTIONS_FILE
 
-    def get_mcp_path(self, project_path: str) -> Path:
-        return Path(project_path) / ".gemini" / "settings.json"
+    def get_mcp_path(self, project_path: str, scope: str = "project") -> Path:
+        base = Path.home() if scope == "user" else Path(project_path)
+        return base / ".gemini" / "settings.json"
 
     def generate_command(
         self,

--- a/src/lola/targets/install.py
+++ b/src/lola/targets/install.py
@@ -15,13 +15,13 @@ import os
 import shutil
 import subprocess  # nosec B404 - required for running install hook scripts
 from pathlib import Path
-from typing import Optional
+from typing import Optional, cast
 
 import click
 from rich.console import Console
 
 import lola.config as config
-from lola.exceptions import ConfigurationError, InstallationError
+from lola.exceptions import InstallationError
 from lola.models import Installation, InstallationRegistry, Module
 from lola.prompts import is_interactive, prompt_agent_conflict, prompt_command_conflict
 
@@ -168,12 +168,13 @@ def _check_skill_exists(
     target: AssistantTarget,
     skill_name: str,
     project_path: str | None,
+    scope: str = "project",
 ) -> bool:
     """Check if a skill already exists at the destination."""
-    if not project_path:
+    if not project_path and scope == "project":
         return False
 
-    skill_dest = target.get_skill_path(project_path)
+    skill_dest = target.get_skill_path(project_path or "", scope)
 
     if target.uses_managed_section:
         # For managed sections, we allow overwriting since skills are grouped by module
@@ -191,6 +192,7 @@ def _install_skills(
     module: Module,
     local_module_path: Path,
     project_path: str | None,
+    scope: str = "project",
     force: bool = False,
 ) -> tuple[list[str], list[str]]:
     """Install skills for a target. Returns (installed, failed) lists."""
@@ -199,10 +201,10 @@ def _install_skills(
 
     installed: list[str] = []
     failed: list[str] = []
-    skill_dest = target.get_skill_path(project_path) if project_path else None
 
-    if not skill_dest:
-        return [], []
+    # For user scope, project_path may be None
+    path_context = project_path or ""
+    skill_dest = target.get_skill_path(path_context, scope)
 
     content_dirname = _get_content_dirname(module)
 
@@ -226,7 +228,7 @@ def _install_skills(
             skill_name = skill  # Use unprefixed name by default
 
             # Check if skill already exists
-            if _check_skill_exists(target, skill_name, project_path):
+            if _check_skill_exists(target, skill_name, project_path, scope):
                 if force:
                     # Force mode: overwrite without prompting
                     pass
@@ -259,6 +261,7 @@ def _install_commands(
     local_module_path: Path,
     project_path: str | None,
     force: bool = False,
+    scope: str = "project",
 ) -> tuple[list[str], list[str]]:
     """Install commands for a target. Returns (installed, failed) lists."""
     if not module.commands:
@@ -266,10 +269,9 @@ def _install_commands(
 
     installed: list[str] = []
     failed: list[str] = []
-    command_dest = target.get_command_path(project_path) if project_path else None
 
-    if not command_dest:
-        return [], []
+    path_context = project_path or ""
+    command_dest = target.get_command_path(path_context, scope)
 
     content_dirname = _get_content_dirname(module)
     content_path = _get_content_path(local_module_path, content_dirname)
@@ -304,12 +306,14 @@ def _install_agents(
     local_module_path: Path,
     project_path: str | None,
     force: bool = False,
+    scope: str = "project",
 ) -> tuple[list[str], list[str]]:
     """Install agents for a target. Returns (installed, failed) lists."""
     if not module.agents or not target.supports_agents:
         return [], []
 
-    agent_dest = target.get_agent_path(project_path) if project_path else None
+    path_context = project_path or ""
+    agent_dest = target.get_agent_path(path_context, scope)
     if not agent_dest:
         return [], []
 
@@ -349,14 +353,19 @@ def _install_instructions(
     local_module_path: Path,
     project_path: str | None,
     append_context: str | None = None,
+    scope: str = "project",
 ) -> bool:
     """Install module instructions for a target. Returns True if installed."""
     from lola.models import INSTRUCTIONS_FILE
 
-    if not project_path:
+    if not module.has_instructions:
         return False
 
-    instructions_dest = target.get_instructions_path(project_path)
+    if scope == "project" and not project_path:
+        return False
+
+    # Type checker: at this point project_path is guaranteed to be a string
+    instructions_dest = target.get_instructions_path(cast(str, project_path), scope)
 
     # --append-context: insert a reference instead of verbatim copy
     if append_context:
@@ -367,7 +376,7 @@ def _install_instructions(
 
         try:
             relative_path = context_file.resolve().relative_to(
-                Path(project_path).resolve()
+                Path(cast(str, project_path)).resolve()
             )
         except ValueError:
             relative_path = context_file.resolve()
@@ -395,12 +404,14 @@ def _install_mcps(
     module: Module,
     local_module_path: Path,
     project_path: str | None,
+    scope: str = "project",
 ) -> tuple[list[str], list[str]]:
     """Install MCPs for a target. Returns (installed, failed) lists."""
-    if not module.mcps or not project_path:
+    if not module.mcps:
         return [], []
 
-    mcp_dest = target.get_mcp_path(project_path)
+    path_context = project_path or ""
+    mcp_dest = target.get_mcp_path(path_context, scope)
     if not mcp_dest:
         return [], []
 
@@ -513,9 +524,6 @@ def install_to_assistant(
 
     target = get_target(assistant)
 
-    if scope != "project":
-        raise ConfigurationError("Only project scope is supported")
-
     local_module_path = copy_module_to_local(module, local_modules)
 
     if pre_install_script:
@@ -535,19 +543,19 @@ def install_to_assistant(
             raise
 
     installed_skills, failed_skills = _install_skills(
-        target, module, local_module_path, project_path, force
+        target, module, local_module_path, project_path, scope, force
     )
     installed_commands, failed_commands = _install_commands(
-        target, module, local_module_path, project_path, force
+        target, module, local_module_path, project_path, force, scope
     )
     installed_agents, failed_agents = _install_agents(
-        target, module, local_module_path, project_path, force
+        target, module, local_module_path, project_path, force, scope
     )
     installed_mcps, failed_mcps = _install_mcps(
-        target, module, local_module_path, project_path
+        target, module, local_module_path, project_path, scope
     )
     instructions_installed = _install_instructions(
-        target, module, local_module_path, project_path, append_context
+        target, module, local_module_path, project_path, append_context, scope
     )
 
     _print_summary(
@@ -629,10 +637,10 @@ def _uninstall_skills(
 
     removed: list[str] = []
     failed: list[str] = []
-    skill_dest = target.get_skill_path(inst.project_path) if inst.project_path else None
 
-    if not skill_dest:
-        return [], []
+    path_context = inst.project_path or ""
+    scope = inst.scope
+    skill_dest = target.get_skill_path(path_context, scope)
 
     for skill in inst.skills:
         if target.remove_skill(skill_dest, skill):
@@ -653,12 +661,10 @@ def _uninstall_commands(
 
     removed: list[str] = []
     failed: list[str] = []
-    command_dest = (
-        target.get_command_path(inst.project_path) if inst.project_path else None
-    )
 
-    if not command_dest:
-        return [], []
+    path_context = inst.project_path or ""
+    scope = inst.scope
+    command_dest = target.get_command_path(path_context, scope)
 
     for cmd in inst.commands:
         if target.remove_command(command_dest, cmd, inst.module_name):
@@ -677,7 +683,9 @@ def _uninstall_agents(
     if not inst.agents or not target.supports_agents:
         return [], []
 
-    agent_dest = target.get_agent_path(inst.project_path) if inst.project_path else None
+    path_context = inst.project_path or ""
+    scope = inst.scope
+    agent_dest = target.get_agent_path(path_context, scope)
     if not agent_dest:
         return [], []
 
@@ -698,10 +706,12 @@ def _uninstall_instructions(
     inst: Installation,
 ) -> bool:
     """Uninstall module instructions for a target. Returns True if removed."""
-    if not inst.has_instructions or not inst.project_path:
+    if not inst.has_instructions:
         return False
 
-    instructions_dest = target.get_instructions_path(inst.project_path)
+    path_context = inst.project_path or ""
+    scope = inst.scope
+    instructions_dest = target.get_instructions_path(path_context, scope)
     return target.remove_instructions(instructions_dest, inst.module_name)
 
 
@@ -710,10 +720,12 @@ def _uninstall_mcps(
     inst: Installation,
 ) -> tuple[list[str], list[str]]:
     """Uninstall MCPs for a target. Returns (removed, failed) lists."""
-    if not inst.mcps or not inst.project_path:
+    if not inst.mcps:
         return [], []
 
-    mcp_dest = target.get_mcp_path(inst.project_path)
+    path_context = inst.project_path or ""
+    scope = inst.scope
+    mcp_dest = target.get_mcp_path(path_context, scope)
     if not mcp_dest:
         return [], []
 

--- a/src/lola/targets/openclaw.py
+++ b/src/lola/targets/openclaw.py
@@ -37,13 +37,19 @@ class OpenClawTarget(BaseAssistantTarget):
             return Path(workspace).expanduser().absolute()
         return Path.home() / ".openclaw" / f"workspace-{workspace}"
 
-    def get_skill_path(self, project_path: str) -> Path:
+    def get_skill_path(self, project_path: str, scope: str = "project") -> Path:
+        if scope == "user":
+            return self.resolve_workspace(None) / "skills"
         return Path(project_path) / "skills"
 
-    def get_command_path(self, project_path: str) -> Path:
+    def get_command_path(self, project_path: str, scope: str = "project") -> Path:
+        if scope == "user":
+            return self.resolve_workspace(None) / "commands"
         return Path(project_path) / ".openclaw" / "commands"
 
-    def get_instructions_path(self, project_path: str) -> Path:
+    def get_instructions_path(self, project_path: str, scope: str = "project") -> Path:
+        if scope == "user":
+            return self.resolve_workspace(None) / "instructions.md"
         return Path(project_path) / ".openclaw" / "instructions.md"
 
     def generate_skill(

--- a/src/lola/targets/opencode.py
+++ b/src/lola/targets/opencode.py
@@ -46,21 +46,21 @@ def _transform_mcp_to_opencode(server_config: dict[str, Any]) -> dict[str, Any]:
         url = server_config.get("url")
         if isinstance(url, str):
             url = _convert_env_var_syntax(url)
-        result: dict[str, Any] = {
+        remote_result: dict[str, Any] = {
             "type": "remote",
         }
         if url is not None:
-            result["url"] = url
+            remote_result["url"] = url
         headers = server_config.get("headers", {})
         if headers:
-            result["headers"] = {
+            remote_result["headers"] = {
                 k: _convert_env_var_syntax(v) if isinstance(v, str) else v
                 for k, v in headers.items()
             }
-        return result
+        return remote_result
 
     # Local (stdio) server
-    result = {"type": "local"}
+    result: dict[str, Any] = {"type": "local"}
     command = server_config.get("command", "")
     args = server_config.get("args", [])
     if command:
@@ -173,17 +173,21 @@ class OpenCodeTarget(ManagedInstructionsTarget, ManagedSectionTarget):
     MANAGED_FILE = "AGENTS.md"
     INSTRUCTIONS_FILE = "AGENTS.md"
 
-    def get_command_path(self, project_path: str) -> Path:
-        return Path(project_path) / ".opencode" / "commands"
+    def get_command_path(self, project_path: str, scope: str = "project") -> Path:
+        base = Path.home() if scope == "user" else Path(project_path)
+        return base / ".opencode" / "commands"
 
-    def get_agent_path(self, project_path: str) -> Path:
-        return Path(project_path) / ".opencode" / "agents"
+    def get_agent_path(self, project_path: str, scope: str = "project") -> Path:
+        base = Path.home() if scope == "user" else Path(project_path)
+        return base / ".opencode" / "agents"
 
-    def get_instructions_path(self, project_path: str) -> Path:
-        return Path(project_path) / self.INSTRUCTIONS_FILE
+    def get_instructions_path(self, project_path: str, scope: str = "project") -> Path:
+        base = Path.home() if scope == "user" else Path(project_path)
+        return base / self.INSTRUCTIONS_FILE
 
-    def get_mcp_path(self, project_path: str) -> Path:
-        return Path(project_path) / "opencode.json"
+    def get_mcp_path(self, project_path: str, scope: str = "project") -> Path:
+        base = Path.home() if scope == "user" else Path(project_path)
+        return base / "opencode.json"
 
     def generate_command(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,9 @@ def mock_lola_home(tmp_path):
         patch("lola.cli.mod.MODULES_DIR", modules_dir),
         patch("lola.cli.mod.INSTALLED_FILE", lola_home / "installed.yml"),
         patch("lola.cli.install.MODULES_DIR", modules_dir),
+        patch(
+            "lola.targets.install.config.INSTALLED_FILE", lola_home / "installed.yml"
+        ),
     ):
         yield {
             "home": lola_home,

--- a/tests/test_claude_code_target.py
+++ b/tests/test_claude_code_target.py
@@ -1,0 +1,101 @@
+"""Tests for ClaudeCodeTarget scope-aware path resolution."""
+
+from pathlib import Path
+
+from lola.targets.claude_code import ClaudeCodeTarget
+
+
+def test_claude_code_skill_path_project_scope():
+    target = ClaudeCodeTarget()
+    path = target.get_skill_path("/home/user/project", "project")
+    assert path == Path("/home/user/project/.claude/skills")
+
+
+def test_claude_code_skill_path_user_scope():
+    target = ClaudeCodeTarget()
+    path = target.get_skill_path("/home/user/project", "user")
+    assert path == Path.home() / ".claude" / "skills"
+
+
+def test_claude_code_command_path_user_scope():
+    target = ClaudeCodeTarget()
+    path = target.get_command_path("/home/user/project", "user")
+    assert path == Path.home() / ".claude" / "commands"
+
+
+def test_claude_code_agent_path_user_scope():
+    target = ClaudeCodeTarget()
+    path = target.get_agent_path("/home/user/project", "user")
+    assert path == Path.home() / ".claude" / "agents"
+
+
+def test_claude_code_instructions_path_user_scope():
+    target = ClaudeCodeTarget()
+    path = target.get_instructions_path("/home/user/project", "user")
+    assert path == Path.home() / ".claude" / "CLAUDE.md"
+
+
+def test_claude_code_mcp_path_user_scope():
+    target = ClaudeCodeTarget()
+    path = target.get_mcp_path("/home/user/project", "user")
+    assert path == Path.home() / ".mcp.json"
+
+
+# --- Project scope tests for remaining methods ---
+
+
+def test_claude_code_command_path_project_scope():
+    target = ClaudeCodeTarget()
+    result = target.get_command_path("/home/user/project", scope="project")
+    assert result == Path("/home/user/project/.claude/commands")
+
+
+def test_claude_code_agent_path_project_scope():
+    target = ClaudeCodeTarget()
+    result = target.get_agent_path("/home/user/project", scope="project")
+    assert result == Path("/home/user/project/.claude/agents")
+
+
+def test_claude_code_instructions_path_project_scope():
+    target = ClaudeCodeTarget()
+    result = target.get_instructions_path("/home/user/project", scope="project")
+    assert result == Path("/home/user/project/CLAUDE.md")
+
+
+def test_claude_code_mcp_path_project_scope():
+    target = ClaudeCodeTarget()
+    result = target.get_mcp_path("/home/user/project", scope="project")
+    assert result == Path("/home/user/project/.mcp.json")
+
+
+# --- Default scope tests (no explicit scope argument) ---
+
+
+def test_claude_code_skill_path_default_scope():
+    target = ClaudeCodeTarget()
+    result = target.get_skill_path("/home/user/project")
+    assert result == Path("/home/user/project/.claude/skills")
+
+
+def test_claude_code_command_path_default_scope():
+    target = ClaudeCodeTarget()
+    result = target.get_command_path("/home/user/project")
+    assert result == Path("/home/user/project/.claude/commands")
+
+
+def test_claude_code_agent_path_default_scope():
+    target = ClaudeCodeTarget()
+    result = target.get_agent_path("/home/user/project")
+    assert result == Path("/home/user/project/.claude/agents")
+
+
+def test_claude_code_instructions_path_default_scope():
+    target = ClaudeCodeTarget()
+    result = target.get_instructions_path("/home/user/project")
+    assert result == Path("/home/user/project/CLAUDE.md")
+
+
+def test_claude_code_mcp_path_default_scope():
+    target = ClaudeCodeTarget()
+    result = target.get_mcp_path("/home/user/project")
+    assert result == Path("/home/user/project/.mcp.json")

--- a/tests/test_cli_install_scope.py
+++ b/tests/test_cli_install_scope.py
@@ -1,0 +1,36 @@
+"""Tests for --scope option in install command."""
+
+from click.testing import CliRunner
+
+from lola.cli.install import install_cmd
+
+
+def test_install_user_scope_with_explicit_path_fails():
+    """User scope with explicit project path should fail."""
+    runner = CliRunner()
+    result = runner.invoke(
+        install_cmd,
+        ["test-module", "--scope", "user", "/some/path"],
+    )
+    assert result.exit_code == 1
+    assert "cannot be used with a project path argument" in result.output
+
+
+def test_install_user_scope_without_path_succeeds(
+    mock_lola_home, registered_module, monkeypatch
+):
+    """User scope without explicit path should succeed."""
+    # Set HOME to a temp path to avoid polluting real home
+    monkeypatch.setenv("HOME", str(mock_lola_home["home"].parent / "fakehome"))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        install_cmd,
+        ["sample-module", "--scope", "user", "-a", "claude-code"],
+        catch_exceptions=False,
+    )
+
+    # Should succeed - validation passes for user scope without explicit path
+    assert result.exit_code == 0
+    # Should show success message
+    assert "Installed to" in result.output

--- a/tests/test_completion_integration.py
+++ b/tests/test_completion_integration.py
@@ -1,6 +1,7 @@
 """Integration tests to verify completion callbacks are wired correctly."""
 
 import click
+from click.core import Command
 
 from lola.__main__ import main
 from lola.cli.completions import (
@@ -32,8 +33,10 @@ class TestCompletionIntegration:
         }
 
         for cmd_name, arg_name in commands_with_module_completion.items():
-            cmd = mod_group.commands.get(cmd_name)
-            assert cmd is not None, f"mod {cmd_name} command not found"
+            cmd_maybe = mod_group.commands.get(cmd_name)
+            assert cmd_maybe is not None, f"mod {cmd_name} command not found"
+            assert isinstance(cmd_maybe, Command)
+            cmd = cmd_maybe
 
             # Find the argument with the expected name
             arg = None
@@ -71,8 +74,10 @@ class TestCompletionIntegration:
         }
 
         for cmd_name, arg_name in commands_with_marketplace_completion.items():
-            cmd = market_group.commands.get(cmd_name)
-            assert cmd is not None, f"market {cmd_name} command not found"
+            cmd_maybe = market_group.commands.get(cmd_name)
+            assert cmd_maybe is not None, f"market {cmd_name} command not found"
+            assert isinstance(cmd_maybe, Command)
+            cmd = cmd_maybe
 
             # Find the argument with the expected name
             arg = None

--- a/tests/test_cursor_target.py
+++ b/tests/test_cursor_target.py
@@ -1,0 +1,104 @@
+"""Tests for CursorTarget scope-aware path resolution."""
+
+from pathlib import Path
+
+from lola.targets.cursor import CursorTarget
+
+
+# --- User scope tests ---
+
+
+def test_cursor_skill_path_user_scope():
+    target = CursorTarget()
+    path = target.get_skill_path("/home/user/project", "user")
+    assert path == Path.home() / ".cursor" / "skills"
+
+
+def test_cursor_command_path_user_scope():
+    target = CursorTarget()
+    path = target.get_command_path("/home/user/project", "user")
+    assert path == Path.home() / ".cursor" / "commands"
+
+
+def test_cursor_agent_path_user_scope():
+    target = CursorTarget()
+    path = target.get_agent_path("/home/user/project", "user")
+    assert path == Path.home() / ".cursor" / "agents"
+
+
+def test_cursor_instructions_path_user_scope():
+    target = CursorTarget()
+    path = target.get_instructions_path("/home/user/project", "user")
+    assert path == Path.home() / ".cursor" / "rules"
+
+
+def test_cursor_mcp_path_user_scope():
+    target = CursorTarget()
+    path = target.get_mcp_path("/home/user/project", "user")
+    assert path == Path.home() / ".cursor" / "mcp.json"
+
+
+# --- Project scope tests ---
+
+
+def test_cursor_skill_path_project_scope():
+    target = CursorTarget()
+    path = target.get_skill_path("/home/user/project", "project")
+    assert path == Path("/home/user/project/.cursor/skills")
+
+
+def test_cursor_command_path_project_scope():
+    target = CursorTarget()
+    path = target.get_command_path("/home/user/project", "project")
+    assert path == Path("/home/user/project/.cursor/commands")
+
+
+def test_cursor_agent_path_project_scope():
+    target = CursorTarget()
+    path = target.get_agent_path("/home/user/project", "project")
+    assert path == Path("/home/user/project/.cursor/agents")
+
+
+def test_cursor_instructions_path_project_scope():
+    target = CursorTarget()
+    path = target.get_instructions_path("/home/user/project", "project")
+    assert path == Path("/home/user/project/.cursor/rules")
+
+
+def test_cursor_mcp_path_project_scope():
+    target = CursorTarget()
+    path = target.get_mcp_path("/home/user/project", "project")
+    assert path == Path("/home/user/project/.cursor/mcp.json")
+
+
+# --- Default scope tests (no explicit scope argument) ---
+
+
+def test_cursor_skill_path_default_scope():
+    target = CursorTarget()
+    result = target.get_skill_path("/home/user/project")
+    assert result == Path("/home/user/project/.cursor/skills")
+
+
+def test_cursor_command_path_default_scope():
+    target = CursorTarget()
+    result = target.get_command_path("/home/user/project")
+    assert result == Path("/home/user/project/.cursor/commands")
+
+
+def test_cursor_agent_path_default_scope():
+    target = CursorTarget()
+    result = target.get_agent_path("/home/user/project")
+    assert result == Path("/home/user/project/.cursor/agents")
+
+
+def test_cursor_instructions_path_default_scope():
+    target = CursorTarget()
+    result = target.get_instructions_path("/home/user/project")
+    assert result == Path("/home/user/project/.cursor/rules")
+
+
+def test_cursor_mcp_path_default_scope():
+    target = CursorTarget()
+    result = target.get_mcp_path("/home/user/project")
+    assert result == Path("/home/user/project/.cursor/mcp.json")

--- a/tests/test_gemini_target.py
+++ b/tests/test_gemini_target.py
@@ -1,0 +1,87 @@
+"""Tests for GeminiTarget scope-aware path resolution."""
+
+from pathlib import Path
+
+from lola.targets.gemini import GeminiTarget
+
+
+# --- User scope tests ---
+
+
+def test_gemini_command_path_user_scope():
+    target = GeminiTarget()
+    path = target.get_command_path("/home/user/project", "user")
+    assert path == Path.home() / ".gemini" / "commands"
+
+
+def test_gemini_instructions_path_user_scope():
+    target = GeminiTarget()
+    path = target.get_instructions_path("/home/user/project", "user")
+    assert path == Path.home() / "GEMINI.md"
+
+
+def test_gemini_mcp_path_user_scope():
+    target = GeminiTarget()
+    path = target.get_mcp_path("/home/user/project", "user")
+    assert path == Path.home() / ".gemini" / "settings.json"
+
+
+def test_gemini_skill_path_user_scope_from_managed_section():
+    """GeminiTarget inherits from ManagedSectionTarget which has get_skill_path."""
+    target = GeminiTarget()
+    path = target.get_skill_path("/home/user/project", "user")
+    assert path == Path.home() / "GEMINI.md"
+
+
+# --- Project scope tests ---
+
+
+def test_gemini_command_path_project_scope():
+    target = GeminiTarget()
+    path = target.get_command_path("/home/user/project", "project")
+    assert path == Path("/home/user/project/.gemini/commands")
+
+
+def test_gemini_instructions_path_project_scope():
+    target = GeminiTarget()
+    path = target.get_instructions_path("/home/user/project", "project")
+    assert path == Path("/home/user/project/GEMINI.md")
+
+
+def test_gemini_mcp_path_project_scope():
+    target = GeminiTarget()
+    path = target.get_mcp_path("/home/user/project", "project")
+    assert path == Path("/home/user/project/.gemini/settings.json")
+
+
+def test_gemini_skill_path_project_scope():
+    target = GeminiTarget()
+    path = target.get_skill_path("/home/user/project", "project")
+    assert path == Path("/home/user/project/GEMINI.md")
+
+
+# --- Default scope tests (no explicit scope argument) ---
+
+
+def test_gemini_command_path_default_scope():
+    target = GeminiTarget()
+    result = target.get_command_path("/home/user/project")
+    assert result == Path("/home/user/project/.gemini/commands")
+
+
+def test_gemini_instructions_path_default_scope():
+    target = GeminiTarget()
+    result = target.get_instructions_path("/home/user/project")
+    assert result == Path("/home/user/project/GEMINI.md")
+
+
+def test_gemini_mcp_path_default_scope():
+    target = GeminiTarget()
+    result = target.get_mcp_path("/home/user/project")
+    assert result == Path("/home/user/project/.gemini/settings.json")
+
+
+def test_gemini_skill_path_default_scope():
+    target = GeminiTarget()
+    result = target.get_skill_path("/home/user/project")
+    assert result == Path("/home/user/project/GEMINI.md")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -41,7 +41,7 @@ def _uninstall(env: dict, assistant: str) -> None:
     """Uninstall test-module from the given assistant; assert success."""
     result = env["runner"].invoke(
         uninstall_cmd,
-        [env["module_name"], "-a", assistant, "-f"],
+        [env["module_name"], str(env["project"]), "-a", assistant, "-f"],
     )
     assert result.exit_code == 0, f"uninstall from {assistant} failed:\n{result.output}"
 
@@ -572,3 +572,75 @@ class TestRegistryState:
         _install(integration_env, "claude-code")
         inst = _find_inst(integration_env, "claude-code")
         assert sorted(inst["mcps"]) == ["github", "memory"]
+
+
+# =============================================================================
+# TestScopedInstallation
+# =============================================================================
+
+
+class TestScopedInstallation:
+    """Test that --scope user correctly installs commands and agents to user paths."""
+
+    def test_user_scope_commands_installed_to_home(self, integration_env, monkeypatch):
+        """Commands with --scope user should go to ~/.claude/commands, not cwd."""
+        from pathlib import Path
+
+        # Mock Path.home() to return a controlled location
+        fake_home = integration_env["project"].parent / "fake_home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+        result = integration_env["runner"].invoke(
+            install_cmd,
+            [
+                integration_env["module_name"],
+                "--scope",
+                "user",
+                "-a",
+                "claude-code",
+                "-f",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+        # Verify commands are in user scope (~/.claude/commands)
+        user_cmd_dir = fake_home / ".claude" / "commands"
+        assert user_cmd_dir.exists()
+        assert (user_cmd_dir / "review-pr.md").exists()
+        assert (user_cmd_dir / "quick-commit.md").exists()
+
+        # Verify commands are NOT in project scope
+        project_cmd_dir = integration_env["project"] / ".claude" / "commands"
+        assert not project_cmd_dir.exists()
+
+    def test_user_scope_agents_installed_to_home(self, integration_env, monkeypatch):
+        """Agents with --scope user should go to ~/.claude/agents, not cwd."""
+        from pathlib import Path
+
+        # Mock Path.home() to return a controlled location
+        fake_home = integration_env["project"].parent / "fake_home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+        result = integration_env["runner"].invoke(
+            install_cmd,
+            [
+                integration_env["module_name"],
+                "--scope",
+                "user",
+                "-a",
+                "claude-code",
+                "-f",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+        # Verify agents are in user scope (~/.claude/agents)
+        user_agent_dir = fake_home / ".claude" / "agents"
+        assert user_agent_dir.exists()
+        assert (user_agent_dir / "code-reviewer.md").exists()
+
+        # Verify agents are NOT in project scope
+        project_agent_dir = integration_env["project"] / ".claude" / "agents"
+        assert not project_agent_dir.exists()

--- a/tests/test_list_scope.py
+++ b/tests/test_list_scope.py
@@ -1,0 +1,226 @@
+"""Tests for scope display in the list command."""
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from lola.cli.install import list_installed_cmd
+from lola.models import Installation, InstallationRegistry
+
+
+class TestListShowsScope:
+    """Tests that list command displays scope information."""
+
+    def test_list_shows_user_scope(self, tmp_path):
+        """List command should display 'scope: user' for user-scoped installations."""
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        installed_file.parent.mkdir(parents=True)
+
+        registry = InstallationRegistry(installed_file)
+        registry.add(
+            Installation(
+                module_name="test-module",
+                assistant="claude-code",
+                scope="user",
+                project_path=None,
+                skills=["skill1"],
+            )
+        )
+
+        runner = CliRunner()
+        with (
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry", return_value=registry),
+        ):
+            result = runner.invoke(list_installed_cmd, [])
+
+        assert result.exit_code == 0
+        assert "test-module" in result.output
+        assert "scope:" in result.output
+        assert "user" in result.output
+        assert "claude-code" in result.output
+
+    def test_list_shows_project_scope_with_path(self, tmp_path):
+        """List command should display scope and path for project-scoped installations."""
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        installed_file.parent.mkdir(parents=True)
+
+        project_path = "/home/user/project"
+        registry = InstallationRegistry(installed_file)
+        registry.add(
+            Installation(
+                module_name="test-module",
+                assistant="cursor",
+                scope="project",
+                project_path=project_path,
+                skills=["skill1"],
+            )
+        )
+
+        runner = CliRunner()
+        with (
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry", return_value=registry),
+        ):
+            result = runner.invoke(list_installed_cmd, [])
+
+        assert result.exit_code == 0
+        assert "test-module" in result.output
+        assert "scope:" in result.output
+        assert "project" in result.output
+        assert "path:" in result.output
+        assert project_path in result.output
+        assert "cursor" in result.output
+
+    def test_list_user_scope_no_path_shown(self, tmp_path):
+        """User scope installations should not show path."""
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        installed_file.parent.mkdir(parents=True)
+
+        registry = InstallationRegistry(installed_file)
+        registry.add(
+            Installation(
+                module_name="test-module",
+                assistant="claude-code",
+                scope="user",
+                project_path=None,
+                skills=["skill1"],
+            )
+        )
+
+        runner = CliRunner()
+        with (
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry", return_value=registry),
+        ):
+            result = runner.invoke(list_installed_cmd, [])
+
+        assert result.exit_code == 0
+        assert "path:" not in result.output
+
+    def test_list_groups_by_scope_and_path(self, tmp_path):
+        """List groups installations by (scope, project_path) and consolidates assistants."""
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        installed_file.parent.mkdir(parents=True)
+
+        registry = InstallationRegistry(installed_file)
+        # Two user-scope installations for different assistants
+        registry.add(
+            Installation(
+                module_name="test-module",
+                assistant="claude-code",
+                scope="user",
+                project_path=None,
+                skills=["skill1"],
+            )
+        )
+        registry.add(
+            Installation(
+                module_name="test-module",
+                assistant="cursor",
+                scope="user",
+                project_path=None,
+                skills=["skill1"],
+            )
+        )
+        # One project-scope installation
+        registry.add(
+            Installation(
+                module_name="test-module",
+                assistant="claude-code",
+                scope="project",
+                project_path="/home/user/project",
+                skills=["skill1"],
+            )
+        )
+
+        runner = CliRunner()
+        with (
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry", return_value=registry),
+        ):
+            result = runner.invoke(list_installed_cmd, [])
+
+        assert result.exit_code == 0
+        # Should show one module header
+        assert "Installed (1 module)" in result.output
+        # Should show both scopes
+        assert "user" in result.output
+        assert "project" in result.output
+        # User scope should consolidate both assistants
+        assert "claude-code, cursor" in result.output
+
+    def test_list_assistants_sorted_alphabetically(self, tmp_path):
+        """Assistants within a scope group should be sorted alphabetically."""
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        installed_file.parent.mkdir(parents=True)
+
+        registry = InstallationRegistry(installed_file)
+        # Add in reverse alphabetical order
+        registry.add(
+            Installation(
+                module_name="test-module",
+                assistant="cursor",
+                scope="user",
+                project_path=None,
+                skills=["skill1"],
+            )
+        )
+        registry.add(
+            Installation(
+                module_name="test-module",
+                assistant="claude-code",
+                scope="user",
+                project_path=None,
+                skills=["skill1"],
+            )
+        )
+
+        runner = CliRunner()
+        with (
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry", return_value=registry),
+        ):
+            result = runner.invoke(list_installed_cmd, [])
+
+        assert result.exit_code == 0
+        # claude-code should come before cursor alphabetically
+        assert "claude-code, cursor" in result.output
+
+    def test_list_multiple_modules_with_mixed_scopes(self, tmp_path):
+        """Multiple modules with different scopes display correctly."""
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        installed_file.parent.mkdir(parents=True)
+
+        registry = InstallationRegistry(installed_file)
+        registry.add(
+            Installation(
+                module_name="module-a",
+                assistant="claude-code",
+                scope="user",
+                project_path=None,
+                skills=["skill1"],
+            )
+        )
+        registry.add(
+            Installation(
+                module_name="module-b",
+                assistant="cursor",
+                scope="project",
+                project_path="/home/user/myapp",
+                skills=["skill1"],
+            )
+        )
+
+        runner = CliRunner()
+        with (
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry", return_value=registry),
+        ):
+            result = runner.invoke(list_installed_cmd, [])
+
+        assert result.exit_code == 0
+        assert "Installed (2 modules)" in result.output
+        assert "module-a" in result.output
+        assert "module-b" in result.output
+        assert "/home/user/myapp" in result.output

--- a/tests/test_openclaw_target.py
+++ b/tests/test_openclaw_target.py
@@ -1,0 +1,68 @@
+"""Tests for OpenClawTarget scope-aware path resolution."""
+
+from pathlib import Path
+
+from lola.targets.openclaw import OpenClawTarget
+
+
+# --- User scope tests ---
+
+
+def test_openclaw_skill_path_user_scope():
+    target = OpenClawTarget()
+    path = target.get_skill_path("/home/user/project", "user")
+    assert path == Path.home() / ".openclaw" / "workspace" / "skills"
+
+
+def test_openclaw_command_path_user_scope():
+    target = OpenClawTarget()
+    path = target.get_command_path("/home/user/project", "user")
+    assert path == Path.home() / ".openclaw" / "workspace" / "commands"
+
+
+def test_openclaw_instructions_path_user_scope():
+    target = OpenClawTarget()
+    path = target.get_instructions_path("/home/user/project", "user")
+    assert path == Path.home() / ".openclaw" / "workspace" / "instructions.md"
+
+
+# --- Project scope tests ---
+
+
+def test_openclaw_skill_path_project_scope():
+    target = OpenClawTarget()
+    path = target.get_skill_path("/home/user/project", "project")
+    assert path == Path("/home/user/project/skills")
+
+
+def test_openclaw_command_path_project_scope():
+    target = OpenClawTarget()
+    path = target.get_command_path("/home/user/project", "project")
+    assert path == Path("/home/user/project/.openclaw/commands")
+
+
+def test_openclaw_instructions_path_project_scope():
+    target = OpenClawTarget()
+    path = target.get_instructions_path("/home/user/project", "project")
+    assert path == Path("/home/user/project/.openclaw/instructions.md")
+
+
+# --- Default scope tests (no explicit scope argument) ---
+
+
+def test_openclaw_skill_path_default_scope():
+    target = OpenClawTarget()
+    result = target.get_skill_path("/home/user/project")
+    assert result == Path("/home/user/project/skills")
+
+
+def test_openclaw_command_path_default_scope():
+    target = OpenClawTarget()
+    result = target.get_command_path("/home/user/project")
+    assert result == Path("/home/user/project/.openclaw/commands")
+
+
+def test_openclaw_instructions_path_default_scope():
+    target = OpenClawTarget()
+    result = target.get_instructions_path("/home/user/project")
+    assert result == Path("/home/user/project/.openclaw/instructions.md")

--- a/tests/test_opencode_target.py
+++ b/tests/test_opencode_target.py
@@ -1,0 +1,105 @@
+"""Tests for OpenCodeTarget scope-aware path resolution."""
+
+from pathlib import Path
+
+from lola.targets.opencode import OpenCodeTarget
+
+
+# --- User scope tests ---
+
+
+def test_opencode_command_path_user_scope():
+    target = OpenCodeTarget()
+    path = target.get_command_path("/home/user/project", "user")
+    assert path == Path.home() / ".opencode" / "commands"
+
+
+def test_opencode_agent_path_user_scope():
+    target = OpenCodeTarget()
+    path = target.get_agent_path("/home/user/project", "user")
+    assert path == Path.home() / ".opencode" / "agents"
+
+
+def test_opencode_instructions_path_user_scope():
+    target = OpenCodeTarget()
+    path = target.get_instructions_path("/home/user/project", "user")
+    assert path == Path.home() / "AGENTS.md"
+
+
+def test_opencode_mcp_path_user_scope():
+    target = OpenCodeTarget()
+    path = target.get_mcp_path("/home/user/project", "user")
+    assert path == Path.home() / "opencode.json"
+
+
+def test_opencode_skill_path_user_scope_from_managed_section():
+    """OpenCodeTarget inherits from ManagedSectionTarget which has get_skill_path."""
+    target = OpenCodeTarget()
+    path = target.get_skill_path("/home/user/project", "user")
+    assert path == Path.home() / "AGENTS.md"
+
+
+# --- Project scope tests ---
+
+
+def test_opencode_command_path_project_scope():
+    target = OpenCodeTarget()
+    path = target.get_command_path("/home/user/project", "project")
+    assert path == Path("/home/user/project/.opencode/commands")
+
+
+def test_opencode_agent_path_project_scope():
+    target = OpenCodeTarget()
+    path = target.get_agent_path("/home/user/project", "project")
+    assert path == Path("/home/user/project/.opencode/agents")
+
+
+def test_opencode_instructions_path_project_scope():
+    target = OpenCodeTarget()
+    path = target.get_instructions_path("/home/user/project", "project")
+    assert path == Path("/home/user/project/AGENTS.md")
+
+
+def test_opencode_mcp_path_project_scope():
+    target = OpenCodeTarget()
+    path = target.get_mcp_path("/home/user/project", "project")
+    assert path == Path("/home/user/project/opencode.json")
+
+
+def test_opencode_skill_path_project_scope():
+    target = OpenCodeTarget()
+    path = target.get_skill_path("/home/user/project", "project")
+    assert path == Path("/home/user/project/AGENTS.md")
+
+
+# --- Default scope tests (no explicit scope argument) ---
+
+
+def test_opencode_command_path_default_scope():
+    target = OpenCodeTarget()
+    result = target.get_command_path("/home/user/project")
+    assert result == Path("/home/user/project/.opencode/commands")
+
+
+def test_opencode_agent_path_default_scope():
+    target = OpenCodeTarget()
+    result = target.get_agent_path("/home/user/project")
+    assert result == Path("/home/user/project/.opencode/agents")
+
+
+def test_opencode_instructions_path_default_scope():
+    target = OpenCodeTarget()
+    result = target.get_instructions_path("/home/user/project")
+    assert result == Path("/home/user/project/AGENTS.md")
+
+
+def test_opencode_mcp_path_default_scope():
+    target = OpenCodeTarget()
+    result = target.get_mcp_path("/home/user/project")
+    assert result == Path("/home/user/project/opencode.json")
+
+
+def test_opencode_skill_path_default_scope():
+    target = OpenCodeTarget()
+    result = target.get_skill_path("/home/user/project")
+    assert result == Path("/home/user/project/AGENTS.md")

--- a/tests/test_scoped_install_integration.py
+++ b/tests/test_scoped_install_integration.py
@@ -1,0 +1,234 @@
+"""Integration tests for scoped installation flow.
+
+These tests verify the end-to-end install workflow for both user and project
+scopes, including file creation in the correct locations and registry records.
+"""
+
+import shutil
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from lola.cli.install import install_cmd
+from lola.models import InstallationRegistry
+
+
+@pytest.fixture
+def isolated_lola_home(monkeypatch, tmp_path):
+    """Create isolated lola home for testing."""
+    lola_home = tmp_path / ".lola"
+    lola_home.mkdir()
+    (lola_home / "modules").mkdir()
+
+    monkeypatch.setattr("lola.config.LOLA_HOME", lola_home)
+    monkeypatch.setattr("lola.config.MODULES_DIR", lola_home / "modules")
+    monkeypatch.setattr("lola.config.INSTALLED_FILE", lola_home / "installed.yml")
+
+    # Patch from-imports in modules that use them
+    monkeypatch.setattr("lola.cli.install.MODULES_DIR", lola_home / "modules")
+    monkeypatch.setattr("lola.utils.LOLA_HOME", lola_home)
+    monkeypatch.setattr("lola.utils.MODULES_DIR", lola_home / "modules")
+
+    return lola_home
+
+
+@pytest.fixture
+def sample_module(tmp_path):
+    """Create a sample module with a skill."""
+    module_dir = tmp_path / "test-module"
+    module_dir.mkdir()
+
+    skills_dir = module_dir / "skills" / "test-skill"
+    skills_dir.mkdir(parents=True)
+
+    skill_file = skills_dir / "SKILL.md"
+    skill_file.write_text(
+        "---\n"
+        "name: test-skill\n"
+        "description: A test skill\n"
+        "---\n"
+        "\n"
+        "# Test Skill\n"
+        "\n"
+        "This is a test skill.\n"
+    )
+
+    return module_dir
+
+
+def test_install_user_scope_creates_files_in_home(
+    isolated_lola_home, sample_module, tmp_path
+):
+    """Installing with user scope should create files in home directory."""
+    runner = CliRunner()
+
+    # Register the module first
+    shutil.copytree(sample_module, isolated_lola_home / "modules" / "test-module")
+
+    # Use a fake home directory to avoid polluting real home
+    fake_home = tmp_path / "fakehome"
+    fake_home.mkdir()
+
+    with patch("pathlib.Path.home", return_value=fake_home):
+        result = runner.invoke(
+            install_cmd,
+            ["test-module", "--scope", "user", "-a", "claude-code"],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+
+    # Verify files created in fake home directory
+    skill_file = fake_home / ".claude" / "skills" / "test-skill" / "SKILL.md"
+    assert skill_file.exists(), (
+        f"Expected skill file at {skill_file}, but it does not exist"
+    )
+
+    # Verify installation record has scope=user, project_path=None
+    registry = InstallationRegistry(isolated_lola_home / "installed.yml")
+    installations = registry.all()
+    assert len(installations) == 1
+    assert installations[0].scope == "user"
+    assert installations[0].project_path is None
+    assert installations[0].module_name == "test-module"
+    assert installations[0].assistant == "claude-code"
+    assert "test-skill" in installations[0].skills
+
+
+def test_install_project_scope_creates_files_in_project(
+    isolated_lola_home, sample_module, tmp_path
+):
+    """Installing with project scope should create files in project directory."""
+    runner = CliRunner()
+
+    # Register the module
+    shutil.copytree(sample_module, isolated_lola_home / "modules" / "test-module")
+
+    project_dir = tmp_path / "my-project"
+    project_dir.mkdir()
+
+    result = runner.invoke(
+        install_cmd,
+        [
+            "test-module",
+            "--scope",
+            "project",
+            "-a",
+            "claude-code",
+            str(project_dir),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+
+    # Verify files created in project directory
+    skill_file = project_dir / ".claude" / "skills" / "test-skill" / "SKILL.md"
+    assert skill_file.exists(), (
+        f"Expected skill file at {skill_file}, but it does not exist"
+    )
+
+    # Verify installation record
+    registry = InstallationRegistry(isolated_lola_home / "installed.yml")
+    installations = registry.all()
+    assert len(installations) == 1
+    assert installations[0].scope == "project"
+    assert installations[0].project_path == str(project_dir)
+    assert installations[0].module_name == "test-module"
+    assert installations[0].assistant == "claude-code"
+    assert "test-skill" in installations[0].skills
+
+
+def test_install_user_scope_with_explicit_path_fails(
+    isolated_lola_home, sample_module, tmp_path
+):
+    """User scope with explicit path should fail validation."""
+    runner = CliRunner()
+
+    shutil.copytree(sample_module, isolated_lola_home / "modules" / "test-module")
+
+    project_dir = tmp_path / "my-project"
+    project_dir.mkdir()
+
+    result = runner.invoke(
+        install_cmd,
+        [
+            "test-module",
+            "--scope",
+            "user",
+            "-a",
+            "claude-code",
+            str(project_dir),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1
+    assert "cannot be used with a project path argument" in result.output
+
+
+def test_install_both_scopes_coexist(isolated_lola_home, sample_module, tmp_path):
+    """Installing same module in both scopes should work."""
+    runner = CliRunner()
+
+    shutil.copytree(sample_module, isolated_lola_home / "modules" / "test-module")
+
+    # Use a fake home directory to avoid polluting real home
+    fake_home = tmp_path / "fakehome"
+    fake_home.mkdir()
+
+    # Install user scope
+    with patch("pathlib.Path.home", return_value=fake_home):
+        result1 = runner.invoke(
+            install_cmd,
+            ["test-module", "--scope", "user", "-a", "claude-code"],
+            catch_exceptions=False,
+        )
+    assert result1.exit_code == 0
+
+    # Install project scope
+    project_dir = tmp_path / "my-project"
+    project_dir.mkdir()
+
+    result2 = runner.invoke(
+        install_cmd,
+        [
+            "test-module",
+            "--scope",
+            "project",
+            "-a",
+            "claude-code",
+            str(project_dir),
+        ],
+        catch_exceptions=False,
+    )
+    assert result2.exit_code == 0
+
+    # Verify both installations exist in registry
+    registry = InstallationRegistry(isolated_lola_home / "installed.yml")
+    installations = registry.all()
+    assert len(installations) == 2
+
+    scopes = {inst.scope for inst in installations}
+    assert scopes == {"user", "project"}
+
+    # Verify user scope record
+    user_insts = [inst for inst in installations if inst.scope == "user"]
+    assert len(user_insts) == 1
+    assert user_insts[0].project_path is None
+    assert user_insts[0].module_name == "test-module"
+
+    # Verify project scope record
+    project_insts = [inst for inst in installations if inst.scope == "project"]
+    assert len(project_insts) == 1
+    assert project_insts[0].project_path == str(project_dir)
+    assert project_insts[0].module_name == "test-module"
+
+    # Verify files exist in both locations
+    user_skill = fake_home / ".claude" / "skills" / "test-skill" / "SKILL.md"
+    project_skill = project_dir / ".claude" / "skills" / "test-skill" / "SKILL.md"
+    assert user_skill.exists(), f"Expected user scope skill file at {user_skill}"
+    assert project_skill.exists(), (
+        f"Expected project scope skill file at {project_skill}"
+    )

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -909,7 +909,7 @@ class TestTarSourceHandlerAdvanced:
         source_dir.mkdir()
 
         for ext, mode in [
-            (".tar", "w"),
+            (".tar", "w:tar"),
             (".tar.gz", "w:gz"),
             (".tgz", "w:gz"),
             (".tar.bz2", "w:bz2"),
@@ -920,7 +920,9 @@ class TestTarSourceHandlerAdvanced:
             (content_dir / "file.txt").write_text("content")
 
             tar_file = source_dir / f"mymodule{ext}"
-            with tarfile.open(tar_file, mode) as tf:  # type: ignore[no-matching-overload]
+            # Type checker doesn't recognize dynamic mode strings from the list
+            tf = tarfile.open(str(tar_file), mode)  # type: ignore
+            with tf:
                 tf.add(content_dir, arcname="content")
 
             dest_dir = tmp_path / f"dest{ext.replace('.', '_')}"

--- a/tests/test_targets_base.py
+++ b/tests/test_targets_base.py
@@ -1,0 +1,106 @@
+"""Tests for AssistantTarget ABC scope parameter support."""
+
+from pathlib import Path
+
+from lola.targets.base import AssistantTarget
+
+
+class MockTarget(AssistantTarget):
+    """Mock target for testing ABC."""
+
+    name = "mock"
+    supports_agents = True
+    uses_managed_section = False
+
+    def get_skill_path(self, project_path: str, scope: str = "project") -> Path:
+        if scope == "user":
+            return Path.home() / ".mock" / "skills"
+        return Path(project_path) / ".mock" / "skills"
+
+    def get_command_path(self, project_path: str, scope: str = "project") -> Path:
+        if scope == "user":
+            return Path.home() / ".mock" / "commands"
+        return Path(project_path) / ".mock" / "commands"
+
+    def get_agent_path(self, project_path: str, scope: str = "project") -> Path:
+        if scope == "user":
+            return Path.home() / ".mock" / "agents"
+        return Path(project_path) / ".mock" / "agents"
+
+    def get_instructions_path(self, project_path: str, scope: str = "project") -> Path:
+        if scope == "user":
+            return Path.home() / "MOCK.md"
+        return Path(project_path) / "MOCK.md"
+
+    def get_mcp_path(self, project_path: str, scope: str = "project") -> Path:
+        if scope == "user":
+            return Path.home() / ".mock.json"
+        return Path(project_path) / ".mock.json"
+
+    # Minimal stubs for other required methods
+    def generate_skill(self, source_path, dest_path, skill_name, project_path=None):
+        return True
+
+    def generate_command(self, source_path, dest_dir, cmd_name, module_name):
+        return True
+
+    def generate_agent(self, source_path, dest_dir, agent_name, module_name):
+        return True
+
+    def generate_instructions(
+        self, source: Path | str, dest_path: Path, module_name: str
+    ) -> bool:
+        return True
+
+    def remove_skill(self, dest_path, skill_name):
+        return True
+
+    def remove_instructions(self, dest_path, module_name):
+        return True
+
+    def generate_skills_batch(self, dest_file, module_name, skills, project_path):
+        return True
+
+    def get_command_filename(self, module_name, cmd_name):
+        return f"{module_name}.{cmd_name}.md"
+
+    def get_agent_filename(self, module_name, agent_name):
+        return f"{module_name}.{agent_name}.md"
+
+    def generate_mcps(self, mcps, dest_path, module_name):
+        return True
+
+    def remove_mcps(
+        self, dest_path: Path, module_name: str, mcp_names: list[str] | None = None
+    ) -> bool:
+        return True
+
+    def remove_command(self, dest_dir, cmd_name, module_name):
+        return True
+
+    def remove_agent(self, dest_dir, agent_name, module_name):
+        return True
+
+
+def test_get_skill_path_project_scope():
+    target = MockTarget()
+    path = target.get_skill_path("/home/user/project", "project")
+    assert path == Path("/home/user/project/.mock/skills")
+
+
+def test_get_skill_path_user_scope():
+    target = MockTarget()
+    path = target.get_skill_path("/home/user/project", "user")
+    assert path == Path.home() / ".mock" / "skills"
+
+
+def test_get_command_path_project_scope():
+    target = MockTarget()
+    path = target.get_command_path("/home/user/project", "project")
+    assert path == Path("/home/user/project/.mock/commands")
+
+
+def test_get_command_path_user_scope():
+    target = MockTarget()
+    path = target.get_command_path("/home/user/project", "user")
+    assert path == Path.home() / ".mock" / "commands"

--- a/tests/test_uninstall_scope.py
+++ b/tests/test_uninstall_scope.py
@@ -1,0 +1,199 @@
+"""Tests for uninstall --scope filter functionality."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from lola.cli.install import uninstall_cmd
+from lola.models import Installation, InstallationRegistry
+
+
+class TestUninstallScopeFilter:
+    """Test --scope filter for uninstall command."""
+
+    def test_scope_option_exists(self):
+        """Verify --scope option is registered on uninstall_cmd."""
+        runner = CliRunner()
+        result = runner.invoke(uninstall_cmd, ["--help"])
+        assert result.exit_code == 0
+        assert "--scope" in result.output
+
+    def test_uninstall_filters_by_scope_user(self, mock_lola_home, tmp_path):
+        """Uninstall with --scope user should only remove user-scoped installations."""
+        project_path = str(tmp_path / "project")
+        Path(project_path).mkdir(parents=True)
+
+        registry = InstallationRegistry(mock_lola_home["installed"])
+        registry.add(
+            Installation(
+                module_name="test-module",
+                assistant="claude-code",
+                scope="user",
+                project_path=None,
+                skills=["skill1"],
+            )
+        )
+        registry.add(
+            Installation(
+                module_name="test-module",
+                assistant="claude-code",
+                scope="project",
+                project_path=project_path,
+                skills=["skill1"],
+            )
+        )
+
+        runner = CliRunner()
+        with patch("lola.cli.install.get_registry", return_value=registry):
+            result = runner.invoke(
+                uninstall_cmd,
+                ["test-module", "--scope", "user", "-f"],
+            )
+
+        assert result.exit_code == 0
+
+        # Verify only user-scoped installation was removed
+        remaining = registry.all()
+        assert len(remaining) == 1
+        assert remaining[0].scope == "project"
+        assert remaining[0].project_path == project_path
+
+    def test_uninstall_filters_by_scope_project(self, mock_lola_home, tmp_path):
+        """Uninstall with --scope project should only remove project-scoped installations."""
+        project_path = str(tmp_path / "project")
+        Path(project_path).mkdir(parents=True)
+
+        registry = InstallationRegistry(mock_lola_home["installed"])
+        registry.add(
+            Installation(
+                module_name="test-module",
+                assistant="claude-code",
+                scope="user",
+                project_path=None,
+                skills=["skill1"],
+            )
+        )
+        registry.add(
+            Installation(
+                module_name="test-module",
+                assistant="claude-code",
+                scope="project",
+                project_path=project_path,
+                skills=["skill1"],
+            )
+        )
+
+        runner = CliRunner()
+        with patch("lola.cli.install.get_registry", return_value=registry):
+            result = runner.invoke(
+                uninstall_cmd,
+                ["test-module", "--scope", "project", "-f"],
+            )
+
+        assert result.exit_code == 0
+
+        # Verify only project-scoped installation was removed
+        remaining = registry.all()
+        assert len(remaining) == 1
+        assert remaining[0].scope == "user"
+        assert remaining[0].project_path is None
+
+    def test_uninstall_no_scope_filter_removes_all(self, mock_lola_home, tmp_path):
+        """Uninstall without --scope should remove all matching installations."""
+        project_path = str(tmp_path / "project")
+        Path(project_path).mkdir(parents=True)
+
+        registry = InstallationRegistry(mock_lola_home["installed"])
+        registry.add(
+            Installation(
+                module_name="test-module",
+                assistant="claude-code",
+                scope="user",
+                project_path=None,
+                skills=["skill1"],
+            )
+        )
+        registry.add(
+            Installation(
+                module_name="test-module",
+                assistant="claude-code",
+                scope="project",
+                project_path=project_path,
+                skills=["skill1"],
+            )
+        )
+
+        runner = CliRunner()
+        with patch("lola.cli.install.get_registry", return_value=registry):
+            result = runner.invoke(
+                uninstall_cmd,
+                ["test-module", "-f"],
+            )
+
+        assert result.exit_code == 0
+
+        # Verify all installations were removed
+        remaining = registry.all()
+        assert len(remaining) == 0
+
+    def test_uninstall_user_scope_not_skipped(self, mock_lola_home):
+        """User scope installations (project_path=None) should NOT be skipped."""
+        registry = InstallationRegistry(mock_lola_home["installed"])
+        registry.add(
+            Installation(
+                module_name="test-module",
+                assistant="claude-code",
+                scope="user",
+                project_path=None,
+                skills=["skill1"],
+            )
+        )
+
+        runner = CliRunner()
+        with patch("lola.cli.install.get_registry", return_value=registry):
+            result = runner.invoke(
+                uninstall_cmd,
+                ["test-module", "-f"],
+            )
+
+        assert result.exit_code == 0
+        # Should NOT contain "legacy entry" skip message
+        assert "legacy entry" not in result.output
+        # Should be properly uninstalled
+        remaining = registry.all()
+        assert len(remaining) == 0
+
+    def test_uninstall_scope_no_matching(self, mock_lola_home, tmp_path):
+        """Uninstall with --scope that has no matching installations shows warning."""
+        project_path = str(tmp_path / "project")
+        Path(project_path).mkdir(parents=True)
+
+        registry = InstallationRegistry(mock_lola_home["installed"])
+        registry.add(
+            Installation(
+                module_name="test-module",
+                assistant="claude-code",
+                scope="project",
+                project_path=project_path,
+                skills=["skill1"],
+            )
+        )
+
+        runner = CliRunner()
+        with patch("lola.cli.install.get_registry", return_value=registry):
+            result = runner.invoke(
+                uninstall_cmd,
+                ["test-module", "--scope", "user", "-f"],
+            )
+
+        assert result.exit_code == 0
+        # New improved error message shows what scope was requested
+        assert (
+            "not with --scope user" in result.output
+            or "Found 1 installation(s)" in result.output
+        )
+
+        # Verify project installation was NOT removed
+        remaining = registry.all()
+        assert len(remaining) == 1

--- a/tests/test_update_user_scope.py
+++ b/tests/test_update_user_scope.py
@@ -1,0 +1,39 @@
+"""Tests for _validate_installation_for_update with user scope."""
+
+from lola.cli.install import _validate_installation_for_update
+from lola.models import Installation
+
+
+def test_validate_user_scope_installation_no_project_path_check(
+    mock_lola_home, registered_module
+):
+    """User scope installations should not validate project_path."""
+    inst = Installation(
+        module_name="sample-module",
+        assistant="claude-code",
+        scope="user",
+        project_path=None,
+        skills=["skill1"],
+    )
+
+    is_valid, error_msg = _validate_installation_for_update(inst)
+
+    # Should not fail on missing project path for user scope
+    assert is_valid, f"User scope validation should pass but got: {error_msg}"
+    assert error_msg is None
+
+
+def test_validate_project_scope_installation_requires_project_path():
+    """Project scope installations should validate project_path exists."""
+    inst = Installation(
+        module_name="test-module",
+        assistant="claude-code",
+        scope="project",
+        project_path="/nonexistent/path",
+        skills=["skill1"],
+    )
+
+    is_valid, error_msg = _validate_installation_for_update(inst)
+
+    assert not is_valid
+    assert error_msg == "project path no longer exists"


### PR DESCRIPTION
Enables installing modules to either project directories (`.claude/`, `.cursor/`, etc.) or user home directories (`~/.claude/`, `~/.cursor/`, etc.).

**Use cases**

1) A skill or agent should be available in every user project.

**Usage:**
```bash
lola install my-module              # project scope (default)
lola install my-module --scope user # user scope (global)
lola uninstall my-module --scope user
lola list                           # shows scope for each installation
```
                                                                               
**Changes:**
- Add --scope flag to install, uninstall, update, and list commands
- Implement scope-aware path resolution for all assistant targets
- Add comprehensive test coverage for scoped operations
- Update AGENTS.md with scope documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * install/uninstall/list gain a --scope (project|user) option; user installs write to the user home workspace and are recorded without a project path.

* **Bug Fixes / Behavior**
  * Scope-aware install/update/uninstall flows, improved cleanup (including symlinks), clearer messages when scope filters exclude matches, and scope-aware list grouping/indentation.
  * Default installation scope handling adjusted (omitted scope now treated as project by default).

* **Documentation**
  * Added "Installation Scopes" docs with concrete CLI examples.

* **Tests**
  * Extensive unit and integration tests for scoped paths, CLI validation, and registry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->