### PR TITLE
fix: store marketplace modules by catalog name

### DIFF
--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -22,7 +22,7 @@ from lola.exceptions import (
 )
 from lola.models import Installation, InstallationRegistry, Module
 from lola.market.manager import parse_market_ref, MarketplaceRegistry
-from lola.parsers import fetch_module, detect_source_type
+from lola.parsers import fetch_module_as_name, detect_source_type
 from lola.cli.mod import (
     save_source_info,
     load_registered_module,
@@ -131,7 +131,9 @@ def _fetch_from_marketplace(
 
     try:
         source_type = detect_source_type(repository)
-        module_path = fetch_module(repository, MODULES_DIR, content_dirname)
+        module_path = fetch_module_as_name(
+            repository, MODULES_DIR, module_name, content_dirname
+        )
         save_source_info(module_path, repository, source_type, content_dirname)
         console.print(f"[green]Added {module_name}[/green]")
         return module_path, module_dict

--- a/src/lola/cli/sync.py
+++ b/src/lola/cli/sync.py
@@ -11,7 +11,7 @@ from lola.cli.mod import load_registered_module, save_source_info
 from lola.targets import get_registry, TARGETS
 from lola.targets.install import install_to_assistant
 from lola.market.manager import parse_market_ref, MarketplaceRegistry
-from lola.parsers import detect_source_type, fetch_module
+from lola.parsers import detect_source_type, fetch_module, fetch_module_as_name
 from lola.models import Marketplace
 
 console = Console()
@@ -60,7 +60,9 @@ def _fetch_from_marketplace_quiet(
     content_dirname = module_dict.get("path")
 
     source_type = detect_source_type(repository)
-    module_path = fetch_module(repository, MODULES_DIR, content_dirname)
+    module_path = fetch_module_as_name(
+        repository, MODULES_DIR, module_name, content_dirname
+    )
     save_source_info(module_path, repository, source_type, content_dirname)
 
     return module_path, module_dict

--- a/src/lola/parsers.py
+++ b/src/lola/parsers.py
@@ -487,6 +487,59 @@ def fetch_module(
     raise UnsupportedSourceError(source)
 
 
+def move_fetched_module_to_name(
+    module_path: Path, module_name: str, dest_dir: Path | None = None
+) -> Path:
+    """Store a fetched module under an explicit registry module name.
+
+    Source handlers derive the destination directory from the repository or
+    archive name. Marketplace catalogs can intentionally expose that source
+    under a different module name, so marketplace installs need to normalize
+    the fetched directory before saving registry metadata.
+
+    Existing target directories are never overwritten here; callers must decide
+    whether reinstall/update semantics should replace an existing module.
+    """
+    module_name = validate_module_name(module_name)
+    target_dir = dest_dir or module_path.parent
+    target_dir.mkdir(parents=True, exist_ok=True)
+    renamed_path = target_dir / module_name
+    if module_path == renamed_path:
+        return module_path
+
+    if renamed_path.exists():
+        if module_path.exists():
+            shutil.rmtree(module_path)
+        raise FileExistsError(
+            f"Module '{module_name}' already exists at {renamed_path}"
+        )
+
+    return Path(shutil.move(str(module_path), str(renamed_path)))
+
+
+def fetch_module_as_name(
+    source: str,
+    dest_dir: Path,
+    module_name: str,
+    module_content_dirname: Optional[str] = None,
+    ref: Optional[str] = None,
+) -> Path:
+    """Fetch a module and store it under an explicit registry module name.
+
+    The fetch happens in an isolated temporary directory first, so source
+    handlers cannot delete or replace existing modules that happen to share the
+    repository/archive-derived folder name.
+    """
+    module_name = validate_module_name(module_name)
+    final_path = dest_dir / module_name
+    if final_path.exists():
+        raise FileExistsError(f"Module '{module_name}' already exists at {final_path}")
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        module_path = fetch_module(source, Path(tmp_dir), module_content_dirname, ref)
+        return move_fetched_module_to_name(module_path, module_name, dest_dir)
+
+
 def detect_source_type(source: str) -> str:
     """Detect the type of source."""
     for handler in SOURCE_HANDLERS:

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -3,8 +3,8 @@
 import shutil
 from unittest.mock import patch
 
-
 from lola.cli.install import (
+    _fetch_from_marketplace,
     install_cmd,
     uninstall_cmd,
     update_cmd,
@@ -156,6 +156,118 @@ class TestMarketplaceReference:
         assert parse_market_ref("git-tools") is None
         assert parse_market_ref("official/git-tools") is None
         assert parse_market_ref("@official") is None
+
+    def test_fetch_from_marketplace_renames_repository_folder_to_module_name(
+        self, tmp_path
+    ):
+        """Marketplace installs should be stored under the marketplace module name."""
+        modules_dir = tmp_path / ".lola" / "modules"
+        modules_dir.mkdir(parents=True)
+        market_dir = tmp_path / ".lola" / "market"
+        cache_dir = tmp_path / ".lola" / "market" / "cache"
+        market_dir.mkdir(parents=True)
+        cache_dir.mkdir(parents=True)
+
+        source_repo = tmp_path / "anthropics-claude-plugins-official"
+        source_repo.mkdir()
+        skills_dir = source_repo / "skills" / "module"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text("---\ndescription: x\n---\n")
+
+        (market_dir / "demo.yml").write_text(
+            "name: demo\nurl: file:///tmp/demo.yml\nenabled: true\n"
+        )
+        (cache_dir / "demo.yml").write_text(
+            "name: demo\nurl: file:///tmp/demo.yml\nenabled: true\n"
+            "modules:\n"
+            "  - name: claude-md-management\n"
+            "    description: Tools\n"
+            "    version: 1.0.0\n"
+            f"    repository: {source_repo.as_posix()}\n"
+        )
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.MARKET_DIR", market_dir),
+            patch("lola.cli.install.CACHE_DIR", cache_dir),
+            patch("lola.cli.install.save_source_info"),
+        ):
+            module_path, module_dict = _fetch_from_marketplace(
+                "demo", "claude-md-management"
+            )
+
+        assert module_dict["name"] == "claude-md-management"
+        assert module_path.name == "claude-md-management"
+        assert module_path.exists()
+        assert (modules_dir / "claude-md-management").exists()
+        assert not (modules_dir / "anthropics-claude-plugins-official").exists()
+
+    def test_marketplace_install_lists_catalog_name_and_registry_record(
+        self, cli_runner, tmp_path
+    ):
+        """Marketplace installs should list and persist the catalog module name."""
+        modules_dir = tmp_path / ".lola" / "modules"
+        modules_dir.mkdir(parents=True)
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        market_dir = tmp_path / ".lola" / "market"
+        cache_dir = tmp_path / ".lola" / "market" / "cache"
+        market_dir.mkdir(parents=True)
+        cache_dir.mkdir(parents=True)
+        project_path = tmp_path / "project"
+        project_path.mkdir()
+
+        source_repo = tmp_path / "claude-plugins-official"
+        module_content = source_repo / "plugins" / "claude-md-management"
+        skills_dir = module_content / "skills" / "claude-md-improver"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text("---\ndescription: x\n---\n")
+
+        (market_dir / "demo.yml").write_text(
+            "name: demo\nurl: file:///tmp/demo.yml\nenabled: true\n"
+        )
+        (cache_dir / "demo.yml").write_text(
+            "name: demo\nurl: file:///tmp/demo.yml\nenabled: true\n"
+            "modules:\n"
+            "  - name: claude-md-management\n"
+            "    description: Tools\n"
+            "    version: 1.0.0\n"
+            f"    repository: {source_repo.as_posix()}\n"
+            "    path: plugins/claude-md-management\n"
+        )
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.MARKET_DIR", market_dir),
+            patch("lola.cli.install.CACHE_DIR", cache_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch(
+                "lola.cli.install.get_registry",
+                side_effect=lambda: InstallationRegistry(installed_file),
+            ),
+        ):
+            install_result = cli_runner.invoke(
+                install_cmd,
+                [
+                    "@demo/claude-md-management",
+                    "-a",
+                    "claude-code",
+                    str(project_path),
+                ],
+            )
+            list_result = cli_runner.invoke(list_installed_cmd, [])
+
+        assert install_result.exit_code == 0, install_result.output
+        assert list_result.exit_code == 0, list_result.output
+        assert "claude-md-management" in list_result.output
+        assert "claude-plugins-official" not in list_result.output
+
+        registry_records = InstallationRegistry(installed_file).all()
+        assert len(registry_records) == 1
+        assert registry_records[0].module_name == "claude-md-management"
+
+        installed_text = installed_file.read_text()
+        assert "module: claude-md-management" in installed_text
+        assert "module: claude-plugins-official" not in installed_text
 
 
 class TestUninstallCmd:

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -3,7 +3,7 @@
 import pytest
 from unittest.mock import patch
 
-from lola.cli.sync import sync_cmd
+from lola.cli.sync import sync_cmd, _fetch_from_marketplace_quiet
 
 
 @pytest.fixture
@@ -270,6 +270,51 @@ class TestSyncWithVersions:
 
 class TestSyncWithMarketplace:
     """Tests for sync command with marketplace integration."""
+
+    def test_fetch_from_marketplace_quiet_renames_repository_folder_to_module_name(
+        self, tmp_path
+    ):
+        """Sync marketplace fetches should use the marketplace module name."""
+        modules_dir = tmp_path / ".lola" / "modules"
+        modules_dir.mkdir(parents=True)
+        market_dir = tmp_path / ".lola" / "market"
+        cache_dir = tmp_path / ".lola" / "market" / "cache"
+        market_dir.mkdir(parents=True)
+        cache_dir.mkdir(parents=True)
+
+        source_repo = tmp_path / "anthropics-claude-plugins-official"
+        source_repo.mkdir()
+        skills_dir = source_repo / "skills" / "module"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text("---\ndescription: x\n---\n")
+
+        (market_dir / "demo.yml").write_text(
+            "name: demo\nurl: file:///tmp/demo.yml\nenabled: true\n"
+        )
+        (cache_dir / "demo.yml").write_text(
+            "name: demo\nurl: file:///tmp/demo.yml\nenabled: true\n"
+            "modules:\n"
+            "  - name: claude-md-management\n"
+            "    description: Tools\n"
+            "    version: 1.0.0\n"
+            f"    repository: {source_repo.as_posix()}\n"
+        )
+
+        with (
+            patch("lola.cli.sync.MODULES_DIR", modules_dir),
+            patch("lola.cli.sync.MARKET_DIR", market_dir),
+            patch("lola.cli.sync.CACHE_DIR", cache_dir),
+            patch("lola.cli.sync.save_source_info"),
+        ):
+            module_path, module_dict = _fetch_from_marketplace_quiet(
+                "demo", "claude-md-management"
+            )
+
+        assert module_dict["name"] == "claude-md-management"
+        assert module_path.name == "claude-md-management"
+        assert module_path.exists()
+        assert (modules_dir / "claude-md-management").exists()
+        assert not (modules_dir / "anthropics-claude-plugins-official").exists()
 
     def test_sync_searches_marketplace_when_module_not_in_registry(
         self,

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -23,12 +23,80 @@ from lola.parsers import (
     TarUrlSourceHandler,
     FolderSourceHandler,
     fetch_module,
+    fetch_module_as_name,
+    move_fetched_module_to_name,
     detect_source_type,
     save_source_info,
     load_source_info,
     update_module,
     SOURCE_FILE,
 )
+
+
+class TestMoveFetchedModuleToName:
+    """Tests for move_fetched_module_to_name()."""
+
+    def test_renames_fetched_module_to_registry_name(self, tmp_path):
+        """Fetched modules can be stored under an explicit registry name."""
+        fetched = tmp_path / "repository-name"
+        fetched.mkdir()
+        (fetched / "module.txt").write_text("content")
+
+        result = move_fetched_module_to_name(fetched, "registry-name")
+
+        assert result == tmp_path / "registry-name"
+        assert (result / "module.txt").read_text() == "content"
+        assert not fetched.exists()
+
+    def test_does_not_overwrite_existing_registry_name(self, tmp_path):
+        """Existing registry-name modules are preserved on name collisions."""
+        fetched = tmp_path / "repository-name"
+        fetched.mkdir()
+        (fetched / "module.txt").write_text("new content")
+        existing = tmp_path / "registry-name"
+        existing.mkdir()
+        existing_marker = existing / "module.txt"
+        existing_marker.write_text("existing content")
+
+        with pytest.raises(FileExistsError, match="already exists"):
+            move_fetched_module_to_name(fetched, "registry-name")
+
+        assert existing_marker.read_text() == "existing content"
+        assert not fetched.exists()
+
+
+class TestFetchModuleAsName:
+    """Tests for fetch_module_as_name()."""
+
+    def test_fetches_into_explicit_registry_name(self, tmp_path):
+        """Fetched modules are stored under the registry name in the destination."""
+        source = tmp_path / "repository-name"
+        source.mkdir()
+        (source / "module.txt").write_text("content")
+        modules_dir = tmp_path / "modules"
+
+        result = fetch_module_as_name(str(source), modules_dir, "registry-name")
+
+        assert result == modules_dir / "registry-name"
+        assert (result / "module.txt").read_text() == "content"
+        assert not (modules_dir / "repository-name").exists()
+
+    def test_existing_registry_name_fails_before_fetching(self, tmp_path):
+        """A canonical-name collision does not touch repo-derived destinations."""
+        source = tmp_path / "repository-name"
+        source.mkdir()
+        (source / "module.txt").write_text("new content")
+        modules_dir = tmp_path / "modules"
+        existing = modules_dir / "registry-name"
+        existing.mkdir(parents=True)
+        existing_marker = existing / "module.txt"
+        existing_marker.write_text("existing content")
+
+        with pytest.raises(FileExistsError, match="already exists"):
+            fetch_module_as_name(str(source), modules_dir, "registry-name")
+
+        assert existing_marker.read_text() == "existing content"
+        assert not (modules_dir / "repository-name").exists()
 
 
 class TestValidateModuleName:


### PR DESCRIPTION
## Summary
- store marketplace-fetched modules under the marketplace catalog module name instead of the source repository directory name
- share the normalization between `install` and `sync`
- fail safely on name collisions instead of overwriting an existing module directory

Fixes #70

## Validation
- `uv run pytest tests/test_cli_install.py::TestMarketplaceReference::test_fetch_from_marketplace_renames_repository_folder_to_module_name tests/test_cli_install.py::TestMarketplaceReference::test_fetch_from_marketplace_does_not_overwrite_existing_module tests/test_cli_sync.py::TestSyncWithMarketplace::test_fetch_from_marketplace_quiet_renames_repository_folder_to_module_name tests/test_cli_sync.py::TestSyncWithMarketplace::test_fetch_from_marketplace_quiet_does_not_overwrite_existing_module -q`
- `uv run pytest -q` — 812 passed
- `uv run ruff check src tests`
- `uv run ty check`

Note: `uv run basedpyright src` currently reports existing `InquirerPy.inquirer` private-import errors in `src/lola/prompts.py`; I reproduced the same errors on a clean `origin/main` worktree, so they are unrelated to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Marketplace installs and syncs now store modules under their canonical marketplace names for consistent listings and metadata.

* **Bug Fixes**
  * Prevents accidental overwrites by checking for existing modules with the intended canonical name and failing early.

* **Tests**
  * Added tests verifying canonical naming, moved/renamed installations, registry/listing output, and collision handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->