### PR TITLE
docs: add design documents directory under dev-guide

### DIFF
--- a/docs/dev-guide/design/.pages
+++ b/docs/dev-guide/design/.pages
@@ -1,0 +1,3 @@
+title: Design Documents
+nav:
+  - ...

--- a/docs/dev-guide/design/index.md
+++ b/docs/dev-guide/design/index.md
@@ -1,0 +1,7 @@
+# Design Documents
+
+Implementation design documents paired with [Architecture Decision Records](../../adr/README.md). Each ADR captures **what** was decided and **why**; the corresponding design document here describes **how** it will be implemented.
+
+| Design Doc | Paired ADR | Status |
+|------------|-----------|--------|
+| *Coming soon* | | |


### PR DESCRIPTION
## Summary

- Add `docs/dev-guide/design/` directory with index page and `.pages` navigation for mkdocs awesome-pages plugin
- Design documents will pair with Architecture Decision Records (ADRs): ADRs capture what/why, design docs describe how

## Related Issues

Relates to the Lola Go migration and extension platform architecture initiative.

## Test Plan

- [x] `mkdocs serve` renders the new Design Documents section under Development
- [x] Navigation shows "Design Documents" as a nested section

## AI Disclosure

AI-assisted with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Design Documents" section to the developer guide, including an index page that describes the purpose and relationship to architecture decision records.
  * Added navigation configuration for the new section and a placeholder table for listing design documents with paired ADRs and status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LobsterTrap/lola/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->