### PR TITLE
chore: migrate all repo references from RedHatProductSecurity to lobstertrap

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: true
 contact_links:
   - name: Discussions
-    url: https://github.com/lobstertrap/lola/discussions
+    url: https://github.com/LobsterTrap/lola/discussions
     about: Ask questions, share ideas, and discuss lola with the community
   - name: Documentation
-    url: https://github.com/lobstertrap/lola/blob/main/README.md
+    url: https://github.com/LobsterTrap/lola/blob/main/README.md
     about: Read the documentation to learn more about lola
   - name: Security Issue
-    url: https://github.com/lobstertrap/lola/security/advisories/new
+    url: https://github.com/LobsterTrap/lola/security/advisories/new
     about: Report security vulnerabilities privately

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: true
 contact_links:
   - name: Discussions
-    url: https://github.com/RedHatProductSecurity/lola/discussions
+    url: https://github.com/lobstertrap/lola/discussions
     about: Ask questions, share ideas, and discuss lola with the community
   - name: Documentation
-    url: https://github.com/RedHatProductSecurity/lola/blob/main/README.md
+    url: https://github.com/lobstertrap/lola/blob/main/README.md
     about: Read the documentation to learn more about lola
   - name: Security Issue
-    url: https://github.com/RedHatProductSecurity/lola/security/advisories/new
+    url: https://github.com/lobstertrap/lola/security/advisories/new
     about: Report security vulnerabilities privately

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Before you begin, ensure you have the following installed:
 ### 1. Fork and Clone
 
 1. Fork the repository by clicking the "Fork" button on
-   https://github.com/lobstertrap/lola
+   https://github.com/LobsterTrap/lola
 2. Clone your fork:
 
 ```bash
@@ -122,7 +122,7 @@ git push origin your-feature-name
 
 ### 2. Open the Pull Request
 
-1. Go to https://github.com/lobstertrap/lola
+1. Go to https://github.com/LobsterTrap/lola
 2. Click "Compare & pull request"
 3. Describe what changed and why
 4. Link related issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Before you begin, ensure you have the following installed:
 ### 1. Fork and Clone
 
 1. Fork the repository by clicking the "Fork" button on
-   https://github.com/RedHatProductSecurity/lola
+   https://github.com/lobstertrap/lola
 2. Clone your fork:
 
 ```bash
@@ -122,7 +122,7 @@ git push origin your-feature-name
 
 ### 2. Open the Pull Request
 
-1. Go to https://github.com/RedHatProductSecurity/lola
+1. Go to https://github.com/lobstertrap/lola
 2. Click "Compare & pull request"
 3. Describe what changed and why
 4. Link related issues

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Write Agent Skills and Contexts once, use everywhere.**
 
