### PR TITLE
feat: add --workspace flag for openclaw target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ Defined in `targets.py` TARGETS dict. Each assistant has different output format
 | claude-code | `.claude/skills/<skill>/SKILL.md` | `.claude/commands/<cmd>.md` | `.claude/agents/<agent>.md` |
 | cursor | `.cursor/skills/<skill>/SKILL.md` | `.cursor/commands/<cmd>.md` | `.cursor/agents/<agent>.md` |
 | gemini-cli | `GEMINI.md` (managed section) | `.gemini/commands/<cmd>.toml` | N/A |
-| openclaw | `skills/<skill>/SKILL.md` | N/A | N/A |
+| openclaw | `~/.openclaw/workspace/skills/<skill>/SKILL.md` | N/A | N/A |
 | opencode | `AGENTS.md` (managed section) | `.opencode/commands/<cmd>.md` | `.opencode/agents/<agent>.md` |
 
 Agent frontmatter is modified during generation:

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ lola install compliance-skills
 | Claude Code | `.claude/skills/<skill>/SKILL.md`       | `.claude/commands/<cmd>.md`       | `.claude/agents/<agent>.md`     |
 | Cursor      | `.cursor/skills/<skill>/SKILL.md`       | `.cursor/commands/<cmd>.md`       | `.cursor/agents/<agent>.md`     |
 | Gemini CLI  | `GEMINI.md`                             | `.gemini/commands/<cmd>.toml`     | N/A                             |
-| OpenClaw    | `skills/<skill>/SKILL.md`               | N/A                               | N/A                             |
+| OpenClaw    | `~/.openclaw/workspace/skills/<skill>/SKILL.md` | N/A                       | N/A                             |
 | OpenCode    | `AGENTS.md`                             | `.opencode/commands/<cmd>.md`     | `.opencode/agents/<agent>.md`   |
 
 ## Quick Install

