### PR TITLE
feat: display hooks in lola mod info command

### DIFF
--- a/src/lola/cli/mod.py
+++ b/src/lola/cli/mod.py
@@ -1037,10 +1037,18 @@ def module_info(module_name_or_path: str | None):
     if module.pre_install_hook or module.post_install_hook:
         console.print()
         console.print("[bold]Hooks[/bold]")
-        if module.pre_install_hook:
-            console.print(f"  [dim]pre-install:[/dim] {module.pre_install_hook}")
-        if module.post_install_hook:
-            console.print(f"  [dim]post-install:[/dim] {module.post_install_hook}")
+        for hook_type, hook_path in [
+            ("pre-install", module.pre_install_hook),
+            ("post-install", module.post_install_hook),
+        ]:
+            if not hook_path:
+                continue
+            if (module.content_path / hook_path).exists():
+                console.print(f"  [dim]{hook_type}:[/dim] {hook_path}")
+            else:
+                console.print(
+                    f"  [red]{hook_type}: {hook_path}[/red] [dim](not found)[/dim]"
+                )
 
     # Source info
     source_info = load_source_info(module.path)

--- a/src/lola/cli/mod.py
+++ b/src/lola/cli/mod.py
@@ -1033,6 +1033,15 @@ def module_info(module_name_or_path: str | None):
                     cmd_str += " ..."
                 console.print(f"    [dim]{cmd_str[:60]}[/dim]")
 
+    # Hooks
+    if module.pre_install_hook or module.post_install_hook:
+        console.print()
+        console.print("[bold]Hooks[/bold]")
+        if module.pre_install_hook:
+            console.print(f"  [dim]pre-install:[/dim] {module.pre_install_hook}")
+        if module.post_install_hook:
+            console.print(f"  [dim]post-install:[/dim] {module.post_install_hook}")
+
     # Source info
     source_info = load_source_info(module.path)
     if source_info:

--- a/tests/test_cli_mod.py
+++ b/tests/test_cli_mod.py
@@ -753,6 +753,12 @@ class TestModInfoAdvanced:
             "---\nname: my-skill\ndescription: A skill\n---\n\nContent"
         )
 
+        # Create the actual hook scripts on disk
+        scripts_dir = content_dir / "scripts"
+        scripts_dir.mkdir()
+        (scripts_dir / "setup.sh").write_text("#!/bin/sh\necho setup")
+        (scripts_dir / "verify.sh").write_text("#!/bin/sh\necho verify")
+
         # lola.yaml with both hooks
         (content_dir / "lola.yaml").write_text(
             "hooks:\n  pre-install: scripts/setup.sh\n  post-install: scripts/verify.sh\n"
@@ -767,6 +773,7 @@ class TestModInfoAdvanced:
         assert "scripts/setup.sh" in result.output
         assert "post-install" in result.output
         assert "scripts/verify.sh" in result.output
+        assert "(not found)" not in result.output
 
     def test_info_shows_partial_hooks(self, cli_runner, tmp_path):
         """Show only defined hooks when only one hook is configured."""
@@ -781,6 +788,11 @@ class TestModInfoAdvanced:
             "---\nname: my-skill\ndescription: A skill\n---\n\nContent"
         )
 