-Lola is a universal AI Package Manager. If an agent's skills were an RPM, Lola is the DNF for it. Write your [skills and context modules](https://redhatproductsecurity.github.io/lola/concepts/skills-and-modules/) once as portable packages, then install them to any AI assistant or agent with a single command.
+Lola is a universal AI Package Manager. If an agent's skills were an RPM, Lola is the DNF for it. Write your [skills and context modules](https://lobstertrap.org/lola/concepts/skills-and-modules/) once as portable packages, then install them to any AI assistant or agent with a single command.
 
 [![asciicast](https://asciinema.org/a/UsbI8adasbdAhAFQuiXj70eVp.svg)](https://asciinema.org/a/UsbI8adasbdAhAFQuiXj70eVp)
 
@@ -26,7 +26,7 @@ pip install lola-ai
 ```
 
 > **Want the latest dev version?**
-> `uv tool install git+https://github.com/RedHatProductSecurity/lola`
+> `uv tool install git+https://github.com/lobstertrap/lola`
 
 ## Quick Start
 
@@ -60,14 +60,14 @@ lola sync
 
 ## Documentation
 
-Full documentation is available at **[redhatproductsecurity.github.io/lola](https://redhatproductsecurity.github.io/lola/)**.
+Full documentation is available at **[lobstertrap.org/lola](https://lobstertrap.org/lola/)**.
 
-- [Installation](https://redhatproductsecurity.github.io/lola/getting-started/installation/) - Prerequisites and setup
-- [Quick Start](https://redhatproductsecurity.github.io/lola/getting-started/quick-start/) - Get up and running
-- [User Guide](https://redhatproductsecurity.github.io/lola/user-guide/modules/) - Modules, marketplace, and more
-- [CLI Reference](https://redhatproductsecurity.github.io/lola/cli-reference/) - Complete command reference
-- [Skills and Modules](https://redhatproductsecurity.github.io/lola/concepts/skills-and-modules/) - Understanding Agent Skills vs AI Context Modules
-- [Roadmap](https://redhatproductsecurity.github.io/lola/concepts/roadmap/) - Vision and where Lola is heading
+- [Installation](https://lobstertrap.org/lola/getting-started/installation/) - Prerequisites and setup
+- [Quick Start](https://lobstertrap.org/lola/getting-started/quick-start/) - Get up and running
+- [User Guide](https://lobstertrap.org/lola/user-guide/modules/) - Modules, marketplace, and more
+- [CLI Reference](https://lobstertrap.org/lola/cli-reference/) - Complete command reference
+- [Skills and Modules](https://lobstertrap.org/lola/concepts/skills-and-modules/) - Understanding Agent Skills vs AI Context Modules
+- [Roadmap](https://lobstertrap.org/lola/concepts/roadmap/) - Vision and where Lola is heading
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install lola-ai
 ```
 
 > **Want the latest dev version?**
-> `uv tool install git+https://github.com/lobstertrap/lola`
+> `uv tool install git+https://github.com/LobsterTrap/lola`
 
 ## Quick Start
 

--- a/docs/concepts/roadmap.md
+++ b/docs/concepts/roadmap.md
@@ -52,7 +52,7 @@ This vision includes:
 - **Provenance**: Attestation that skills originated from a trusted source and were built by a specific workflow, ensuring the full supply chain is verifiable
 - **Trusted Catalogs**: Curated, verified collections of skills that serve as the single source of truth for enterprise-approved AI context
 
-We envision Lola as part of a broader ecosystem of tools that can sign and attest skills, while Lola handles verification during installation. This is an open area of design and we welcome discussion - see [GitHub Issue #62](https://github.com/lobstertrap/lola/issues/62) for the ongoing conversation.
+We envision Lola as part of a broader ecosystem of tools that can sign and attest skills, while Lola handles verification during installation. This is an open area of design and we welcome discussion - see [GitHub Issue #62](https://github.com/LobsterTrap/lola/issues/62) for the ongoing conversation.
 
 ### Go Migration
 

--- a/docs/concepts/roadmap.md
+++ b/docs/concepts/roadmap.md
@@ -52,7 +52,7 @@ This vision includes:
 - **Provenance**: Attestation that skills originated from a trusted source and were built by a specific workflow, ensuring the full supply chain is verifiable
 - **Trusted Catalogs**: Curated, verified collections of skills that serve as the single source of truth for enterprise-approved AI context
 
-We envision Lola as part of a broader ecosystem of tools that can sign and attest skills, while Lola handles verification during installation. This is an open area of design and we welcome discussion - see [GitHub Issue #62](https://github.com/RedHatProductSecurity/lola/issues/62) for the ongoing conversation.
+We envision Lola as part of a broader ecosystem of tools that can sign and attest skills, while Lola handles verification during installation. This is an open area of design and we welcome discussion - see [GitHub Issue #62](https://github.com/lobstertrap/lola/issues/62) for the ongoing conversation.
 
 ### Go Migration
 

--- a/docs/concepts/why-lola.md
+++ b/docs/concepts/why-lola.md
@@ -68,7 +68,7 @@ There are many great tools in this space, each solving a real problem. This tabl
 | **Slash commands** | ✅ | ❌ | ❌ | ✅ |
 | **Subagents** | ✅ | ✅ | ❌ | ✅ |
 | **MCP servers** | ✅ | ✅ | ❌ | ✅ |
-| **Module dependencies** | 🔮 On the roadmap ([#28](https://github.com/lobstertrap/lola/issues/28), [#64](https://github.com/lobstertrap/lola/issues/64)) | ✅ Full transitive | ❌ | ❌ |
+| **Module dependencies** | 🔮 On the roadmap ([#28](https://github.com/LobsterTrap/lola/issues/28), [#64](https://github.com/LobsterTrap/lola/issues/64)) | ✅ Full transitive | ❌ | ❌ |
 | **Autonomous agent roadmap** | ✅ LangChain, CrewAI, AutoGen | ❌ | ❌ | ❌ |
 | **Ecosystem language** | Python | Python | Node.js | Node.js |
 
@@ -103,4 +103,4 @@ The vendor plugin movement is validating the idea that reusable context packages
 
 ---
 
-[Join the conversation on GitHub →](https://github.com/lobstertrap/lola)
+[Join the conversation on GitHub →](https://github.com/LobsterTrap/lola)

--- a/docs/concepts/why-lola.md
+++ b/docs/concepts/why-lola.md
@@ -68,7 +68,7 @@ There are many great tools in this space, each solving a real problem. This tabl
 | **Slash commands** | ✅ | ❌ | ❌ | ✅ |
 | **Subagents** | ✅ | ✅ | ❌ | ✅ |
 | **MCP servers** | ✅ | ✅ | ❌ | ✅ |
-| **Module dependencies** | 🔮 On the roadmap ([#28](https://github.com/RedHatProductSecurity/lola/issues/28), [#64](https://github.com/RedHatProductSecurity/lola/issues/64)) | ✅ Full transitive | ❌ | ❌ |
+| **Module dependencies** | 🔮 On the roadmap ([#28](https://github.com/lobstertrap/lola/issues/28), [#64](https://github.com/lobstertrap/lola/issues/64)) | ✅ Full transitive | ❌ | ❌ |
 | **Autonomous agent roadmap** | ✅ LangChain, CrewAI, AutoGen | ❌ | ❌ | ❌ |
 | **Ecosystem language** | Python | Python | Node.js | Node.js |
 
@@ -103,4 +103,4 @@ The vendor plugin movement is validating the idea that reusable context packages
 
 ---
 
-[Join the conversation on GitHub →](https://github.com/RedHatProductSecurity/lola)
+[Join the conversation on GitHub →](https://github.com/lobstertrap/lola)

--- a/docs/dev-guide/contributing.md
+++ b/docs/dev-guide/contributing.md
@@ -1,11 +1,11 @@
 # Contributing
 
-We welcome contributions to Lola! For the full contributing guide, see [CONTRIBUTING.md](https://github.com/lobstertrap/lola/blob/main/CONTRIBUTING.md).
+We welcome contributions to Lola! For the full contributing guide, see [CONTRIBUTING.md](https://github.com/LobsterTrap/lola/blob/main/CONTRIBUTING.md).
 
 ## Quick Start
 
 ```bash
-git clone https://github.com/lobstertrap/lola
+git clone https://github.com/LobsterTrap/lola
 cd lola
 uv sync --group dev
 source .venv/bin/activate

--- a/docs/dev-guide/contributing.md
+++ b/docs/dev-guide/contributing.md
@@ -1,11 +1,11 @@
 # Contributing
 
-We welcome contributions to Lola! For the full contributing guide, see [CONTRIBUTING.md](https://github.com/RedHatProductSecurity/lola/blob/main/CONTRIBUTING.md).
+We welcome contributions to Lola! For the full contributing guide, see [CONTRIBUTING.md](https://github.com/lobstertrap/lola/blob/main/CONTRIBUTING.md).
 
 ## Quick Start
 
 ```bash
-git clone https://github.com/RedHatProductSecurity/lola
+git clone https://github.com/lobstertrap/lola
 cd lola
 uv sync --group dev
 source .venv/bin/activate

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -23,13 +23,13 @@
 === "Latest from Git"
 
     ```bash
-    uv tool install git+https://github.com/lobstertrap/lola
+    uv tool install git+https://github.com/LobsterTrap/lola
     ```
 
 === "From source"
 
     ```bash
-    git clone https://github.com/lobstertrap/lola
+    git clone https://github.com/LobsterTrap/lola
     cd lola
     uv tool install .
     ```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -23,13 +23,13 @@
 === "Latest from Git"
 
     ```bash
-    uv tool install git+https://github.com/RedHatProductSecurity/lola
+    uv tool install git+https://github.com/lobstertrap/lola
     ```
 
 === "From source"
 
     ```bash
-    git clone https://github.com/RedHatProductSecurity/lola
+    git clone https://github.com/lobstertrap/lola
     cd lola
     uv tool install .
     ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ lola install compliance-skills
 ## Quick Install
 
 ```bash
-uv tool install git+https://github.com/lobstertrap/lola
+uv tool install git+https://github.com/LobsterTrap/lola
 ```
 
 ## Next Steps

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ lola install compliance-skills
 ## Quick Install
 
 ```bash
-uv tool install git+https://github.com/RedHatProductSecurity/lola
+uv tool install git+https://github.com/lobstertrap/lola
 ```
 
 ## Next Steps

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,8 +4,8 @@ site_description: Write Agent Skills and Contexts once, use everywhere
 site_author: Red Hat
 site_url: https://lobstertrap.org/lola/
 
-repo_name: lobstertrap/lola
-repo_url: https://github.com/lobstertrap/lola
+repo_name: LobsterTrap/lola
+repo_url: https://github.com/LobsterTrap/lola
 edit_uri: edit/main/docs/
 
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,10 +2,10 @@
 site_name: Lola - AI Context Package Manager
 site_description: Write Agent Skills and Contexts once, use everywhere
 site_author: Red Hat
-site_url: https://redhatproductsecurity.github.io/lola/
+site_url: https://lobstertrap.org/lola/
 
-repo_name: RedHatProductSecurity/lola
-repo_url: https://github.com/RedHatProductSecurity/lola
+repo_name: lobstertrap/lola
+repo_url: https://github.com/lobstertrap/lola
 edit_uri: edit/main/docs/
 
 theme:


### PR DESCRIPTION
## Summary

- Updated all GitHub repo URLs from `github.com/RedHatProductSecurity/lola` to `github.com/lobstertrap/lola` across docs, CI config, and MkDocs settings
- Updated GitHub Pages docs URL from `redhatproductsecurity.github.io/lola` to `lobstertrap.org/lola` to reflect the new custom domain
- References to `RedHatProductSecurity/lola-market` are intentionally unchanged — that repo remains in the original org

## Related Issues

N/A

## Test Plan

- [x] Verify all links in the updated docs resolve correctly on `lobstertrap.org/lola`
- [x] Confirm GitHub Pages deploys successfully after merge (Docs workflow)
- [x] Check `.github/ISSUE_TEMPLATE/config.yml` links point to the correct repo

## Checklist

- [x] Tests pass (`pytest`)
- [x] Linting passes (`ruff check src tests`)
- [x] Type checking passes (`ty check`)

## AI Disclosure

AI-assisted with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links and references across all guides to reflect new repository location.
  * Changed documentation website base URL.
  * Updated installation instructions to use new repository URL.

* **Chores**
  * Updated configuration files, issue templates, and contributing guide with new repository references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->