### PR TITLE
fix: install OpenCode skills as files instead of managed AGENTS.md sections

### DIFF
--- a/src/lola/targets/opencode.py
+++ b/src/lola/targets/opencode.py
@@ -176,7 +176,7 @@ class OpenCodeTarget(ManagedInstructionsTarget, BaseAssistantTarget):
     supports_agents = True
     INSTRUCTIONS_FILE = "AGENTS.md"
 
-    def get_skill_path(self, project_path: str) -> Path:
+    def get_skill_path(self, project_path: str, scope: str = "project") -> Path:  # noqa: ARG002
         return Path(project_path) / ".opencode" / "skills"
 
     def get_command_path(self, project_path: str, scope: str = "project") -> Path:

--- a/src/lola/targets/opencode.py
+++ b/src/lola/targets/opencode.py
@@ -7,9 +7,12 @@ import re
 from pathlib import Path
 from typing import Any
 
+import shutil
+
+import lola.config as config
 from .base import (
+    BaseAssistantTarget,
     ManagedInstructionsTarget,
-    ManagedSectionTarget,
     _generate_agent_with_frontmatter,
     _generate_passthrough_command,
 )
@@ -160,18 +163,21 @@ def _remove_mcps_from_opencode_file(
 # =============================================================================
 
 
-class OpenCodeTarget(ManagedInstructionsTarget, ManagedSectionTarget):
+class OpenCodeTarget(ManagedInstructionsTarget, BaseAssistantTarget):
     """Target for OpenCode assistant.
 
-    OpenCode uses AGENTS.md for both skills and instructions (similar to Gemini's GEMINI.md approach).
+    OpenCode supports file-based skills in .opencode/skills/<name>/SKILL.md
+    and uses AGENTS.md for module instructions.
 
     Note: OpenCodeTarget does NOT use MCPSupportMixin because it has its own MCP format.
     """
 
     name = "opencode"
     supports_agents = True
-    MANAGED_FILE = "AGENTS.md"
     INSTRUCTIONS_FILE = "AGENTS.md"
+
+    def get_skill_path(self, project_path: str) -> Path:
+        return Path(project_path) / ".opencode" / "skills"
 
     def get_command_path(self, project_path: str, scope: str = "project") -> Path:
         base = Path.home() if scope == "user" else Path(project_path)
@@ -188,6 +194,45 @@ class OpenCodeTarget(ManagedInstructionsTarget, ManagedSectionTarget):
     def get_mcp_path(self, project_path: str, scope: str = "project") -> Path:
         base = Path.home() if scope == "user" else Path(project_path)
         return base / "opencode.json"
+
+    def generate_skill(
+        self,
+        source_path: Path,
+        dest_path: Path,
+        skill_name: str,
+        project_path: str | None = None,  # noqa: ARG002
+    ) -> bool:
+        """Copy skill directory with SKILL.md and supporting files.
+
+        OpenCode uses the Agent Skills standard with SKILL.md files
+        at .opencode/skills/<skill-name>/SKILL.md.
+        """
+        if not source_path.exists():
+            return False
+
+        # Verify SKILL.md exists before creating destination directory
+        skill_file = source_path / config.SKILL_FILE
+        if not skill_file.exists():
+            return False
+
+        skill_dest = dest_path / skill_name
+        skill_dest.mkdir(parents=True, exist_ok=True)
+
+        # Copy SKILL.md
+        shutil.copy2(skill_file, skill_dest / config.SKILL_FILE)
+
+        # Copy supporting files (scripts, references, assets, etc.)
+        for item in source_path.iterdir():
+            if item.name == config.SKILL_FILE:
+                continue
+            dest_item = skill_dest / item.name
+            if item.is_dir():
+                if dest_item.exists():
+                    shutil.rmtree(dest_item)
+                shutil.copytree(item, dest_item)
+            else:
+                shutil.copy2(item, dest_item)
+        return True
 
     def generate_command(
         self,

--- a/tests/test_opencode_target.py
+++ b/tests/test_opencode_target.py
@@ -32,11 +32,11 @@ def test_opencode_mcp_path_user_scope():
     assert path == Path.home() / "opencode.json"
 
 
-def test_opencode_skill_path_user_scope_from_managed_section():
-    """OpenCodeTarget inherits from ManagedSectionTarget which has get_skill_path."""
+def test_opencode_skill_path_user_scope():
+    """OpenCodeTarget uses file-based skills at .opencode/skills/."""
     target = OpenCodeTarget()
-    path = target.get_skill_path("/home/user/project", "user")
-    assert path == Path.home() / "AGENTS.md"
+    path = target.get_skill_path("/home/user/project")
+    assert path == Path("/home/user/project/.opencode/skills")
 
 
 # --- Project scope tests ---
@@ -68,8 +68,8 @@ def test_opencode_mcp_path_project_scope():
 
 def test_opencode_skill_path_project_scope():
     target = OpenCodeTarget()
-    path = target.get_skill_path("/home/user/project", "project")
-    assert path == Path("/home/user/project/AGENTS.md")
+    path = target.get_skill_path("/home/user/project")
+    assert path == Path("/home/user/project/.opencode/skills")
 
 
 # --- Default scope tests (no explicit scope argument) ---
@@ -102,4 +102,4 @@ def test_opencode_mcp_path_default_scope():
 def test_opencode_skill_path_default_scope():
     target = OpenCodeTarget()
     result = target.get_skill_path("/home/user/project")
-    assert result == Path("/home/user/project/AGENTS.md")
+    assert result == Path("/home/user/project/.opencode/skills")

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -4,7 +4,7 @@ This module tests:
 - ClaudeCodeTarget: skill directory copying, command passthrough, agent frontmatter
 - CursorTarget: MDC format conversion, path rewriting, skill removal
 - GeminiTarget: managed section generation, TOML command format
-- OpenCodeTarget: managed section generation, agent frontmatter
+- OpenCodeTarget: file-based skill installation, agent frontmatter
 - Helper functions: path rewriting, skill description extraction
 """
 
@@ -834,9 +834,7 @@ class TestOpenCodeTarget:
         path = target.get_agent_path(str(tmp_path))
         assert path == tmp_path / ".opencode" / "agents"
 
-    def test_generate_skill_copies_skill_md(
-        self, tmp_path: Path, skill_source: Path
-    ):
+    def test_generate_skill_copies_skill_md(self, tmp_path: Path, skill_source: Path):
         """generate_skill should copy SKILL.md to .opencode/skills/<name>/."""
         target = OpenCodeTarget()
         dest_path = tmp_path / ".opencode" / "skills"
@@ -863,9 +861,7 @@ class TestOpenCodeTarget:
         assert (dest_path / "test-skill" / "scripts" / "helper.py").exists()
         assert (dest_path / "test-skill" / "notes.md").exists()
 
-    def test_generate_skill_returns_false_for_missing_skill_md(
-        self, tmp_path: Path
-    ):
+    def test_generate_skill_returns_false_for_missing_skill_md(self, tmp_path: Path):
         """generate_skill should return False when SKILL.md is missing."""
         target = OpenCodeTarget()
         empty_source = tmp_path / "empty-skill"

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -807,21 +807,20 @@ Some text after.
 
 
 class TestOpenCodeTarget:
-    """Tests for OpenCodeTarget (ManagedSectionTarget) implementation."""
+    """Tests for OpenCodeTarget (file-based skills) implementation."""
 
     def test_name_and_attributes(self):
         """Verify target name and capability attributes."""
         target = OpenCodeTarget()
         assert target.name == "opencode"
         assert target.supports_agents is True
-        assert target.uses_managed_section is True
-        assert target.MANAGED_FILE == "AGENTS.md"
+        assert target.uses_managed_section is False
 
     def test_get_skill_path(self, tmp_path: Path):
-        """Skill path should be AGENTS.md file."""
+        """Skill path should be .opencode/skills directory."""
         target = OpenCodeTarget()
         path = target.get_skill_path(str(tmp_path))
-        assert path == tmp_path / "AGENTS.md"
+        assert path == tmp_path / ".opencode" / "skills"
 
     def test_get_command_path(self, tmp_path: Path):
         """Command path should be .opencode/commands."""
@@ -835,20 +834,47 @@ class TestOpenCodeTarget:
         path = target.get_agent_path(str(tmp_path))
         assert path == tmp_path / ".opencode" / "agents"
 
-    def test_generate_skills_batch_creates_agents_md(
+    def test_generate_skill_copies_skill_md(
         self, tmp_path: Path, skill_source: Path
     ):
-        """generate_skills_batch should create AGENTS.md."""
+        """generate_skill should copy SKILL.md to .opencode/skills/<name>/."""
         target = OpenCodeTarget()
-        dest_file = tmp_path / "AGENTS.md"
+        dest_path = tmp_path / ".opencode" / "skills"
 
-        skills = [("test-skill", "Test skill", skill_source)]
-        result = target.generate_skills_batch(dest_file, "mymod", skills, str(tmp_path))
+        result = target.generate_skill(skill_source, dest_path, "test-skill")
 
         assert result is True
-        assert dest_file.exists()
-        content = dest_file.read_text()
-        assert "### mymod" in content
+        skill_file = dest_path / "test-skill" / "SKILL.md"
+        assert skill_file.exists()
+        content = skill_file.read_text()
+        assert "description: Test skill for unit testing" in content
+
+    def test_generate_skill_copies_supporting_files(
+        self, tmp_path: Path, skill_source: Path
+    ):
+        """generate_skill should copy supporting files alongside SKILL.md."""
+        target = OpenCodeTarget()
+        dest_path = tmp_path / ".opencode" / "skills"
+
+        result = target.generate_skill(skill_source, dest_path, "test-skill")
+
+        assert result is True
+        # The fixture already includes scripts/helper.py and notes.md
+        assert (dest_path / "test-skill" / "scripts" / "helper.py").exists()
+        assert (dest_path / "test-skill" / "notes.md").exists()
+
+    def test_generate_skill_returns_false_for_missing_skill_md(
+        self, tmp_path: Path
+    ):
+        """generate_skill should return False when SKILL.md is missing."""
+        target = OpenCodeTarget()
+        empty_source = tmp_path / "empty-skill"
+        empty_source.mkdir()
+        dest_path = tmp_path / ".opencode" / "skills"
+
+        result = target.generate_skill(empty_source, dest_path, "test-skill")
+
+        assert result is False
 
     def test_generate_command_creates_markdown_file(
         self, command_source: Path, dest_path: Path


### PR DESCRIPTION
## Summary

- OpenCode skills now install as files at `.opencode/skills/<name>/SKILL.md` instead of being written as text references into `AGENTS.md`
- Fixes #61

## Problem

OpenCode supports file-based skills at `.opencode/skills/<name>/SKILL.md` (the Agent Skills standard), but `OpenCodeTarget` inherited from `ManagedSectionTarget` which wrote skill references as markdown text into `AGENTS.md`. This meant skills were never actually copied as files, and OpenCode couldn't discover them.

## Changes

**`src/lola/targets/opencode.py`**
- Changed `OpenCodeTarget` to inherit from `BaseAssistantTarget` instead of `ManagedSectionTarget`
- Added `get_skill_path()` returning `.opencode/skills/`
- Added `generate_skill()` that copies `SKILL.md` and supporting files (scripts, references, assets)
- Instructions still use `ManagedInstructionsTarget` for `AGENTS.md` (unchanged)
- No changes to Cursor, Claude Code, or Gemini targets

**`tests/test_targets.py`**
- Updated `TestOpenCodeTarget` assertions from managed-section to file-based behavior
- Added tests for skill file copy, supporting file copy, and missing SKILL.md handling
- All 785 tests pass

## Testing

Verified with a real Lola module containing a skill — after this change, `lola install` correctly places the skill at `.opencode/skills/<name>/SKILL.md` for OpenCode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skills are now installed as per-skill directories under a standardized .opencode/skills location; supporting files and subfolders are copied alongside each skill.
  * Installation checks for a required skill descriptor and fails gracefully if it's missing.

* **Tests**
  * Added/updated tests covering skill path resolution, successful skill installation and asset copying, and descriptor-missing failure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LobsterTrap/lola/pull/106)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->