### PR TITLE
fix: filter cruft and locate module subtree in FolderSourceHandler

### DIFF
--- a/docs/guides/modules.md
+++ b/docs/guides/modules.md
@@ -21,6 +21,11 @@ lola mod add https://github.com/company/monorepo.git --module-content=packages/l
 lola mod add https://github.com/user/flat-repo.git --module-content=/
 ```
 
+When adding from a local folder that is inside a git repository, Lola honors
+the repository's `.gitignore` and skips ignored files. Common development
+directories such as `.git/`, `.venv/`, `node_modules/`, and Lola's own install
+paths are also excluded from the copied module.
+
 ## Managing Modules
 
 ```bash

--- a/src/lola/parsers.py
+++ b/src/lola/parsers.py
@@ -429,7 +429,39 @@ class TarUrlSourceHandler(SourceHandler):
 
 
 class FolderSourceHandler(SourceHandler):
-    """Handler for local folder sources."""
+    """Handler for local folder sources.
+
+    Mirrors the zip/tar handlers: locate the module subtree (SKILL.md or
+    commands/) and copy only that subtree, filtering out generated artifacts
+    (virtualenvs, caches, prior .lola/ install state). When the source is a
+    git repo, .gitignore is honored via ``git ls-files``.
+    """
+
+    # Excluded by directory name regardless of .gitignore presence. Covers
+    # tools that don't ship a useful .gitignore and the case where the source
+    # is not a git repo at all. ``.lola`` matters most: a project that has
+    # been installed-to contains a copy of the registered module, and an
+    # unfiltered re-add would copy that copy into itself.
+    ALWAYS_IGNORE: frozenset[str] = frozenset(
+        {
+            ".git",
+            ".svn",
+            ".hg",
+            ".venv",
+            "venv",
+            ".env",
+            "__pycache__",
+            ".pytest_cache",
+            ".mypy_cache",
+            ".tox",
+            ".ruff_cache",
+            "node_modules",
+            ".lola",
+            ".test-output",
+            ".coverage",
+            ".DS_Store",
+        }
+    )
 
     def can_handle(self, source: str) -> bool:
         path = Path(source)
@@ -443,13 +475,128 @@ class FolderSourceHandler(SourceHandler):
         ref: Optional[str] = None,
     ) -> Path:
         source_path = Path(source).resolve()
-        module_name = validate_module_name(source_path.name)
+        kept = self._git_kept_paths(source_path)
+        # When the caller specifies a content directory (marketplace path,
+        # explicit --module-content), trust them: copy the whole source and
+        # let the downstream Module loader navigate. Otherwise locate the
+        # module subtree by walking for SKILL.md / commands/, like the
+        # zip/tar handlers do.
+        if module_content_dirname:
+            module_root = source_path
+        else:
+            module_root = self._find_module_root(source_path, kept) or source_path
+        module_name = validate_module_name(module_root.name)
 
         final_dir = dest_dir / module_name
+        # shutil.rmtree below would otherwise destroy part of the source if
+        # the destination resolves to a path inside it (LOLA_HOME under cwd,
+        # ``.lola/modules`` inside the source, etc.).
+        if final_dir.resolve().is_relative_to(source_path):
+            raise SourceError(source, f"destination is inside source: {final_dir}")
+
         if final_dir.exists():
             shutil.rmtree(final_dir)
-        shutil.copytree(source_path, final_dir)
+
+        # symlinks=False (default) resolves links and copies their targets,
+        # which preserves modules that share files via symlinks pointing
+        # outside the module subtree. Do not change this.
+        shutil.copytree(
+            module_root,
+            final_dir,
+            ignore=self._make_ignore(source_path, module_root, kept),
+        )
         return final_dir