--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -36,6 +36,7 @@ from lola.prompts import (
 )
 from lola.targets import (
     AssistantTarget,
+    OpenClawTarget,
     TARGETS,
     _get_content_path,
     _get_skill_description,
@@ -49,6 +50,23 @@ from lola.utils import ensure_lola_dirs, get_local_modules_path
 from lola.cli.utils import handle_lola_error
 
 console = Console()
+
+
+def _resolve_install_path(
+    assistant: Optional[str],
+    project_path: str,
+    workspace: Optional[str],
+) -> str:
+    """Resolve the effective install path for an assistant.
+
+    For openclaw, overrides project_path with the configured workspace.
+    Raises UsageError if --workspace is used with a non-openclaw assistant.
+    """
+    if workspace and assistant != "openclaw":
+        raise click.UsageError("--workspace is only valid with -a openclaw")
+    if assistant == "openclaw":
+        return str(OpenClawTarget.resolve_workspace(workspace))
+    return project_path
 
 
 def _fetch_from_marketplace(
@@ -692,6 +710,14 @@ def _format_update_summary(result: UpdateResult) -> str:
     "Pass the path to the main context file relative to the module root "
     "(e.g., module/AGENTS.md).",
 )
+@click.option(
+    "--workspace",
+    type=str,
+    default=None,
+    help="OpenClaw workspace name or absolute path (only valid with -a openclaw). "
+    "Defaults to ~/.openclaw/workspace. "
+    "Pass a name like 'work' to target ~/.openclaw/workspace-work.",
+)
 @click.argument("project_path", required=False, default="./")
 def install_cmd(
     module_name: Optional[str],
@@ -701,6 +727,7 @@ def install_cmd(
     pre_install: Optional[str],
     post_install: Optional[str],
     append_context: Optional[str],
+    workspace: Optional[str],
     project_path: str,
 ):
     """
@@ -717,7 +744,12 @@ def install_cmd(
         lola install my-module -a claude-code          # Specific assistant, no prompt
         lola install my-module ./my-project            # Install in a specific project directory
         lola install my-module --append-context module/AGENTS.md   # Append context reference
+        lola install my-module -a openclaw             # Install to ~/.openclaw/workspace/skills/
+        lola install my-module -a openclaw --workspace work        # Install to workspace-work
+        lola install my-module -a openclaw --workspace /custom/path  # Install to custom path
     """
+    project_path = _resolve_install_path(assistant, project_path, workspace)
+
     ensure_lola_dirs()
 
     # Resolve module_name interactively when omitted

--- a/src/lola/targets/openclaw.py
+++ b/src/lola/targets/openclaw.py
@@ -23,6 +23,21 @@ class OpenClawTarget(BaseAssistantTarget):
     name = "openclaw"
     supports_agents = False
 
+    @staticmethod
+    def resolve_workspace(workspace: str | None) -> Path:
+        """Resolve a workspace argument to an absolute Path.
+
+        - None        → ~/.openclaw/workspace  (default)
+        - absolute    → used as-is
+        - name        → ~/.openclaw/workspace-{name}
+        """
+        if workspace is None:
+            return Path.home() / ".openclaw" / "workspace"
+        p = Path(workspace)
+        if p.is_absolute():
+            return p
+        return Path.home() / ".openclaw" / f"workspace-{workspace}"
+
     def get_skill_path(self, project_path: str) -> Path:
         return Path(project_path) / "skills"
 

--- a/src/lola/targets/openclaw.py
+++ b/src/lola/targets/openclaw.py
@@ -28,14 +28,13 @@ class OpenClawTarget(BaseAssistantTarget):
         """Resolve a workspace argument to an absolute Path.
 
         - None        → ~/.openclaw/workspace  (default)
-        - absolute    → used as-is
-        - name        → ~/.openclaw/workspace-{name}
+        - path        → expanded and resolved (contains / or \\, e.g. ./foo, ~/foo)
+        - name        → ~/.openclaw/workspace-{name}  (e.g. foo → workspace-foo)
         """
         if workspace is None:
             return Path.home() / ".openclaw" / "workspace"
-        p = Path(workspace)
-        if p.is_absolute():
-            return p
+        if "/" in workspace or "\\" in workspace:
+            return Path(workspace).expanduser().absolute()
         return Path.home() / ".openclaw" / f"workspace-{workspace}"
 
     def get_skill_path(self, project_path: str) -> Path:

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -946,9 +946,20 @@ class TestOpenClawTarget:
         assert result == Path.home() / ".openclaw" / "workspace-work"
 
     def test_resolve_workspace_absolute(self, tmp_path: Path):
-        """resolve_workspace with an absolute path should return it as-is."""
+        """resolve_workspace with an absolute path should resolve it."""
         result = OpenClawTarget.resolve_workspace(str(tmp_path))
         assert result == tmp_path
+
+    def test_resolve_workspace_relative(self, tmp_path: Path, monkeypatch):
+        """resolve_workspace with ./path should resolve relative to CWD."""
+        monkeypatch.chdir(tmp_path)
+        result = OpenClawTarget.resolve_workspace("./myworkspace")
+        assert result == tmp_path / "myworkspace"
+
+    def test_resolve_workspace_home(self):
+        """resolve_workspace with ~/path should expand home directory."""
+        result = OpenClawTarget.resolve_workspace("~/.openclaw/workspace-custom")
+        assert result == Path.home() / ".openclaw" / "workspace-custom"
 
     def test_get_command_path(self, tmp_path: Path):
         """Command path should be .openclaw/commands."""
@@ -1093,9 +1104,15 @@ class TestResolveInstallPath:
         assert result == str(Path.home() / ".openclaw" / "workspace-work")
 
     def test_openclaw_workspace_absolute_path(self, tmp_path: Path):
-        """openclaw with absolute workspace path uses it as-is."""
+        """openclaw with absolute workspace path resolves it."""
         result = _resolve_install_path("openclaw", "./", str(tmp_path))
         assert result == str(tmp_path)
+
+    def test_openclaw_workspace_relative_path(self, tmp_path: Path, monkeypatch):
+        """openclaw with relative workspace path resolves to absolute."""
+        monkeypatch.chdir(tmp_path)
+        result = _resolve_install_path("openclaw", "./", "./myworkspace")
+        assert result == str(tmp_path / "myworkspace")
 
     def test_workspace_with_non_openclaw_raises(self, tmp_path: Path):
         """--workspace with a non-openclaw assistant raises UsageError."""

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -23,6 +23,7 @@ from lola.targets import (
     _get_skill_description,
     get_target,
 )
+from lola.cli.install import _resolve_install_path
 
 
 # =============================================================================
@@ -929,10 +930,25 @@ class TestOpenClawTarget:
         assert target.uses_managed_section is False
 
     def test_get_skill_path(self, tmp_path: Path):
-        """Skill path should be skills/ at workspace root (no dot-prefix)."""
+        """Skill path should be skills/ under the given workspace root."""
         target = OpenClawTarget()
         path = target.get_skill_path(str(tmp_path))
         assert path == tmp_path / "skills"
+
+    def test_resolve_workspace_default(self):
+        """resolve_workspace(None) should return ~/.openclaw/workspace."""
+        result = OpenClawTarget.resolve_workspace(None)
+        assert result == Path.home() / ".openclaw" / "workspace"
+
+    def test_resolve_workspace_name(self):
+        """resolve_workspace('work') should return ~/.openclaw/workspace-work."""
+        result = OpenClawTarget.resolve_workspace("work")
+        assert result == Path.home() / ".openclaw" / "workspace-work"
+
+    def test_resolve_workspace_absolute(self, tmp_path: Path):
+        """resolve_workspace with an absolute path should return it as-is."""
+        result = OpenClawTarget.resolve_workspace(str(tmp_path))
+        assert result == tmp_path
 
     def test_get_command_path(self, tmp_path: Path):
         """Command path should be .openclaw/commands."""
@@ -1051,6 +1067,49 @@ class TestOpenClawTarget:
         result = target.remove_skill(skill_dest, "mymod-test-skill")
         assert result is True
         assert not skill_dir.exists()
+
+
+# =============================================================================
+# _resolve_install_path Tests
+# =============================================================================
+
+
+class TestResolveInstallPath:
+    """Tests for _resolve_install_path helper in cli/install.py."""
+
+    def test_non_openclaw_returns_project_path(self, tmp_path: Path):
+        """Non-openclaw assistants return project_path unchanged."""
+        result = _resolve_install_path("claude-code", str(tmp_path), None)
+        assert result == str(tmp_path)
+
+    def test_openclaw_no_workspace_returns_default(self):
+        """openclaw with no --workspace returns ~/.openclaw/workspace."""
+        result = _resolve_install_path("openclaw", "./", None)
+        assert result == str(Path.home() / ".openclaw" / "workspace")
+
+    def test_openclaw_workspace_name_resolves(self):
+        """openclaw with workspace name resolves to ~/.openclaw/workspace-{name}."""
+        result = _resolve_install_path("openclaw", "./", "work")
+        assert result == str(Path.home() / ".openclaw" / "workspace-work")
+
+    def test_openclaw_workspace_absolute_path(self, tmp_path: Path):
+        """openclaw with absolute workspace path uses it as-is."""
+        result = _resolve_install_path("openclaw", "./", str(tmp_path))
+        assert result == str(tmp_path)
+
+    def test_workspace_with_non_openclaw_raises(self, tmp_path: Path):
+        """--workspace with a non-openclaw assistant raises UsageError."""
+        import click
+
+        with pytest.raises(click.UsageError, match="only valid with -a openclaw"):
+            _resolve_install_path("claude-code", str(tmp_path), "work")
+
+    def test_none_assistant_with_workspace_raises(self, tmp_path: Path):
+        """--workspace with no assistant raises UsageError."""
+        import click
+
+        with pytest.raises(click.UsageError, match="only valid with -a openclaw"):
+            _resolve_install_path(None, str(tmp_path), "work")
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Fix openclaw skill path to `~/.openclaw/workspace/skills/` (was installing to CWD)
- Add `--workspace` flag to `lola install -a openclaw` for named (`work` → `workspace-work`), relative (`./foo`), and absolute paths

## Related Issues

Closes #96

## Test Plan

- [ ] `lola install <module> -a openclaw` installs to `~/.openclaw/workspace/skills/`
- [ ] `--workspace work` resolves to `~/.openclaw/workspace-work/skills/`
- [ ] `--workspace ./custom` resolves relative path correctly
- [ ] `--workspace` with any other assistant raises a usage error

## Checklist

- [x] Tests pass (`pytest`) — 808 passed
- [x] Linting passes (`ruff check src tests`)
- [x] Type checking passes (`ty check`)

## AI Disclosure

AI-assisted with Claude Code