### PR TITLE
fix: correct publish workflow version ordering

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,11 +29,11 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         id: version
         run: |
-          # Get base version from git describe (e.g., 0.4.3.dev17)
+          # Get base version from git describe (e.g., 0.4.3.post15.dev17)
           TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
           TAG="${TAG#v}"
           DISTANCE=$(git rev-list "${TAG:+v}${TAG}..HEAD" --count 2>/dev/null || echo "0")
-          VERSION="${TAG}.dev${DISTANCE}.post${GITHUB_RUN_NUMBER}"
+          VERSION="${TAG}.post${GITHUB_RUN_NUMBER}.dev${DISTANCE}"
           echo "SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}" >> "$GITHUB_ENV"
           echo "Building version: ${VERSION}"
 


### PR DESCRIPTION
## Summary
- reorder workflow_dispatch TestPyPI pretend versions from .devN.postM to .postM.devN
- keep the existing tag distance and GitHub run number inputs unchanged

## Root cause
The manual publish workflow generated versions like 0.4.3.dev37.post15, which current packaging validation rejects as invalid PEP 440 ordering. The valid combined post/dev form is 0.4.3.post15.dev37.

## Validation
- source .venv/bin/activate && pytest
- source .venv/bin/activate && ruff check src tests
- source .venv/bin/activate && ty check
- SETUPTOOLS_SCM_PRETEND_VERSION=0.4.3.post15.dev37 uv build
- pre-commit hooks during commit, including Snyk

## AI disclosure
Assisted-by: OpenAI Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pre-release version numbering format for build artifacts to ensure consistent version string formatting across releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->