+
+    def _git_kept_paths(self, source_path: Path) -> Optional[set[Path]]:
+        """Return source-relative paths git considers kept, or None.
+
+        ``None`` means the source is not a git repo (or git is unavailable),
+        in which case callers fall back to ``ALWAYS_IGNORE`` only.
+        """
+        if not (source_path / ".git").exists():
+            return None
+        try:
+            result = subprocess.run(  # nosec B603 B607 - list args, git from PATH is intentional
+                [
+                    "git",
+                    "-C",
+                    str(source_path),
+                    "ls-files",
+                    "--cached",
+                    "--others",
+                    "--exclude-standard",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            return None
+        return {Path(line) for line in result.stdout.splitlines() if line}
+
+    def _find_module_root(
+        self, source_path: Path, kept: Optional[set[Path]]
+    ) -> Optional[Path]:
+        """Locate the module subtree by scanning for SKILL.md or commands/*.md."""
+        candidates = self._candidate_files(source_path, kept)
+        # Prefer SKILL.md
+        for rel in candidates:
+            if rel.name == SKILL_FILE:
+                skill_dir = source_path / rel.parent
+                if skill_dir.parent.name == "skills":
+                    return skill_dir.parent.parent
+                return skill_dir.parent
+        # Fall back to commands/*.md
+        for rel in candidates:
+            if rel.suffix == ".md" and rel.parent.name == "commands":
+                return source_path / rel.parent.parent
+        return None
+
+    def _candidate_files(
+        self, source_path: Path, kept: Optional[set[Path]]
+    ) -> list[Path]:
+        """Source-relative file paths to scan for module markers."""
+        if kept is not None:
+            return sorted(kept)
+        out: list[Path] = []
+        for root, dirs, files in os.walk(source_path):
+            dirs[:] = [d for d in dirs if d not in self.ALWAYS_IGNORE]
+            rel_root = Path(root).relative_to(source_path)
+            out.extend(rel_root / f for f in files)
+        return sorted(out)
+
+    def _make_ignore(
+        self,
+        source_path: Path,
+        module_root: Path,
+        kept: Optional[set[Path]],
+    ):
+        """Return a ``shutil.copytree`` ignore callback for the module subtree."""
+        module_rel = module_root.relative_to(source_path)
+        kept_dirs: set[Path] = (
+            {p for k in kept for p in k.parents} if kept is not None else set()
+        )
+
+        def ignore(dirname: str, files: list[str]) -> list[str]:
+            dir_in_source = module_rel / Path(dirname).relative_to(module_root)
+            ignored: list[str] = []
+            for name in files:
+                if name in self.ALWAYS_IGNORE:
+                    ignored.append(name)
+                    continue
+                if kept is None:
+                    continue
+                rel = dir_in_source / name
+                full_path = Path(dirname) / name
+                # Treat symlinks as regular files, not directories
+                if not full_path.is_symlink() and full_path.is_dir():
+                    if rel not in kept_dirs:
+                        ignored.append(name)
+                elif rel not in kept:
+                    ignored.append(name)
+            return ignored
+
+        return ignore
 
 
 SOURCE_HANDLERS: list[SourceHandler] = [

--- a/src/lola/parsers.py
+++ b/src/lola/parsers.py
@@ -529,8 +529,13 @@ class FolderSourceHandler(SourceHandler):
                 capture_output=True,
                 text=True,
                 check=True,
+                timeout=30,
             )
-        except (subprocess.CalledProcessError, FileNotFoundError):
+        except (
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+            FileNotFoundError,
+        ):
             return None
         return {Path(line) for line in result.stdout.splitlines() if line}
 
@@ -543,6 +548,12 @@ class FolderSourceHandler(SourceHandler):
         for rel in candidates:
             if rel.name == SKILL_FILE:
                 skill_dir = source_path / rel.parent
+                # A bare SKILL.md at the source root has no enclosing module
+                # to point at — returning skill_dir.parent here would walk
+                # outside the source. Skip and let the caller fall back to
+                # source_path.
+                if skill_dir == source_path:
+                    continue
                 if skill_dir.parent.name == "skills":
                     return skill_dir.parent.parent
                 return skill_dir.parent

--- a/src/lola/parsers.py
+++ b/src/lola/parsers.py
@@ -522,6 +522,7 @@ class FolderSourceHandler(SourceHandler):
                     "-C",
                     str(source_path),
                     "ls-files",
+                    "-z",
                     "--cached",
                     "--others",
                     "--exclude-standard",
@@ -537,7 +538,13 @@ class FolderSourceHandler(SourceHandler):
             FileNotFoundError,
         ):
             return None
-        return {Path(line) for line in result.stdout.splitlines() if line}
+        # Drop ALWAYS_IGNORE components even when git tracks them. A committed
+        # ``.lola/modules/<stale>/skills/<x>/SKILL.md`` from a prior install
+        # otherwise wins ``_find_module_root`` over the real module subtree.
+        paths = (Path(path) for path in result.stdout.split("\0") if path)
+        return {
+            p for p in paths if not any(part in self.ALWAYS_IGNORE for part in p.parts)
+        }
 
     def _find_module_root(
         self, source_path: Path, kept: Optional[set[Path]]
@@ -738,9 +745,15 @@ def predict_module_name(source: str) -> Optional[str]:
             module_name = validate_module_name(repo_name)
 
         elif source_type == "folder":
-            # Use folder name (same as FolderSourceHandler)
+            # Mirror FolderSourceHandler.fetch: locate the module subtree so
+            # the predicted name matches what fetch will actually produce.
+            # Otherwise the overwrite check guards the wrong name and a
+            # collision under the real fetched name slips through silently.
             source_path = Path(source).resolve()
-            module_name = validate_module_name(source_path.name)
+            handler = FolderSourceHandler()
+            kept = handler._git_kept_paths(source_path)
+            module_root = handler._find_module_root(source_path, kept) or source_path
+            module_name = validate_module_name(module_root.name)
 
         elif source_type == "zip":
             # Best guess: use zip filename stem

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -549,6 +549,42 @@ class TestFolderSourceHandler:
         with pytest.raises(SourceError, match="inside source"):
             self.handler.fetch(str(source_dir), dest_dir)
 
+    def test_fetch_with_module_content_dirname_skips_subtree_search(self, tmp_path):
+        """Marketplace ``path:`` flow: trust the caller, copy the whole source.
+
+        When ``module_content_dirname`` is set, the handler must not walk for
+        SKILL.md / commands/ — it copies the source as-is so the downstream
+        Module loader can navigate into the named subdirectory. ALWAYS_IGNORE
+        cruft is still filtered.
+        """
+        source_dir = tmp_path / "mymodule"
+        source_dir.mkdir()
+        # Top-level files and a sibling directory the subtree-search would
+        # have stripped if it were active.
+        (source_dir / "README.md").write_text("repo readme")
+        (source_dir / "extras").mkdir()
+        (source_dir / "extras" / "notes.md").write_text("kept")
+        # A nested SKILL.md that subtree-search would otherwise lock onto.
+        nested = source_dir / "packaged" / "skills" / "example"
+        nested.mkdir(parents=True)
+        (nested / "SKILL.md").write_text("---\nname: example\n---\n# Example")
+        # Cruft must still be filtered even on the bypass path.
+        (source_dir / ".venv").mkdir()
+        (source_dir / ".venv" / "junk").write_text("ignored")
+
+        dest_dir = tmp_path / "dest"
+        dest_dir.mkdir()
+
+        result = self.handler.fetch(
+            str(source_dir), dest_dir, module_content_dirname="packaged"
+        )
+
+        assert result.name == "mymodule"
+        assert (result / "README.md").exists()
+        assert (result / "extras" / "notes.md").exists()
+        assert (result / "packaged" / "skills" / "example" / "SKILL.md").exists()
+        assert not (result / ".venv").exists()
+
 
 class TestDetectSourceType:
     """Tests for detect_source_type()."""

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -414,6 +414,141 @@ class TestFolderSourceHandler:
         assert (result / "new.txt").exists()
         assert not (result / "old.txt").exists()
 
+    def test_fetch_excludes_dot_git_directory(self, tmp_path):
+        """Skip .git/ even when source is a working repo."""
+        import subprocess
+
+        source_dir = tmp_path / "mymodule"
+        source_dir.mkdir()
+        (source_dir / "file.txt").write_text("content")
+        subprocess.run(
+            ["git", "init", "-q", str(source_dir)], check=True, capture_output=True
+        )
+
+        dest_dir = tmp_path / "dest"
+        dest_dir.mkdir()
+
+        result = self.handler.fetch(str(source_dir), dest_dir)
+
+        assert (result / "file.txt").exists()
+        assert not (result / ".git").exists()
+
+    def test_fetch_excludes_common_caches(self, tmp_path):
+        """Skip virtualenvs and cache directories on non-git sources."""
+        source_dir = tmp_path / "mymodule"
+        source_dir.mkdir()
+        (source_dir / "file.txt").write_text("content")
+        for cache in (".venv", "__pycache__", ".pytest_cache", "node_modules"):
+            (source_dir / cache).mkdir()
+            (source_dir / cache / "junk").write_text("ignored")
+
+        dest_dir = tmp_path / "dest"
+        dest_dir.mkdir()
+
+        result = self.handler.fetch(str(source_dir), dest_dir)
+
+        assert (result / "file.txt").exists()
+        for cache in (".venv", "__pycache__", ".pytest_cache", "node_modules"):
+            assert not (result / cache).exists()
+
+    def test_fetch_excludes_nested_lola_directory(self, tmp_path):
+        """Skip .lola/ to prevent registry-into-registry recursion."""
+        source_dir = tmp_path / "mymodule"
+        source_dir.mkdir()
+        (source_dir / "file.txt").write_text("content")
+        nested = source_dir / ".lola" / "modules" / "mymodule"
+        nested.mkdir(parents=True)
+        (nested / "stale.txt").write_text("from a previous install")
+
+        dest_dir = tmp_path / "dest"
+        dest_dir.mkdir()
+
+        result = self.handler.fetch(str(source_dir), dest_dir)
+
+        assert (result / "file.txt").exists()
+        assert not (result / ".lola").exists()
+
+    def test_fetch_honors_gitignore_when_source_is_git_repo(self, tmp_path):
+        """Files matching .gitignore are not copied."""
+        import subprocess
+
+        source_dir = tmp_path / "mymodule"
+        source_dir.mkdir()
+        (source_dir / "file.txt").write_text("kept")
+        (source_dir / ".gitignore").write_text("secrets/\nignored.log\n")
+        (source_dir / "ignored.log").write_text("noise")
+        secrets = source_dir / "secrets"
+        secrets.mkdir()
+        (secrets / "key").write_text("super secret")
+        subprocess.run(
+            ["git", "init", "-q", str(source_dir)], check=True, capture_output=True
+        )
+
+        dest_dir = tmp_path / "dest"
+        dest_dir.mkdir()
+
+        result = self.handler.fetch(str(source_dir), dest_dir)
+
+        assert (result / "file.txt").exists()
+        assert not (result / "ignored.log").exists()
+        assert not (result / "secrets").exists()
+
+    def test_fetch_locates_module_subtree(self, tmp_path):
+        """When SKILL.md is under a module/ subtree, copy only that subtree."""
+        source_dir = tmp_path / "mymodule"
+        source_dir.mkdir()
+        # Cruft at the repo root — must not appear in the module copy.
+        (source_dir / "README.md").write_text("repo readme")
+        (source_dir / "tests").mkdir()
+        (source_dir / "tests" / "test_foo.py").write_text("noise")
+        # The actual module content.
+        skill_dir = source_dir / "module" / "skills" / "example"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\nname: example\n---\n# Example")
+
+        dest_dir = tmp_path / "dest"
+        dest_dir.mkdir()
+
+        result = self.handler.fetch(str(source_dir), dest_dir)
+
+        assert result.name == "module"
+        assert (result / "skills" / "example" / "SKILL.md").exists()
+        assert not (result / "tests").exists()
+        assert not (result / "README.md").exists()
+
+    def test_fetch_resolves_symlinks_to_content(self, tmp_path):
+        """Symlinks pointing outside the module subtree resolve to their contents."""
+        source_dir = tmp_path / "mymodule"
+        source_dir.mkdir()
+        shared = source_dir / "shared"
+        shared.mkdir()
+        (shared / "data.md").write_text("shared content")
+        skill_dir = source_dir / "module" / "skills" / "example"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\nname: example\n---\n# Example")
+        (skill_dir / "data.md").symlink_to("../../../shared/data.md")
+
+        dest_dir = tmp_path / "dest"
+        dest_dir.mkdir()
+
+        result = self.handler.fetch(str(source_dir), dest_dir)
+
+        copied = result / "skills" / "example" / "data.md"
+        assert copied.is_file()
+        assert not copied.is_symlink()
+        assert copied.read_text() == "shared content"
+
+    def test_fetch_raises_when_dest_inside_source(self, tmp_path):
+        """Refuse fetches whose destination would be inside the source tree."""
+        source_dir = tmp_path / "mymodule"
+        source_dir.mkdir()
+        (source_dir / "file.txt").write_text("content")
+        dest_dir = source_dir / ".lola" / "modules"
+        dest_dir.mkdir(parents=True)
+
+        with pytest.raises(SourceError, match="inside source"):
+            self.handler.fetch(str(source_dir), dest_dir)
+
 
 class TestDetectSourceType:
     """Tests for detect_source_type()."""

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,5 +1,6 @@
 """Tests for the sources module."""
 
+from pathlib import Path
 import tarfile
 import zipfile
 from unittest.mock import patch, MagicMock
@@ -25,6 +26,7 @@ from lola.parsers import (
     fetch_module,
     fetch_module_as_name,
     move_fetched_module_to_name,
+    predict_module_name,
     detect_source_type,
     save_source_info,
     load_source_info,
@@ -493,6 +495,24 @@ class TestFolderSourceHandler:
         assert not (result / "ignored.log").exists()
         assert not (result / "secrets").exists()
 
+    def test_git_kept_paths_uses_nul_terminated_output(self, tmp_path):
+        """Git output paths are parsed without C-style quoting."""
+        source_dir = tmp_path / "mymodule"
+        (source_dir / ".git").mkdir(parents=True)
+        mock_result = MagicMock(
+            stdout="skills/café/SKILL.md\0commands/weird\nname.md\0\0"
+        )
+
+        with patch("lola.parsers.subprocess.run", return_value=mock_result) as run:
+            kept = self.handler._git_kept_paths(source_dir)
+
+        args = run.call_args.args[0]
+        assert "-z" in args
+        assert kept == {
+            Path("skills/café/SKILL.md"),
+            Path("commands/weird\nname.md"),
+        }
+
     def test_fetch_locates_module_subtree(self, tmp_path):
         """When SKILL.md is under a module/ subtree, copy only that subtree."""
         source_dir = tmp_path / "mymodule"
@@ -515,6 +535,53 @@ class TestFolderSourceHandler:
         assert (result / "skills" / "example" / "SKILL.md").exists()
         assert not (result / "tests").exists()
         assert not (result / "README.md").exists()
+
+    def test_predict_folder_name_matches_discovered_subtree(self, tmp_path):
+        """Folder name prediction matches the actual fetched module name."""
+        source_dir = tmp_path / "repo-name"
+        source_dir.mkdir()
+        skill_dir = source_dir / "module" / "skills" / "example"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\nname: example\n---\n# Example")
+
+        dest_dir = tmp_path / "dest"
+        dest_dir.mkdir()
+
+        predicted_name = predict_module_name(str(source_dir))
+        result = self.handler.fetch(str(source_dir), dest_dir)
+
+        assert result.name == "module"
+        assert predicted_name == result.name
+
+    def test_fetch_ignores_lola_paths_when_finding_git_module_root(self, tmp_path):
+        """Do not let project-local .lola copies win module root discovery."""
+        import subprocess
+
+        source_dir = tmp_path / "project"
+        source_dir.mkdir()
+        skill_dir = source_dir / "skills" / "current"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\nname: current\n---\n# Current")
+
+        stale_skill = (
+            source_dir / ".lola" / "modules" / "stale-module" / "skills" / "stale"
+        )
+        stale_skill.mkdir(parents=True)
+        (stale_skill / "SKILL.md").write_text("---\nname: stale\n---\n# Stale")
+
+        subprocess.run(
+            ["git", "init", "-q", str(source_dir)], check=True, capture_output=True
+        )
+
+        dest_dir = tmp_path / "dest"
+        dest_dir.mkdir()
+
+        result = self.handler.fetch(str(source_dir), dest_dir)
+
+        assert result.name == "project"
+        assert (result / "skills" / "current" / "SKILL.md").exists()
+        assert not (result / "skills" / "stale" / "SKILL.md").exists()
+        assert not (result / ".lola").exists()
 
     def test_fetch_resolves_symlinks_to_content(self, tmp_path):
         """Symlinks pointing outside the module subtree resolve to their contents."""


### PR DESCRIPTION
## Summary

`lola mod add <folder>` previously did `shutil.copytree(source, dest)` with no filter. A working repo (24 GB in a real-world report) shipped into the registry along with `.git/`, `.venv/`, build caches, and any pre-existing `.lola/modules/<name>/` from a prior install — recursive into itself on subsequent runs.

Bring the folder handler in line with zip/tar:

- `_find_module_root` walks for SKILL.md / commands/*.md and copies just that subtree (skipped when the caller already specified `module_content_dirname`, so the marketplace `path:` flow is unchanged).
- `_git_kept_paths` shells out to `git ls-files --cached --others --exclude-standard` when the source is a git repo, honoring `.gitignore`, `.git/info/exclude`, and `core.excludesfile` via git itself.
- `ALWAYS_IGNORE` excludes `.git`, virtualenvs, `__pycache__`, `.lola`, and similar directory names regardless of `.gitignore` state — this is what catches the recursive `.lola/` case and non-git sources.
- New guard rejects fetches where the destination resolves inside the source; this previously triggered a `RecursionError` in `shutil.copytree`.

Symlinks continue to use `shutil.copytree`'s default `symlinks=False`, which resolves links and copies their targets — preserving modules that share files via symlinks pointing outside the module subtree.

## Related Issues

Fixes: #120

## Test Plan

- Follow reproducer steps in #120 and observe lack of issue

## Checklist

- [x] Tests pass (`pytest`)
- [x] Linting passes (`ruff check src tests`)
- [x] Type checking passes (`ty check`)

## AI Disclosure

AI-assisted with Claude Code - Opus 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Folder imports now respect VCS state, skip common junk dirs, and mirror module-root detection used for naming; option to copy a specified content subtree preserved.

* **Bug Fixes**
  * Prevents copying repo metadata or creating destinations inside the source; resolves symlinks by copying target contents.

* **Tests**
  * Added tests for VCS-aware ignores, exclusion rules, subtree detection, name prediction, symlink handling, and safety checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LobsterTrap/lola/pull/121)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->