### PR TITLE
fix: bump pymdown-extensions to fix broken code blocks on docs site

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ docs = [
     "mkdocs>=1.6.1",
     "mkdocs-material>=9.0.0",
     "mkdocs-mermaid2-plugin>=1.0.0",
-    "pymdown-extensions>=10.0.0",
+    "pymdown-extensions>=10.21.2",
     "mkdocs-awesome-pages-plugin>=2.9.0",
     "mkdocs-panzoom-plugin>=0.5.2",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ requires-dist = [
     { name = "mkdocs-panzoom-plugin", marker = "extra == 'docs'", specifier = ">=0.5.2" },
     { name = "packaging", specifier = ">=24.0" },
     { name = "pygments", specifier = ">=2.20.0" },
-    { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.0.0" },
+    { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.21.2" },
     { name = "python-frontmatter", specifier = ">=1.1.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "rich", specifier = ">=13.0.0" },
@@ -797,15 +797,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21"
+version = "10.21.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/63/06673d1eb6d8f83c0ea1f677d770e12565fb516928b4109c9e2055656a9e/pymdown_extensions-10.21.tar.gz", hash = "sha256:39f4a020f40773f6b2ff31d2cd2546c2c04d0a6498c31d9c688d2be07e1767d5", size = 853363, upload-time = "2026-02-15T20:44:06.748Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/2c/5b079febdc65e1c3fb2729bf958d18b45be7113828528e8a0b5850dd819a/pymdown_extensions-10.21-py3-none-any.whl", hash = "sha256:91b879f9f864d49794c2d9534372b10150e6141096c3908a455e45ca72ad9d3f", size = 268877, upload-time = "2026-02-15T20:44:05.464Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `pymdown-extensions` from `>=10.0.0` to `>=10.21.2` in docs dependencies
- Version 10.21 had a bug where `pymdownx.superfences` failed to process fenced code blocks, causing ` ```bash ` fences to render as literal text and `#` comments to become H1 headings on the published site
- Affects both https://lobstertrap.org/lola/guides/modules/ and https://lobstertrap.org/lola/concepts/skills-and-modules/

## Before

<img width="777" height="766" alt="SCR-20260427-mvdj" src="https://github.com/user-attachments/assets/7a8852e7-a19d-4374-924d-c48b32cd9cc2" />

## After

<img width="836" height="564" alt="image" src="https://github.com/user-attachments/assets/aad01be1-eaee-4eb8-8344-44935b64d0cb" />


## Test plan
- [x] Verified `pymdownx.superfences` produces correct `<div class="highlight">` output with 10.21.2
- [x] Built docs locally with `uv run mkdocs build` and confirmed code blocks render with proper syntax highlighting
- [x] Confirmed both affected pages now display correctly in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)