+        # Create the hook script on disk
+        scripts_dir = content_dir / "scripts"
+        scripts_dir.mkdir()
+        (scripts_dir / "setup.sh").write_text("#!/bin/sh\necho setup")
+
         # lola.yaml with only pre-install hook
         (content_dir / "lola.yaml").write_text(
             "hooks:\n  pre-install: scripts/setup.sh\n"
@@ -794,6 +806,32 @@ class TestModInfoAdvanced:
         assert "pre-install" in result.output
         assert "scripts/setup.sh" in result.output
         assert "post-install" not in result.output
+
+    def test_info_hooks_not_found_marker(self, cli_runner, tmp_path):
+        """Show (not found) marker when hook script is missing from disk."""
+        module_dir = tmp_path / "missing-hooks-module"
+        module_dir.mkdir()
+        content_dir = module_dir / "module"
+        content_dir.mkdir()
+
+        skills_dir = content_dir / "skills" / "my-skill"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text(
+            "---\nname: my-skill\ndescription: A skill\n---\n\nContent"
+        )
+
+        # lola.yaml references scripts that don't exist on disk
+        (content_dir / "lola.yaml").write_text(
+            "hooks:\n  pre-install: scripts/missing.sh\n"
+        )
+
+        with patch("lola.cli.mod.ensure_lola_dirs"):
+            result = cli_runner.invoke(mod, ["info", str(module_dir)])
+
+        assert result.exit_code == 0
+        assert "Hooks" in result.output
+        assert "scripts/missing.sh" in result.output
+        assert "(not found)" in result.output
 
     def test_info_no_hooks_section_when_absent(self, cli_runner, tmp_path):
         """Omit Hooks section entirely when no hooks are configured."""

--- a/tests/test_cli_mod.py
+++ b/tests/test_cli_mod.py
@@ -739,6 +739,81 @@ class TestModInfoAdvanced:
         assert "My agent description" in result.output
         assert "(not found)" not in result.output
 
+    def test_info_shows_hooks(self, cli_runner, tmp_path):
+        """Show hooks section when lola.yaml defines pre/post-install hooks."""
+        module_dir = tmp_path / "hooked-module"
+        module_dir.mkdir()
+        content_dir = module_dir / "module"
+        content_dir.mkdir()
+
+        # Minimal skill so the module is valid
+        skills_dir = content_dir / "skills" / "my-skill"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text(
+            "---\nname: my-skill\ndescription: A skill\n---\n\nContent"
+        )
+
+        # lola.yaml with both hooks
+        (content_dir / "lola.yaml").write_text(
+            "hooks:\n  pre-install: scripts/setup.sh\n  post-install: scripts/verify.sh\n"
+        )
+
+        with patch("lola.cli.mod.ensure_lola_dirs"):
+            result = cli_runner.invoke(mod, ["info", str(module_dir)])
+
+        assert result.exit_code == 0
+        assert "Hooks" in result.output
+        assert "pre-install" in result.output
+        assert "scripts/setup.sh" in result.output
+        assert "post-install" in result.output
+        assert "scripts/verify.sh" in result.output
+
+    def test_info_shows_partial_hooks(self, cli_runner, tmp_path):
+        """Show only defined hooks when only one hook is configured."""
+        module_dir = tmp_path / "partial-hooks-module"
+        module_dir.mkdir()
+        content_dir = module_dir / "module"
+        content_dir.mkdir()
+
+        skills_dir = content_dir / "skills" / "my-skill"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text(
+            "---\nname: my-skill\ndescription: A skill\n---\n\nContent"
+        )
+
+        # lola.yaml with only pre-install hook
+        (content_dir / "lola.yaml").write_text(
+            "hooks:\n  pre-install: scripts/setup.sh\n"
+        )
+
+        with patch("lola.cli.mod.ensure_lola_dirs"):
+            result = cli_runner.invoke(mod, ["info", str(module_dir)])
+
+        assert result.exit_code == 0
+        assert "Hooks" in result.output
+        assert "pre-install" in result.output
+        assert "scripts/setup.sh" in result.output
+        assert "post-install" not in result.output
+
+    def test_info_no_hooks_section_when_absent(self, cli_runner, tmp_path):
+        """Omit Hooks section entirely when no hooks are configured."""
+        module_dir = tmp_path / "no-hooks-module"
+        module_dir.mkdir()
+        content_dir = module_dir / "module"
+        content_dir.mkdir()
+
+        skills_dir = content_dir / "skills" / "my-skill"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text(
+            "---\nname: my-skill\ndescription: A skill\n---\n\nContent"
+        )
+
+        with patch("lola.cli.mod.ensure_lola_dirs"):
+            result = cli_runner.invoke(mod, ["info", str(module_dir)])
+
+        assert result.exit_code == 0
+        assert "Hooks" not in result.output
+
 
 class TestModUpdate:
     """Tests for mod update command."""


### PR DESCRIPTION
## Summary

Show pre/post-install hooks from lola.yaml in the `lola mod info` output. The Hooks section is only rendered when at least one hook is defined, matching the conditional style used for other sections.


## Related Issues

Closes #40 

## Test Plan

Have a pre/post-install hooks configured and run `lola mod info`.


## Checklist

- [x] Tests pass (`pytest`)
- [x] Linting passes (`ruff check src tests`)
- [x] Type checking passes (`ty check`)

## AI Disclosure

AI-assisted with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `lola mod info` now shows a Hooks section for modules, listing configured pre-install and/or post-install hooks. Appears after MCP Servers and before Source info and Validation issues; missing hook files are marked “(not found)”.

* **Tests**
  * Added tests verifying Hooks rendering when both hooks exist, when only one exists, when a referenced hook is missing (shows not-found marker), and when no hooks are configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->