### PR TITLE
fix: bump pygments to 2.20.0 to address CVE-2026-4539 (ReDoS)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ authors = [
 dependencies = [
     "click>=8.3.0",
     "rich>=13.0.0",
+    "pygments>=2.20.0",
     "pyyaml>=6.0.0",
     "python-frontmatter>=1.1.0",
     "inquirerpy>=0.3.4",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -211,10 +211,11 @@ prompt-toolkit==3.0.52 \
     --hash=sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855 \
     --hash=sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955
     # via inquirerpy
-pygments==2.19.2 \
-    --hash=sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887 \
-    --hash=sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b
+pygments==2.20.0 \
+    --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
+    --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
     # via
+    #   lola-ai
     #   pytest
     #   rich
 pytest==9.0.2 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,10 +33,12 @@ prompt-toolkit==3.0.52 \
     --hash=sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855 \
     --hash=sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955
     # via inquirerpy
-pygments==2.19.2 \
-    --hash=sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887 \
-    --hash=sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b
-    # via rich
+pygments==2.20.0 \
+    --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
+    --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
+    # via
+    #   lola-ai
+    #   rich
 python-frontmatter==1.1.0 \
     --hash=sha256:335465556358d9d0e6c98bbeb69b1c969f2a4a21360587b9873bfc3b213407c1 \
     --hash=sha256:7118d2bd56af9149625745c58c9b51fb67e8d1294a0c76796dafdc72c36e5f6d

--- a/sbom.json
+++ b/sbom.json
@@ -2,9 +2,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
-  "serialNumber": "urn:uuid:84d8fd2a-25e5-4c1f-b104-105427605dc0",
+  "serialNumber": "urn:uuid:b0f07a70-1b87-4430-856b-80bbedd9bb9d",
   "metadata": {
-    "timestamp": "2026-04-09T23:05:33.962275112Z",
+    "timestamp": "2026-04-24T19:04:16.055677875Z",
     "tools": [
       {
         "vendor": "Astral Software Inc.",
@@ -89,10 +89,10 @@
     },
     {
       "type": "library",
-      "bom-ref": "pygments-10@2.19.2",
+      "bom-ref": "pygments-10@2.20.0",
       "name": "pygments",
-      "version": "2.19.2",
-      "purl": "pkg:pypi/pygments@2.19.2"
+      "version": "2.20.0",
+      "purl": "pkg:pypi/pygments@2.20.0"
     },
     {
       "type": "library",
@@ -147,6 +147,7 @@
         "click-2@8.3.1",
         "inquirerpy-4@0.3.4",
         "packaging-7@26.0",
+        "pygments-10@2.20.0",
         "python-frontmatter-11@1.1.0",
         "pyyaml-12@6.0.3",
         "rich-13@14.3.3"
@@ -177,7 +178,7 @@
       ]
     },
     {
-      "ref": "pygments-10@2.19.2",
+      "ref": "pygments-10@2.20.0",
       "dependsOn": []
     },
     {
@@ -194,7 +195,7 @@
       "ref": "rich-13@14.3.3",
       "dependsOn": [
         "markdown-it-py-5@4.0.0",
-        "pygments-10@2.19.2"
+        "pygments-10@2.20.0"
       ]
     },
     {

--- a/uv.lock
+++ b/uv.lock
@@ -385,6 +385,7 @@ dependencies = [
     { name = "click" },
     { name = "inquirerpy" },
     { name = "packaging" },
+    { name = "pygments" },
     { name = "python-frontmatter" },
     { name = "pyyaml" },
     { name = "rich" },
@@ -424,6 +425,7 @@ requires-dist = [
     { name = "mkdocs-mermaid2-plugin", marker = "extra == 'docs'", specifier = ">=1.0.0" },
     { name = "mkdocs-panzoom-plugin", marker = "extra == 'docs'", specifier = ">=0.5.2" },
     { name = "packaging", specifier = ">=24.0" },
+    { name = "pygments", specifier = ">=2.20.0" },
     { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.0.0" },
     { name = "python-frontmatter", specifier = ">=1.1.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
@@ -786,11 +788,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Pins `pygments>=2.20.0` as a direct dependency to resolve CVE-2026-4539 (SNYK-PYTHON-PYGMENTS-15746419), a medium-severity ReDoS in the `AdlLexer` class
- Previously pulled in transitively via `rich` at version 2.19.2; adding the direct floor forces resolution to the patched version
- Snyk SBOM scan now reports 0 issues (was 1 medium)

## Related Issues

Relates to SNYK-PYTHON-PYGMENTS-15746419 / CVE-2026-4539

## Test Plan

- [ ] `pre-commit run --all-files` passes with 0 Snyk findings
- [ ] `pygments==2.20.0` present in `uv.lock` and `requirements.txt`

## Checklist

- [x] Tests pass (`pytest`)
- [x] Linting passes (`ruff check src tests`)
- [x] Type checking passes (`ty check`)

## AI Disclosure

AI-assisted with Claude Code