### PR TITLE
fix: trigger docs workflow on pyproject.toml and uv.lock changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - docs/**
       - mkdocs.yml
+      - pyproject.toml
+      - uv.lock
       - README.md
       - .github/workflows/docs.yml
 


### PR DESCRIPTION
## Summary
- Adds `pyproject.toml` and `uv.lock` to the docs workflow path filter so dependency updates (like the pymdown-extensions bump in df825f9) trigger a docs rebuild

## Test plan
- [x] Verify the workflow YAML is valid
- [ ] Confirm next push touching `pyproject.toml` triggers the docs workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal documentation build workflow configuration to monitor additional dependency files for changes, ensuring documentation builds trigger when relevant configuration updates occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->