### PR TITLE
feat: cherry-pick skills/commands/agents/MCPs on install (#119)

### DIFF
--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -203,6 +203,10 @@ class UpdateContext:
     installed_commands: set[str] = field(default_factory=set)
     installed_agents: set[str] = field(default_factory=set)
     installed_mcps: set[str] = field(default_factory=set)
+    installed_skill_sources: dict[str, str] = field(default_factory=dict)
+    installed_command_sources: dict[str, str] = field(default_factory=dict)
+    installed_agent_sources: dict[str, str] = field(default_factory=dict)
+    installed_mcp_sources: dict[str, str] = field(default_factory=dict)
 
 
 def _validate_installation_for_update(inst: Installation) -> tuple[bool, str | None]:
@@ -268,11 +272,17 @@ def _build_update_context(
     current_agents = set(global_module.agents)
     current_mcps = set(global_module.mcps)
 
-    # Find orphaned items (in registry but not in module)
-    orphaned_skills = set(inst.skills) - current_skills
-    orphaned_commands = set(inst.commands) - current_commands
-    orphaned_agents = set(inst.agents) - current_agents
-    orphaned_mcps = set(inst.mcps) - current_mcps
+    # Find orphaned installed names whose upstream source item disappeared.
+    orphaned_skills = _orphaned_installed_items(
+        inst.skills, current_skills, inst.skill_sources
+    )
+    orphaned_commands = _orphaned_installed_items(
+        inst.commands, current_commands, inst.command_sources
+    )
+    orphaned_agents = _orphaned_installed_items(
+        inst.agents, current_agents, inst.agent_sources
+    )
+    orphaned_mcps = _orphaned_installed_items(inst.mcps, current_mcps, inst.mcp_sources)
 
     return UpdateContext(
         inst=inst,
@@ -389,8 +399,26 @@ def _skill_owned_by_other_module(ctx: UpdateContext, skill_name: str) -> str | N
     return None
 
 
+def _orphaned_installed_items(
+    installed_items: list[str],
+    current_source_items: set[str],
+    source_map: dict[str, str],
+) -> set[str]:
+    """Return installed item names whose original source item is gone."""
+    if source_map:
+        return {
+            installed
+            for installed in installed_items
+            if source_map.get(installed, installed) not in current_source_items
+        }
+    return set(installed_items) - current_source_items
+
+
 def _resolve_update_items(
-    ctx: UpdateContext, module_items: list[str], inst_items: list[str]
+    ctx: UpdateContext,
+    module_items: list[str],
+    inst_items: list[str],
+    source_map: dict[str, str],
 ) -> list[str]:
     """Pick which items to regenerate during an update.
 
@@ -399,8 +427,16 @@ def _resolve_update_items(
     """
     if ctx.inst.full_install:
         return list(module_items)
-    locked = set(inst_items)
+    locked = set(source_map.values() if source_map else inst_items)
     return [name for name in module_items if name in locked]
+
+
+def _effective_update_name(source_name: str, source_map: dict[str, str]) -> str | None:
+    """Look up the installed name previously chosen for a source item."""
+    for installed_name, mapped_source in source_map.items():
+        if mapped_source == source_name:
+            return installed_name
+    return None
 
 
 def _update_skills(
@@ -415,7 +451,7 @@ def _update_skills(
         return 0, 0
 
     skills_to_update = _resolve_update_items(
-        ctx, ctx.global_module.skills, ctx.inst.skills
+        ctx, ctx.global_module.skills, ctx.inst.skills, ctx.inst.skill_sources
     )
     if not skills_to_update:
         return 0, 0
@@ -432,6 +468,7 @@ def _update_skills(
                 description = _get_skill_description(source)
                 batch_skills.append((skill, description, source))
                 ctx.installed_skills.add(skill)
+                ctx.installed_skill_sources[skill] = skill
                 skills_ok += 1
                 if verbose:
                     console.print(f"      [green]{skill}[/green]")
@@ -453,8 +490,10 @@ def _update_skills(
             source = _skill_source_dir(ctx.source_module, skill)
 
             # Check if another module owns this skill name
-            skill_name = skill
-            owner = _skill_owned_by_other_module(ctx, skill)
+            skill_name = _effective_update_name(skill, ctx.inst.skill_sources) or skill
+            owner = None
+            if skill_name == skill:
+                owner = _skill_owned_by_other_module(ctx, skill)
             if owner:
                 # Use prefixed name to avoid conflict
                 skill_name = f"{ctx.inst.module_name}_{skill}"
@@ -470,6 +509,7 @@ def _update_skills(
 
             if success:
                 ctx.installed_skills.add(skill_name)
+                ctx.installed_skill_sources[skill_name] = skill
                 skills_ok += 1
                 if verbose and not owner:
                     console.print(f"      [green]{skill_name}[/green]")
@@ -493,7 +533,7 @@ def _update_commands(ctx: UpdateContext, verbose: bool) -> tuple[int, int]:
         return 0, 0
 
     commands_to_update = _resolve_update_items(
-        ctx, ctx.global_module.commands, ctx.inst.commands
+        ctx, ctx.global_module.commands, ctx.inst.commands, ctx.inst.command_sources
     )
     if not commands_to_update:
         return 0, 0
@@ -509,15 +549,19 @@ def _update_commands(ctx: UpdateContext, verbose: bool) -> tuple[int, int]:
 
     for cmd_name in commands_to_update:
         source = commands_dir / f"{cmd_name}.md"
+        effective_cmd = (
+            _effective_update_name(cmd_name, ctx.inst.command_sources) or cmd_name
+        )
         success = ctx.target.generate_command(
-            source, command_dest, cmd_name, ctx.inst.module_name
+            source, command_dest, effective_cmd, ctx.inst.module_name
         )
 
         if success:
-            ctx.installed_commands.add(cmd_name)
+            ctx.installed_commands.add(effective_cmd)
+            ctx.installed_command_sources[effective_cmd] = cmd_name
             commands_ok += 1
             if verbose:
-                console.print(f"      [green]/{cmd_name}[/green]")
+                console.print(f"      [green]/{effective_cmd}[/green]")
         else:
             commands_failed += 1
             if verbose:
@@ -538,7 +582,7 @@ def _update_agents(ctx: UpdateContext, verbose: bool) -> tuple[int, int]:
         return 0, 0
 
     agents_to_update = _resolve_update_items(
-        ctx, ctx.global_module.agents, ctx.inst.agents
+        ctx, ctx.global_module.agents, ctx.inst.agents, ctx.inst.agent_sources
     )
     if not agents_to_update:
         return 0, 0
@@ -556,15 +600,19 @@ def _update_agents(ctx: UpdateContext, verbose: bool) -> tuple[int, int]:
     agents_dir = content_path / "agents"
     for agent_name in agents_to_update:
         source = agents_dir / f"{agent_name}.md"
+        effective_agent = (
+            _effective_update_name(agent_name, ctx.inst.agent_sources) or agent_name
+        )
         success = ctx.target.generate_agent(
-            source, agent_dest, agent_name, ctx.inst.module_name
+            source, agent_dest, effective_agent, ctx.inst.module_name
         )
 
         if success:
-            ctx.installed_agents.add(agent_name)
+            ctx.installed_agents.add(effective_agent)
+            ctx.installed_agent_sources[effective_agent] = agent_name
             agents_ok += 1
             if verbose:
-                console.print(f"      [green]@{agent_name}[/green]")
+                console.print(f"      [green]@{effective_agent}[/green]")
         else:
             agents_failed += 1
             if verbose:
@@ -639,7 +687,9 @@ def _update_mcps(ctx: UpdateContext, verbose: bool) -> tuple[int, int]:
     if not ctx.global_module.mcps:
         return 0, 0
 
-    mcps_to_update = _resolve_update_items(ctx, ctx.global_module.mcps, ctx.inst.mcps)
+    mcps_to_update = _resolve_update_items(
+        ctx, ctx.global_module.mcps, ctx.inst.mcps, ctx.inst.mcp_sources
+    )
     if not mcps_to_update:
         return 0, 0
 
@@ -670,6 +720,7 @@ def _update_mcps(ctx: UpdateContext, verbose: bool) -> tuple[int, int]:
     if ctx.target.generate_mcps(servers, mcp_dest, ctx.inst.module_name):
         for mcp_name in servers.keys():
             ctx.installed_mcps.add(mcp_name)
+            ctx.installed_mcp_sources[mcp_name] = mcp_name
             if verbose:
                 console.print(f"      [green]mcp:{mcp_name}[/green]")
         return len(servers), 0
@@ -1526,16 +1577,27 @@ def update_cmd(module_name: Optional[str], assistant: Optional[str], verbose: bo
                 result = _process_single_installation(ctx, verbose)
 
                 # Cherry-picked installs lock to what we regenerated; full
-                # installs track upstream so new items get picked up.
-                inst.skills = list(ctx.installed_skills)
+                # installs track upstream so new items get picked up. Agents
+                # and MCPs may legitimately be skipped by a target/update path,
+                # so preserve their registry entries when nothing was updated.
                 if inst.full_install:
+                    inst.skills = list(ctx.installed_skills)
                     inst.commands = list(ctx.current_commands)
-                    inst.agents = list(ctx.current_agents)
-                    inst.mcps = list(ctx.current_mcps)
+                    if ctx.installed_agents or not ctx.current_agents:
+                        inst.agents = list(ctx.current_agents)
+                    if ctx.installed_mcps or not ctx.current_mcps:
+                        inst.mcps = list(ctx.current_mcps)
                 else:
+                    inst.skills = list(ctx.installed_skills)
                     inst.commands = list(ctx.installed_commands)
                     inst.agents = list(ctx.installed_agents)
                     inst.mcps = list(ctx.installed_mcps)
+                inst.skill_sources = ctx.installed_skill_sources
+                inst.command_sources = ctx.installed_command_sources
+                if ctx.installed_agents or not ctx.current_agents:
+                    inst.agent_sources = ctx.installed_agent_sources
+                if ctx.installed_mcps or not ctx.current_mcps:
+                    inst.mcp_sources = ctx.installed_mcp_sources
                 inst.has_instructions = result.instructions_ok
                 registry.add(inst)
 

--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -31,6 +31,7 @@ from lola.cli.mod import (
 from lola.prompts import (
     is_interactive,
     select_assistants,
+    select_install_mode,
     select_installations,
     select_module,
     select_module_items,
@@ -427,7 +428,9 @@ def _resolve_update_items(
     """
     if ctx.inst.full_install:
         return list(module_items)
-    locked = set(source_map.values() if source_map else inst_items)
+    locked = {
+        source_map.get(installed_name, installed_name) for installed_name in inst_items
+    }
     return [name for name in module_items if name in locked]
 
 
@@ -935,7 +938,7 @@ def install_cmd(
 
     \b
     Cherry-pick a subset of items:
-        lola install my-module                         # Picker with "All" pre-selected
+        lola install my-module                         # Prompt to install all or choose items
         lola install my-module -y                      # Install everything, skip picker
         lola install my-module --skill pr-review --skill commit
         lola install my-module --skill pr-review,commit --command review
@@ -1098,24 +1101,21 @@ def install_cmd(
         )
         > 1
     ):
-        picked = select_module_items(
-            list(module.skills),
-            list(module.commands),
-            list(module.agents),
-            list(module.mcps),
-        )
-        if picked is None:
+        install_mode = select_install_mode()
+        if install_mode is None:
             console.print("[yellow]Cancelled[/yellow]")
             raise SystemExit(130)
-        # The picker returns subsets of the originals, so equal length implies
-        # equal contents — cheaper than four set comparisons.
-        is_full = (
-            len(picked["skills"]) == len(module.skills)
-            and len(picked["commands"]) == len(module.commands)
-            and len(picked["agents"]) == len(module.agents)
-            and len(picked["mcps"]) == len(module.mcps)
-        )
-        if not is_full:
+
+        if install_mode == "cherry-pick":
+            picked = select_module_items(
+                list(module.skills),
+                list(module.commands),
+                list(module.agents),
+                list(module.mcps),
+            )
+            if picked is None:
+                console.print("[yellow]Cancelled[/yellow]")
+                raise SystemExit(130)
             selected_skills = set(picked["skills"])
             selected_commands = set(picked["commands"])
             selected_agents = set(picked["agents"])
@@ -1582,9 +1582,9 @@ def update_cmd(module_name: Optional[str], assistant: Optional[str], verbose: bo
                 # so preserve their registry entries when nothing was updated.
                 if inst.full_install:
                     inst.skills = list(ctx.installed_skills)
-                    inst.commands = list(ctx.current_commands)
+                    inst.commands = list(ctx.installed_commands)
                     if ctx.installed_agents or not ctx.current_agents:
-                        inst.agents = list(ctx.current_agents)
+                        inst.agents = list(ctx.installed_agents)
                     if ctx.installed_mcps or not ctx.current_mcps:
                         inst.mcps = list(ctx.current_mcps)
                 else:

--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -645,6 +645,14 @@ def _update_instructions(ctx: UpdateContext, verbose: bool) -> bool:
             console.print("      [yellow]- instructions[/yellow] [dim](removed)[/dim]")
         return False
 
+    # Cherry-picked installs lock to the original selection: if instructions
+    # were not installed originally, don't pick them up just because upstream
+    # gained an AGENTS.md.
+    if not ctx.inst.full_install and not ctx.inst.has_instructions:
+        instructions_dest = ctx.target.get_instructions_path(path_context, scope)
+        ctx.target.remove_instructions(instructions_dest, ctx.inst.module_name)
+        return False
+
     instructions_dest = ctx.target.get_instructions_path(path_context, scope)
 
     # Respect --append-context from the original installation
@@ -1102,11 +1110,17 @@ def install_cmd(
         agents: set[str] = set()
         mcps: set[str] = set()
         instructions = False
+
+        def _source_names(installed: list[str], source_map: dict[str, str]) -> set[str]:
+            # Compacted source maps only store renamed items; fall back to the
+            # installed name for identity mappings so they aren't dropped.
+            return {source_map.get(name, name) for name in installed}
+
         for inst in existing:
-            skills.update(inst.skill_sources.values() or inst.skills)
-            commands.update(inst.command_sources.values() or inst.commands)
-            agents.update(inst.agent_sources.values() or inst.agents)
-            mcps.update(inst.mcp_sources.values() or inst.mcps)
+            skills.update(_source_names(inst.skills, inst.skill_sources))
+            commands.update(_source_names(inst.commands, inst.command_sources))
+            agents.update(_source_names(inst.agents, inst.agent_sources))
+            mcps.update(_source_names(inst.mcps, inst.mcp_sources))
             if inst.has_instructions:
                 instructions = True
         return {

--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -33,6 +33,7 @@ from lola.prompts import (
     select_assistants,
     select_installations,
     select_module,
+    select_module_items,
 )
 from lola.targets import (
     AssistantTarget,
@@ -50,6 +51,22 @@ from lola.utils import ensure_lola_dirs, get_local_modules_path
 from lola.cli.utils import handle_lola_error
 
 console = Console()
+
+
+def _expand_csv(values: tuple[str, ...]) -> list[str]:
+    """Expand a click multiple=True tuple, splitting any comma-separated values.
+
+    ``--skill foo,bar --skill baz`` and ``--skill foo --skill bar --skill baz``
+    are both flattened to ``["foo", "bar", "baz"]``. Whitespace and empty
+    entries are dropped.
+    """
+    out: list[str] = []
+    for v in values:
+        for part in v.split(","):
+            part = part.strip()
+            if part:
+                out.append(part)
+    return out
 
 
 def _resolve_install_path(
@@ -183,6 +200,9 @@ class UpdateContext:
     orphaned_agents: set[str] = field(default_factory=set)
     orphaned_mcps: set[str] = field(default_factory=set)
     installed_skills: set[str] = field(default_factory=set)  # Actual installed names
+    installed_commands: set[str] = field(default_factory=set)
+    installed_agents: set[str] = field(default_factory=set)
+    installed_mcps: set[str] = field(default_factory=set)
 
 
 def _validate_installation_for_update(inst: Installation) -> tuple[bool, str | None]:
@@ -369,6 +389,20 @@ def _skill_owned_by_other_module(ctx: UpdateContext, skill_name: str) -> str | N
     return None
 
 
+def _resolve_update_items(
+    ctx: UpdateContext, module_items: list[str], inst_items: list[str]
+) -> list[str]:
+    """Pick which items to regenerate during an update.
+
+    Full installs follow the source module; cherry-picked installs lock to the
+    original selection so newly-upstream items are NOT silently picked up.
+    """
+    if ctx.inst.full_install:
+        return list(module_items)
+    locked = set(inst_items)
+    return [name for name in module_items if name in locked]
+
+
 def _update_skills(
     ctx: UpdateContext, skill_dest: Path, verbose: bool
 ) -> tuple[int, int]:
@@ -380,13 +414,19 @@ def _update_skills(
     if not ctx.global_module.skills:
         return 0, 0
 
+    skills_to_update = _resolve_update_items(
+        ctx, ctx.global_module.skills, ctx.inst.skills
+    )
+    if not skills_to_update:
+        return 0, 0
+
     skills_ok = 0
     skills_failed = 0
 
     if ctx.target.uses_managed_section:
         # Managed section targets: Update entries in GEMINI.md/AGENTS.md
         batch_skills = []
-        for skill in ctx.global_module.skills:
+        for skill in skills_to_update:
             source = _skill_source_dir(ctx.source_module, skill)
             if source.exists():
                 description = _get_skill_description(source)
@@ -409,7 +449,7 @@ def _update_skills(
                 ctx.inst.project_path,
             )
     else:
-        for skill in ctx.global_module.skills:
+        for skill in skills_to_update:
             source = _skill_source_dir(ctx.source_module, skill)
 
             # Check if another module owns this skill name
@@ -452,6 +492,12 @@ def _update_commands(ctx: UpdateContext, verbose: bool) -> tuple[int, int]:
     if not ctx.global_module.commands:
         return 0, 0
 
+    commands_to_update = _resolve_update_items(
+        ctx, ctx.global_module.commands, ctx.inst.commands
+    )
+    if not commands_to_update:
+        return 0, 0
+
     commands_ok = 0
     commands_failed = 0
 
@@ -461,13 +507,14 @@ def _update_commands(ctx: UpdateContext, verbose: bool) -> tuple[int, int]:
     content_path = _get_content_path(ctx.source_module)
     commands_dir = content_path / "commands"
 
-    for cmd_name in ctx.global_module.commands:
+    for cmd_name in commands_to_update:
         source = commands_dir / f"{cmd_name}.md"
         success = ctx.target.generate_command(
             source, command_dest, cmd_name, ctx.inst.module_name
         )
 
         if success:
+            ctx.installed_commands.add(cmd_name)
             commands_ok += 1
             if verbose:
                 console.print(f"      [green]/{cmd_name}[/green]")
@@ -490,6 +537,12 @@ def _update_agents(ctx: UpdateContext, verbose: bool) -> tuple[int, int]:
     if not ctx.global_module.agents or not ctx.target.supports_agents:
         return 0, 0
 
+    agents_to_update = _resolve_update_items(
+        ctx, ctx.global_module.agents, ctx.inst.agents
+    )
+    if not agents_to_update:
+        return 0, 0
+
     path_context = ctx.inst.project_path or ""
     scope = ctx.inst.scope
     agent_dest = ctx.target.get_agent_path(path_context, scope)
@@ -501,13 +554,14 @@ def _update_agents(ctx: UpdateContext, verbose: bool) -> tuple[int, int]:
 
     content_path = _get_content_path(ctx.source_module)
     agents_dir = content_path / "agents"
-    for agent_name in ctx.global_module.agents:
+    for agent_name in agents_to_update:
         source = agents_dir / f"{agent_name}.md"
         success = ctx.target.generate_agent(
             source, agent_dest, agent_name, ctx.inst.module_name
         )
 
         if success:
+            ctx.installed_agents.add(agent_name)
             agents_ok += 1
             if verbose:
                 console.print(f"      [green]@{agent_name}[/green]")
@@ -585,6 +639,10 @@ def _update_mcps(ctx: UpdateContext, verbose: bool) -> tuple[int, int]:
     if not ctx.global_module.mcps:
         return 0, 0
 
+    mcps_to_update = _resolve_update_items(ctx, ctx.global_module.mcps, ctx.inst.mcps)
+    if not mcps_to_update:
+        return 0, 0
+
     path_context = ctx.inst.project_path or ""
     scope = ctx.inst.scope
     mcp_dest = ctx.target.get_mcp_path(path_context, scope)
@@ -595,22 +653,28 @@ def _update_mcps(ctx: UpdateContext, verbose: bool) -> tuple[int, int]:
     content_path = _get_content_path(ctx.source_module)
     mcps_file = content_path / MCPS_FILE
     if not mcps_file.exists():
-        return 0, len(ctx.global_module.mcps)
+        return 0, len(mcps_to_update)
 
     try:
         mcps_data = json.loads(mcps_file.read_text())
         servers = mcps_data.get("mcpServers", {})
     except json.JSONDecodeError:
-        return 0, len(ctx.global_module.mcps)
+        return 0, len(mcps_to_update)
+
+    wanted = set(mcps_to_update)
+    servers = {k: v for k, v in servers.items() if k in wanted}
+    if not servers:
+        return 0, len(mcps_to_update)
 
     # Generate MCPs
     if ctx.target.generate_mcps(servers, mcp_dest, ctx.inst.module_name):
-        if verbose:
-            for mcp_name in servers.keys():
+        for mcp_name in servers.keys():
+            ctx.installed_mcps.add(mcp_name)
+            if verbose:
                 console.print(f"      [green]mcp:{mcp_name}[/green]")
         return len(servers), 0
 
-    return 0, len(ctx.global_module.mcps)
+    return 0, len(mcps_to_update)
 
 
 def _process_single_installation(ctx: UpdateContext, verbose: bool) -> UpdateResult:
@@ -750,6 +814,38 @@ def _format_update_summary(result: UpdateResult) -> str:
     default="project",
     help="Installation scope: project (default) or user",
 )
+@click.option(
+    "--skill",
+    "skill_filters",
+    multiple=True,
+    help="Cherry-pick a skill to install. Repeat or use a comma-separated list. "
+    "Omit to install every skill (or use the interactive picker).",
+)
+@click.option(
+    "--command",
+    "command_filters",
+    multiple=True,
+    help="Cherry-pick a command to install. Repeat or use a comma-separated list.",
+)
+@click.option(
+    "--agent",
+    "agent_filters",
+    multiple=True,
+    help="Cherry-pick an agent to install. Repeat or use a comma-separated list.",
+)
+@click.option(
+    "--mcp",
+    "mcp_filters",
+    multiple=True,
+    help="Cherry-pick an MCP to install. Repeat or use a comma-separated list.",
+)
+@click.option(
+    "-y",
+    "--yes",
+    "yes",
+    is_flag=True,
+    help="Skip the interactive picker and install everything (or just what was passed via --skill/--command/--agent/--mcp).",
+)
 @click.argument("project_path", required=False, default="./")
 def install_cmd(
     module_name: Optional[str],
@@ -761,6 +857,11 @@ def install_cmd(
     append_context: Optional[str],
     workspace: Optional[str],
     scope: str,
+    skill_filters: tuple[str, ...],
+    command_filters: tuple[str, ...],
+    agent_filters: tuple[str, ...],
+    mcp_filters: tuple[str, ...],
+    yes: bool,
     project_path: str,
 ):
     """
@@ -780,6 +881,14 @@ def install_cmd(
         lola install my-module -a openclaw             # Install to ~/.openclaw/workspace/skills/
         lola install my-module -a openclaw --workspace work        # Install to workspace-work
         lola install my-module -a openclaw --workspace /custom/path  # Install to custom path
+
+    \b
+    Cherry-pick a subset of items:
+        lola install my-module                         # Picker with "All" pre-selected
+        lola install my-module -y                      # Install everything, skip picker
+        lola install my-module --skill pr-review --skill commit
+        lola install my-module --skill pr-review,commit --command review
+        lola install my-module --agent reviewer
     """
     project_path = _resolve_install_path(assistant, project_path, workspace)
 
@@ -893,6 +1002,79 @@ def install_cmd(
         )
         return
 
+    # Resolve cherry-pick selection.
+    # Precedence: explicit flags > -y > interactive picker > install everything.
+    skill_list = _expand_csv(skill_filters)
+    command_list = _expand_csv(command_filters)
+    agent_list = _expand_csv(agent_filters)
+    mcp_list = _expand_csv(mcp_filters)
+    flags_used = bool(skill_list or command_list or agent_list or mcp_list)
+
+    selected_skills: set[str] | None = None
+    selected_commands: set[str] | None = None
+    selected_agents: set[str] | None = None
+    selected_mcps: set[str] | None = None
+
+    if flags_used:
+        unknown: list[str] = []
+        for requested, available in (
+            (skill_list, set(module.skills)),
+            (command_list, set(module.commands)),
+            (agent_list, set(module.agents)),
+            (mcp_list, set(module.mcps)),
+        ):
+            unknown.extend(n for n in requested if n not in available)
+        if unknown:
+            console.print(f"[red]Unknown items: {', '.join(unknown)}[/red]")
+            console.print(
+                "[dim]Use 'lola mod info <module>' to see available skills, commands, agents, and MCPs[/dim]"
+            )
+            raise SystemExit(1)
+        # Omitted categories install nothing of that type — passing any flag
+        # is an exact selection across all four.
+        selected_skills = set(skill_list)
+        selected_commands = set(command_list)
+        selected_agents = set(agent_list)
+        selected_mcps = set(mcp_list)
+    elif (
+        not yes
+        and is_interactive()
+        and (
+            len(module.skills)
+            + len(module.commands)
+            + len(module.agents)
+            + len(module.mcps)
+        )
+        > 1
+    ):
+        picked = select_module_items(
+            list(module.skills),
+            list(module.commands),
+            list(module.agents),
+            list(module.mcps),
+        )
+        if picked is None:
+            console.print("[yellow]Cancelled[/yellow]")
+            raise SystemExit(130)
+        # The picker returns subsets of the originals, so equal length implies
+        # equal contents — cheaper than four set comparisons.
+        is_full = (
+            len(picked["skills"]) == len(module.skills)
+            and len(picked["commands"]) == len(module.commands)
+            and len(picked["agents"]) == len(module.agents)
+            and len(picked["mcps"]) == len(module.mcps)
+        )
+        if not is_full:
+            selected_skills = set(picked["skills"])
+            selected_commands = set(picked["commands"])
+            selected_agents = set(picked["agents"])
+            selected_mcps = set(picked["mcps"])
+            if not (
+                selected_skills or selected_commands or selected_agents or selected_mcps
+            ):
+                console.print("[yellow]Nothing selected. Cancelled.[/yellow]")
+                raise SystemExit(130)
+
     # Get registry
     registry = get_registry()
 
@@ -937,6 +1119,10 @@ def install_cmd(
             effective_pre_install,
             effective_post_install,
             append_context,
+            selected_skills=selected_skills,
+            selected_commands=selected_commands,
+            selected_agents=selected_agents,
+            selected_mcps=selected_mcps,
         )
 
     # Update installation records with version from marketplace metadata
@@ -1339,11 +1525,17 @@ def update_cmd(module_name: Optional[str], assistant: Optional[str], verbose: bo
                 # Process the installation update
                 result = _process_single_installation(ctx, verbose)
 
-                # Update the registry with actual installed skills (may include prefixed names)
+                # Cherry-picked installs lock to what we regenerated; full
+                # installs track upstream so new items get picked up.
                 inst.skills = list(ctx.installed_skills)
-                inst.commands = list(ctx.current_commands)
-                inst.agents = list(ctx.current_agents)
-                inst.mcps = list(ctx.current_mcps)
+                if inst.full_install:
+                    inst.commands = list(ctx.current_commands)
+                    inst.agents = list(ctx.current_agents)
+                    inst.mcps = list(ctx.current_mcps)
+                else:
+                    inst.commands = list(ctx.installed_commands)
+                    inst.agents = list(ctx.installed_agents)
+                    inst.mcps = list(ctx.installed_mcps)
                 inst.has_instructions = result.instructions_ok
                 registry.add(inst)
 

--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -894,6 +894,14 @@ def _format_update_summary(result: UpdateResult) -> str:
     help="Cherry-pick an MCP to install. Repeat or use a comma-separated list.",
 )
 @click.option(
+    "--instructions/--no-instructions",
+    "instructions_flag",
+    default=None,
+    help="When cherry-picking with --skill/--command/--agent/--mcp, also install "
+    "the module's AGENTS.md instructions. Without this flag, cherry-pick "
+    "modes skip instructions.",
+)
+@click.option(
     "-y",
     "--yes",
     "yes",
@@ -915,6 +923,7 @@ def install_cmd(
     command_filters: tuple[str, ...],
     agent_filters: tuple[str, ...],
     mcp_filters: tuple[str, ...],
+    instructions_flag: Optional[bool],
     yes: bool,
     project_path: str,
 ):
@@ -943,6 +952,7 @@ def install_cmd(
         lola install my-module --skill pr-review --skill commit
         lola install my-module --skill pr-review,commit --command review
         lola install my-module --agent reviewer
+        lola install my-module --skill pr-review --instructions
     """
     project_path = _resolve_install_path(assistant, project_path, workspace)
 
@@ -1062,12 +1072,50 @@ def install_cmd(
     command_list = _expand_csv(command_filters)
     agent_list = _expand_csv(agent_filters)
     mcp_list = _expand_csv(mcp_filters)
-    flags_used = bool(skill_list or command_list or agent_list or mcp_list)
+    flags_used = bool(
+        skill_list
+        or command_list
+        or agent_list
+        or mcp_list
+        or instructions_flag is not None
+    )
 
     selected_skills: set[str] | None = None
     selected_commands: set[str] | None = None
     selected_agents: set[str] | None = None
     selected_mcps: set[str] | None = None
+    selected_instructions: bool | None = None
+
+    # Build `current` for the picker: union of source-name items already
+    # installed for this module at the same scope/project_path (across any
+    # assistant). Used to annotate (installed)/(new) and pre-select.
+    def _current_for_picker() -> dict[str, list[str]] | None:
+        existing = [
+            inst
+            for inst in get_registry().find(module.name)
+            if inst.scope == scope and inst.project_path == install_project_path
+        ]
+        if not existing:
+            return None
+        skills: set[str] = set()
+        commands: set[str] = set()
+        agents: set[str] = set()
+        mcps: set[str] = set()
+        instructions = False
+        for inst in existing:
+            skills.update(inst.skill_sources.values() or inst.skills)
+            commands.update(inst.command_sources.values() or inst.commands)
+            agents.update(inst.agent_sources.values() or inst.agents)
+            mcps.update(inst.mcp_sources.values() or inst.mcps)
+            if inst.has_instructions:
+                instructions = True
+        return {
+            "skills": sorted(skills),
+            "commands": sorted(commands),
+            "agents": sorted(agents),
+            "mcps": sorted(mcps),
+            "instructions": ["yes"] if instructions else [],
+        }
 
     if flags_used:
         unknown: list[str] = []
@@ -1090,6 +1138,7 @@ def install_cmd(
         selected_commands = set(command_list)
         selected_agents = set(agent_list)
         selected_mcps = set(mcp_list)
+        selected_instructions = bool(instructions_flag)
     elif (
         not yes
         and is_interactive()
@@ -1098,6 +1147,7 @@ def install_cmd(
             + len(module.commands)
             + len(module.agents)
             + len(module.mcps)
+            + (1 if module.has_instructions else 0)
         )
         > 1
     ):
@@ -1112,6 +1162,8 @@ def install_cmd(
                 list(module.commands),
                 list(module.agents),
                 list(module.mcps),
+                current=_current_for_picker(),
+                has_instructions=module.has_instructions,
             )
             if picked is None:
                 console.print("[yellow]Cancelled[/yellow]")
@@ -1120,8 +1172,13 @@ def install_cmd(
             selected_commands = set(picked["commands"])
             selected_agents = set(picked["agents"])
             selected_mcps = set(picked["mcps"])
+            selected_instructions = bool(picked["instructions"])
             if not (
-                selected_skills or selected_commands or selected_agents or selected_mcps
+                selected_skills
+                or selected_commands
+                or selected_agents
+                or selected_mcps
+                or selected_instructions
             ):
                 console.print("[yellow]Nothing selected. Cancelled.[/yellow]")
                 raise SystemExit(130)
@@ -1174,6 +1231,7 @@ def install_cmd(
             selected_commands=selected_commands,
             selected_agents=selected_agents,
             selected_mcps=selected_mcps,
+            selected_instructions=selected_instructions,
         )
 
     # Update installation records with version from marketplace metadata

--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -20,7 +20,13 @@ from lola.exceptions import (
     PathNotFoundError,
     ValidationError,
 )
-from lola.models import Installation, InstallationRegistry, Module
+from lola.models import (
+    Installation,
+    InstallationKey,
+    InstallationRegistry,
+    Module,
+    RemovalPlan,
+)
 from lola.market.manager import parse_market_ref, MarketplaceRegistry
 from lola.parsers import fetch_module_as_name, detect_source_type
 from lola.cli.mod import (
@@ -47,11 +53,31 @@ from lola.targets import (
     get_registry,
     get_target,
     install_to_assistant,
+    uninstall_assistant_outputs,
 )
-from lola.utils import ensure_lola_dirs, get_local_modules_path
+from lola.utils import ensure_lola_dirs, get_local_modules_path  # noqa: F401
 from lola.cli.utils import handle_lola_error
 
 console = Console()
+
+
+def _apply_cache_removal_plan(plan: RemovalPlan, verbose: bool) -> int:
+    """Remove cache paths selected by the registry."""
+    removed = 0
+    for cache_path in plan.cache_paths_to_remove:
+        if cache_path.is_symlink():
+            cache_path.unlink()
+            removed += 1
+            if verbose:
+                console.print(f"  [green]Removed cache symlink {cache_path}[/green]")
+        elif cache_path.exists():
+            shutil.rmtree(cache_path)
+            removed += 1
+            if verbose:
+                console.print(f"  [green]Removed cache {cache_path}[/green]")
+        elif verbose:
+            console.print(f"  [dim]Nothing to remove at {cache_path}[/dim]")
+    return removed
 
 
 def _expand_csv(values: tuple[str, ...]) -> list[str]:
@@ -255,17 +281,17 @@ def _build_update_context(
     if not global_module:
         return None
 
-    # For user scope, use current directory for local_modules symlink
-    # For project scope, use the installation's project_path
-    if inst.scope == "user":
-        local_modules = get_local_modules_path(str(Path.cwd()))
-    else:
-        local_modules = get_local_modules_path(inst.project_path)
-
     target = get_target(inst.assistant)
 
-    # Refresh the local copy from global module
-    source_module = copy_module_to_local(global_module, local_modules)
+    cache_path = registry.cache_for(inst.module_name, inst.scope, inst.project_path)
+    if cache_path is None:
+        # Legacy user-scope records from before cache tracking have no safe
+        # local cache path. Update assistant outputs from the registered module
+        # without creating a new cwd-dependent cache guess.
+        source_module = global_module.path
+    else:
+        # Refresh the recorded local copy from the global module.
+        source_module = copy_module_to_local(global_module, cache_path.parent)
 
     # Compute current skills (unprefixed), commands, agents, and mcps from the module
     current_skills = set(global_module.skills)
@@ -997,15 +1023,13 @@ def install_cmd(
     # For user scope, set project_path to None for Installation record
     if scope == "user":
         install_project_path = None
-        # Still need current directory for symlink creation
-        current_dir = str(Path.cwd().resolve())
-        local_modules = get_local_modules_path(current_dir)
+        current_user_context = str(Path.cwd().resolve())
     else:
         # Project scope: validate and resolve project path
         install_project_path = str(Path(project_path).resolve())
         if not Path(install_project_path).exists():
             handle_lola_error(PathNotFoundError(install_project_path, "Project path"))
-        local_modules = get_local_modules_path(install_project_path)
+        current_user_context = None
 
     # Default to global registry
     module_path = MODULES_DIR / module_name
@@ -1073,6 +1097,21 @@ def install_cmd(
             f"[yellow]Module '{module_name}' has no skills, commands, agents, MCPs, or instructions defined[/yellow]"
         )
         return
+
+    # Get registry and resolve the cache path. Existing cache records win,
+    # especially for user-scope installs where the install cwd may differ
+    # from future update/uninstall cwd.
+    registry = get_registry()
+    cache_path = registry.cache_for(
+        module_name,
+        scope,
+        install_project_path,
+        current_user_context=current_user_context,
+    )
+    if cache_path is None:
+        console.print(f"[red]No local cache path available for '{module_name}'[/red]")
+        raise SystemExit(1)
+    local_modules = cache_path.parent
 
     # Resolve cherry-pick selection.
     # Precedence: explicit flags > -y > interactive picker > install everything.
@@ -1197,9 +1236,6 @@ def install_cmd(
                 console.print("[yellow]Nothing selected. Cancelled.[/yellow]")
                 raise SystemExit(130)
 
-    # Get registry
-    registry = get_registry()
-
     # Determine which assistants to install to
     if assistant:
         assistants_to_install = [assistant]
@@ -1260,7 +1296,7 @@ def install_cmd(
                     and inst.project_path == install_project_path
                 ):
                     inst.version = version
-                    registry.add(inst)  # Update the record
+                    registry.upsert_installation(inst)  # Update the record
 
     console.print()
     console.print(
@@ -1438,113 +1474,15 @@ def uninstall_cmd(
                 console.print("[yellow]Cancelled[/yellow]")
                 return
 
-    # Uninstall each
+    # Remove assistant outputs first, then update registry/cache ownership in
+    # one pass so shared cache copies are only deleted after the last reference.
     removed_count = 0
     for inst in installations:
-        target = get_target(inst.assistant)
+        removed_count += uninstall_assistant_outputs(inst, verbose)
 
-        # Get scope-aware paths for removal
-        path_context = inst.project_path or ""
-        inst_scope = inst.scope
-
-        # Remove skill files
-        if inst.skills:
-            skill_dest = target.get_skill_path(path_context, inst_scope)
-
-            if target.uses_managed_section:
-                # Managed section targets: remove module section from GEMINI.md/AGENTS.md
-                if target.remove_skill(skill_dest, module_name):
-                    removed_count += 1
-                    if verbose:
-                        console.print(
-                            f"  [green]Removed skills from {skill_dest}[/green]"
-                        )
-            else:
-                for skill in inst.skills:
-                    if target.remove_skill(skill_dest, skill):
-                        removed_count += 1
-                        if verbose:
-                            console.print(f"  [green]Removed {skill}[/green]")
-
-        # Remove command files
-        if inst.commands:
-            command_dest = target.get_command_path(path_context, inst_scope)
-
-            for cmd_name in inst.commands:
-                if target.remove_command(command_dest, cmd_name, module_name):
-                    removed_count += 1
-                    if verbose:
-                        filename = target.get_command_filename(module_name, cmd_name)
-                        console.print(
-                            f"  [green]Removed {command_dest / filename}[/green]"
-                        )
-
-        # Remove agent files
-        if inst.agents:
-            agent_dest = target.get_agent_path(path_context, inst_scope)
-
-            if agent_dest:
-                for agent_name in inst.agents:
-                    if target.remove_agent(agent_dest, agent_name, module_name):
-                        removed_count += 1
-                        if verbose:
-                            filename = target.get_agent_filename(
-                                module_name, agent_name
-                            )
-                            console.print(
-                                f"  [green]Removed {agent_dest / filename}[/green]"
-                            )
-
-        # Remove instructions
-        if inst.has_instructions:
-            instructions_dest = target.get_instructions_path(path_context, inst_scope)
-            if target.remove_instructions(instructions_dest, module_name):
-                removed_count += 1
-                if verbose:
-                    console.print(
-                        f"  [green]Removed instructions from {instructions_dest}[/green]"
-                    )
-
-        # Remove MCP servers
-        if inst.mcps:
-            mcp_dest = target.get_mcp_path(path_context, inst_scope)
-            if mcp_dest and target.remove_mcps(mcp_dest, module_name, list(inst.mcps)):
-                removed_count += len(inst.mcps)
-                if verbose:
-                    console.print(f"  [green]Removed MCPs from {mcp_dest}[/green]")
-
-        # Also remove the project-local module copy
-        if inst.scope == "project" and inst.project_path:
-            local_modules = get_local_modules_path(inst.project_path)
-            source_module = local_modules / module_name
-            if source_module.is_symlink():
-                source_module.unlink()
-                removed_count += 1
-                if verbose:
-                    console.print(f"  [green]Removed symlink {source_module}[/green]")
-            elif source_module.exists():
-                # Handle legacy copies
-                shutil.rmtree(source_module)
-                removed_count += 1
-                if verbose:
-                    console.print(f"  [green]Removed {source_module}[/green]")
-        elif inst.scope == "user":
-            # For user scope, use current directory for symlink
-            local_modules = get_local_modules_path(str(Path.cwd()))
-            source_module = local_modules / module_name
-            if source_module.is_symlink():
-                source_module.unlink()
-                removed_count += 1
-                if verbose:
-                    console.print(f"  [green]Removed symlink {source_module}[/green]")
-
-        # Remove from registry
-        registry.remove(
-            module_name,
-            assistant=inst.assistant,
-            scope=inst.scope,
-            project_path=inst.project_path,
-        )
+    keys = [InstallationKey.from_installation(inst) for inst in installations]
+    plan = registry.remove_installations(keys)
+    removed_count += _apply_cache_removal_plan(plan, verbose)
 
     console.print(
         f"[green]Uninstalled from {len(installations)} installation{'s' if len(installations) != 1 else ''}[/green]"
@@ -1671,7 +1609,7 @@ def update_cmd(module_name: Optional[str], assistant: Optional[str], verbose: bo
                 if ctx.installed_mcps or not ctx.current_mcps:
                     inst.mcp_sources = ctx.installed_mcp_sources
                 inst.has_instructions = result.instructions_ok
-                registry.add(inst)
+                registry.upsert_installation(inst)
 
                 # Print summary line for this installation
                 summary = _format_update_summary(result)

--- a/src/lola/cli/mod.py
+++ b/src/lola/cli/mod.py
@@ -22,8 +22,8 @@ from lola.exceptions import (
     SourceError,
     UnsupportedSourceError,
 )
-from lola.models import Module, InstallationRegistry
-from lola.targets import get_target
+from lola.models import Module, InstallationRegistry, RemovalPlan
+from lola.targets import uninstall_assistant_outputs
 from lola.parsers import (
     fetch_module,
     detect_source_type,
@@ -32,11 +32,28 @@ from lola.parsers import (
     update_module,
     validate_module_name,
 )
-from lola.utils import ensure_lola_dirs, get_local_modules_path
+from lola.utils import ensure_lola_dirs
 from lola.cli.utils import handle_lola_error
 from lola.prompts import is_interactive, select_module
 
 console = Console()
+
+
+def _apply_cache_removal_plan(plan: RemovalPlan, verbose: bool = False) -> int:
+    """Remove cache paths selected by the registry."""
+    removed = 0
+    for cache_path in plan.cache_paths_to_remove:
+        if cache_path.is_symlink():
+            cache_path.unlink()
+            removed += 1
+            if verbose:
+                console.print(f"  [dim]Removed cache symlink: {cache_path}[/dim]")
+        elif cache_path.exists():
+            shutil.rmtree(cache_path)
+            removed += 1
+            if verbose:
+                console.print(f"  [dim]Removed cache: {cache_path}[/dim]")
+    return removed
 
 
 def load_registered_module(module_path: Path) -> Optional[Module]:
@@ -785,39 +802,13 @@ def remove_module(module_name: str | None, force: bool):
             console.print("[yellow]Cancelled[/yellow]")
             return
 
-    # Uninstall from all locations
+    # Uninstall assistant outputs from all locations. Cache cleanup is decided
+    # by the registry after every module installation record has been removed.
     for inst in installations:
-        if not inst.project_path:
-            continue
+        uninstall_assistant_outputs(inst, verbose=True)
 
-        target = get_target(inst.assistant)
-        skill_dest = target.get_skill_path(inst.project_path)
-
-        # Remove generated skill files
-        if target.uses_managed_section:
-            # Remove module section from managed file (e.g., GEMINI.md, AGENTS.md)
-            if target.remove_skill(skill_dest, module_name):
-                console.print(f"  [dim]Removed from: {skill_dest}[/dim]")
-        else:
-            for skill in inst.skills:
-                if target.remove_skill(skill_dest, skill):
-                    console.print(f"  [dim]Removed: {skill}[/dim]")
-
-        # Remove source files from project .lola/modules/ if applicable
-        if inst.project_path:
-            local_modules = get_local_modules_path(inst.project_path)
-            source_module = local_modules / module_name
-            if source_module.exists():
-                shutil.rmtree(source_module)
-                console.print(f"  [dim]Removed source: {source_module}[/dim]")
-
-        # Remove from registry
-        registry.remove(
-            module_name,
-            assistant=inst.assistant,
-            scope=inst.scope,
-            project_path=inst.project_path,
-        )
+    removal_plan = registry.remove_module(module_name)
+    _apply_cache_removal_plan(removal_plan, verbose=True)
 
     # Remove from global registry
     shutil.rmtree(module_path)

--- a/src/lola/models.py
+++ b/src/lola/models.py
@@ -536,6 +536,103 @@ class Marketplace:
         }
 
 
+@dataclass(frozen=True)
+class ModuleCacheKey:
+    """Stable identity for a local module cache copy."""
+
+    module_name: str
+    scope: str
+    project_path: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for YAML serialization."""
+        return {
+            "module": self.module_name,
+            "scope": self.scope,
+            "project_path": self.project_path,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ModuleCacheKey":
+        """Create from dictionary."""
+        return cls(
+            module_name=data.get("module", ""),
+            scope=data.get("scope", "project"),
+            project_path=data.get("project_path"),
+        )
+
+
+@dataclass(frozen=True)
+class InstallationKey:
+    """Stable identity for one assistant installation."""
+
+    module_name: str
+    assistant: str
+    scope: str
+    project_path: Optional[str] = None
+
+    @classmethod
+    def from_installation(cls, inst: "Installation") -> "InstallationKey":
+        """Build a key from an installation record."""
+        return cls(
+            module_name=inst.module_name,
+            assistant=inst.assistant,
+            scope=inst.scope,
+            project_path=inst.project_path,
+        )
+
+
+@dataclass
+class ModuleCache:
+    """Represents a local cache copy of a registered module."""
+
+    module_name: str
+    scope: str
+    path: str
+    project_path: Optional[str] = None
+    source: Optional[str] = None
+
+    @property
+    def key(self) -> ModuleCacheKey:
+        """Return this cache's stable key."""
+        return ModuleCacheKey(
+            module_name=self.module_name,
+            scope=self.scope,
+            project_path=self.project_path,
+        )
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for YAML serialization."""
+        result = {
+            "module": self.module_name,
+            "scope": self.scope,
+            "project_path": self.project_path,
+            "path": self.path,
+        }
+        if self.source:
+            result["source"] = self.source
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ModuleCache":
+        """Create from dictionary."""
+        return cls(
+            module_name=data.get("module", ""),
+            scope=data.get("scope", "project"),
+            project_path=data.get("project_path"),
+            path=data.get("path", ""),
+            source=data.get("source"),
+        )
+
+
+@dataclass
+class RemovalPlan:
+    """Registry removal result, including safe cache paths to clean up."""
+
+    removed_installations: list["Installation"] = field(default_factory=list)
+    cache_paths_to_remove: list[Path] = field(default_factory=list)
+
+
 @dataclass
 class Installation:
     """Represents an installed module."""
@@ -556,6 +653,9 @@ class Installation:
     has_instructions: bool = False
     append_context: Optional[str] = None
     full_install: bool = True
+    cache_key: Optional[ModuleCacheKey] = None
+    # Legacy v1 field. New registry writes use module_caches/cache_key instead.
+    user_symlink_dir: Optional[str] = None
 
     def to_dict(self) -> dict:
         """Convert to dictionary for YAML serialization."""
@@ -604,11 +704,18 @@ class Installation:
         # Only emit full_install when False to keep existing YAML clean
         if not self.full_install:
             result["full_install"] = False
+        if self.cache_key:
+            result["cache_key"] = self.cache_key.to_dict()
+        if self.user_symlink_dir and self.cache_key is None:
+            result["user_symlink_dir"] = self.user_symlink_dir
         return result
 
     @classmethod
     def from_dict(cls, data: dict) -> "Installation":
         """Create from dictionary."""
+        cache_key = None
+        if data.get("cache_key"):
+            cache_key = ModuleCacheKey.from_dict(data["cache_key"])
         return cls(
             module_name=data.get("module", ""),
             assistant=data.get("assistant", ""),
@@ -626,6 +733,8 @@ class Installation:
             has_instructions=data.get("has_instructions", False),
             append_context=data.get("append_context"),
             full_install=data.get("full_install", True),
+            cache_key=cache_key,
+            user_symlink_dir=data.get("user_symlink_dir"),
         )
 
 
@@ -635,20 +744,79 @@ class InstallationRegistry:
     def __init__(self, registry_path: Path):
         self.path = registry_path
         self._installations: list[Installation] = []
+        self._module_caches: list[ModuleCache] = []
         self._load()
 
     def _load(self):
         """Load installations from file."""
         if not self.path.exists():
             self._installations = []
+            self._module_caches = []
             return
 
         with open(self.path, "r") as f:
             data = yaml.safe_load(f) or {}
 
+        version = str(data.get("version", "1.0"))
+        if version == "2.0" or "module_caches" in data:
+            self._load_v2(data)
+        else:
+            self._load_v1(data)
+
+    def _load_v2(self, data: dict) -> None:
+        """Load v2 registry data."""
+        self._module_caches = [
+            cache
+            for cache in (
+                ModuleCache.from_dict(raw) for raw in data.get("module_caches", [])
+            )
+            if cache.module_name and cache.path
+        ]
         self._installations = [
             Installation.from_dict(inst) for inst in data.get("installations", [])
         ]
+
+        # Be forgiving of partially migrated files: attach an installation to
+        # its matching cache when the cache exists but the per-install key is
+        # missing.
+        for inst in self._installations:
+            if inst.cache_key is None:
+                cache = self._find_cache(
+                    ModuleCacheKey(
+                        inst.module_name,
+                        inst.scope,
+                        inst.project_path if inst.scope == "project" else None,
+                    )
+                )
+                if cache:
+                    inst.cache_key = cache.key
+
+    def _load_v1(self, data: dict) -> None:
+        """Load and normalize legacy v1 registry data into v2 objects."""
+        self._installations = []
+        self._module_caches = []
+
+        for raw in data.get("installations", []):
+            inst = Installation.from_dict(raw)
+            cache_path = self._legacy_cache_path(inst)
+            if cache_path:
+                cache = ModuleCache(
+                    module_name=inst.module_name,
+                    scope=inst.scope,
+                    project_path=inst.project_path if inst.scope == "project" else None,
+                    path=str(cache_path),
+                )
+                self._upsert_cache(cache)
+                inst.cache_key = cache.key
+            self._installations.append(inst)
+
+    def _legacy_cache_path(self, inst: Installation) -> Path | None:
+        """Infer the cache path for legacy records when it is unambiguous."""
+        if inst.scope == "project" and inst.project_path:
+            return Path(inst.project_path) / ".lola" / "modules" / inst.module_name
+        if inst.scope == "user" and inst.user_symlink_dir:
+            return Path(inst.user_symlink_dir) / inst.module_name
+        return None
 
     def _save(self):
         """Save installations to file atomically.
@@ -659,7 +827,8 @@ class InstallationRegistry:
         self.path.parent.mkdir(parents=True, exist_ok=True)
 
         data = {
-            "version": "1.0",
+            "version": "2.0",
+            "module_caches": [cache.to_dict() for cache in self._module_caches],
             "installations": [inst.to_dict() for inst in self._installations],
         }
 
@@ -686,8 +855,66 @@ class InstallationRegistry:
             tmp_path.unlink(missing_ok=True)
             raise
 
+    def _installation_key(self, installation: Installation) -> InstallationKey:
+        """Return an installation's stable key."""
+        return InstallationKey.from_installation(installation)
+
+    def _cache_key_for(
+        self, module_name: str, scope: str, project_path: str | None
+    ) -> ModuleCacheKey:
+        """Build the cache key for an installation context."""
+        return ModuleCacheKey(
+            module_name=module_name,
+            scope=scope,
+            project_path=project_path if scope == "project" else None,
+        )
+
+    def _find_cache(self, key: ModuleCacheKey) -> ModuleCache | None:
+        """Find a module cache by key."""
+        return next((cache for cache in self._module_caches if cache.key == key), None)
+
+    def _upsert_cache(self, cache: ModuleCache) -> None:
+        """Add or replace a module cache record."""
+        self._module_caches = [
+            existing for existing in self._module_caches if existing.key != cache.key
+        ]
+        self._module_caches.append(cache)
+
     def add(self, installation: Installation):
         """Add an installation record."""
+        self.upsert_installation(installation)
+
+    def upsert_installation(
+        self,
+        installation: Installation,
+        cache_path: Path | None = None,
+        source: str | None = None,
+    ) -> None:
+        """Add or replace an installation and optionally record its cache path."""
+        if cache_path is None and installation.cache_key is None:
+            cache_path = self.cache_for(
+                installation.module_name,
+                installation.scope,
+                installation.project_path,
+            )
+
+        if cache_path is not None:
+            cache_key = self._cache_key_for(
+                installation.module_name,
+                installation.scope,
+                installation.project_path,
+            )
+            installation.cache_key = cache_key
+            self._upsert_cache(
+                ModuleCache(
+                    module_name=installation.module_name,
+                    scope=installation.scope,
+                    project_path=cache_key.project_path,
+                    path=str(cache_path),
+                    source=source,
+                )
+            )
+
         # Remove any existing installation with same key
         self._installations = [
             inst
@@ -701,6 +928,108 @@ class InstallationRegistry:
         ]
         self._installations.append(installation)
         self._save()
+
+    def cache_for(
+        self,
+        module_name: str,
+        scope: str,
+        project_path: str | None = None,
+        current_user_context: str | Path | None = None,
+    ) -> Path | None:
+        """Return the cache path for a module/scope/location.
+
+        Existing records always win. For new project-scope installs, the cache
+        path is derived from the target project. For new user-scope installs,
+        callers must provide the current user context; if a legacy user record
+        has no cache, this deliberately returns None instead of guessing.
+        """
+        key = self._cache_key_for(module_name, scope, project_path)
+        existing = self._find_cache(key)
+        if existing and existing.path:
+            return Path(existing.path)
+
+        if scope == "project" and project_path:
+            return Path(project_path) / ".lola" / "modules" / module_name
+        if scope == "user" and current_user_context is not None:
+            return Path(current_user_context) / ".lola" / "modules" / module_name
+        return None
+
+    def remaining_installations_for_cache(
+        self, cache_key: ModuleCacheKey
+    ) -> list[Installation]:
+        """Return installations still referencing a cache key."""
+        return [inst for inst in self._installations if inst.cache_key == cache_key]
+
+    def remove_installation(self, key: InstallationKey) -> RemovalPlan:
+        """Remove one exact installation record."""
+        return self.remove_installations([key])
+
+    def remove_installations(self, keys: list[InstallationKey]) -> RemovalPlan:
+        """Remove exact installation records and plan safe cache cleanup."""
+        key_set = set(keys)
+        removed: list[Installation] = []
+        kept: list[Installation] = []
+
+        for inst in self._installations:
+            if self._installation_key(inst) in key_set:
+                removed.append(inst)
+            else:
+                kept.append(inst)
+
+        self._installations = kept
+        plan = RemovalPlan(removed_installations=removed)
+        self._append_unreferenced_cache_paths(
+            plan, {inst.cache_key for inst in removed if inst.cache_key is not None}
+        )
+        self._save()
+        return plan
+
+    def remove_module(self, module_name: str) -> RemovalPlan:
+        """Remove all installation and cache records for a module."""
+        removed = [
+            inst for inst in self._installations if inst.module_name == module_name
+        ]
+        self._installations = [
+            inst for inst in self._installations if inst.module_name != module_name
+        ]
+        candidate_keys = {
+            cache.key
+            for cache in self._module_caches
+            if cache.module_name == module_name
+        }
+        candidate_keys.update(
+            inst.cache_key for inst in removed if inst.cache_key is not None
+        )
+
+        plan = RemovalPlan(removed_installations=removed)
+        self._append_unreferenced_cache_paths(plan, candidate_keys)
+        self._save()
+        return plan
+
+    def _append_unreferenced_cache_paths(
+        self, plan: RemovalPlan, candidate_keys: set[ModuleCacheKey]
+    ) -> None:
+        """Move cache paths with no remaining references into the removal plan."""
+        if not candidate_keys:
+            return
+
+        paths: list[Path] = []
+        kept_caches: list[ModuleCache] = []
+        for cache in self._module_caches:
+            if (
+                cache.key in candidate_keys
+                and not self.remaining_installations_for_cache(cache.key)
+            ):
+                paths.append(Path(cache.path))
+            else:
+                kept_caches.append(cache)
+
+        self._module_caches = kept_caches
+        seen: set[Path] = set(plan.cache_paths_to_remove)
+        for path in paths:
+            if path not in seen:
+                plan.cache_paths_to_remove.append(path)
+                seen.add(path)
 
     def remove(
         self,
@@ -732,6 +1061,10 @@ class InstallationRegistry:
                 kept.append(inst)
 
         self._installations = kept
+        plan = RemovalPlan(removed_installations=removed)
+        self._append_unreferenced_cache_paths(
+            plan, {inst.cache_key for inst in removed if inst.cache_key is not None}
+        )
         self._save()
         return removed
 
@@ -742,3 +1075,7 @@ class InstallationRegistry:
     def all(self) -> list[Installation]:
         """Get all installations."""
         return self._installations.copy()
+
+    def module_caches(self) -> list[ModuleCache]:
+        """Get all module cache records."""
+        return self._module_caches.copy()

--- a/src/lola/models.py
+++ b/src/lola/models.py
@@ -549,6 +549,10 @@ class Installation:
     commands: list[str] = field(default_factory=list)
     agents: list[str] = field(default_factory=list)
     mcps: list[str] = field(default_factory=list)
+    skill_sources: dict[str, str] = field(default_factory=dict)
+    command_sources: dict[str, str] = field(default_factory=dict)
+    agent_sources: dict[str, str] = field(default_factory=dict)
+    mcp_sources: dict[str, str] = field(default_factory=dict)
     has_instructions: bool = False
     append_context: Optional[str] = None
     full_install: bool = True
@@ -571,6 +575,32 @@ class Installation:
             result["version"] = self.version
         if self.append_context:
             result["append_context"] = self.append_context
+        skill_sources = {
+            name: source
+            for name, source in self.skill_sources.items()
+            if name != source
+        }
+        command_sources = {
+            name: source
+            for name, source in self.command_sources.items()
+            if name != source
+        }
+        agent_sources = {
+            name: source
+            for name, source in self.agent_sources.items()
+            if name != source
+        }
+        mcp_sources = {
+            name: source for name, source in self.mcp_sources.items() if name != source
+        }
+        if skill_sources:
+            result["skill_sources"] = skill_sources
+        if command_sources:
+            result["command_sources"] = command_sources
+        if agent_sources:
+            result["agent_sources"] = agent_sources
+        if mcp_sources:
+            result["mcp_sources"] = mcp_sources
         # Only emit full_install when False to keep existing YAML clean
         if not self.full_install:
             result["full_install"] = False
@@ -589,6 +619,10 @@ class Installation:
             commands=data.get("commands", []),
             agents=data.get("agents", []),
             mcps=data.get("mcps", []),
+            skill_sources=data.get("skill_sources", {}),
+            command_sources=data.get("command_sources", {}),
+            agent_sources=data.get("agent_sources", {}),
+            mcp_sources=data.get("mcp_sources", {}),
             has_instructions=data.get("has_instructions", False),
             append_context=data.get("append_context"),
             full_install=data.get("full_install", True),

--- a/src/lola/models.py
+++ b/src/lola/models.py
@@ -551,6 +551,7 @@ class Installation:
     mcps: list[str] = field(default_factory=list)
     has_instructions: bool = False
     append_context: Optional[str] = None
+    full_install: bool = True
 
     def to_dict(self) -> dict:
         """Convert to dictionary for YAML serialization."""
@@ -570,6 +571,9 @@ class Installation:
             result["version"] = self.version
         if self.append_context:
             result["append_context"] = self.append_context
+        # Only emit full_install when False to keep existing YAML clean
+        if not self.full_install:
+            result["full_install"] = False
         return result
 
     @classmethod
@@ -587,6 +591,7 @@ class Installation:
             mcps=data.get("mcps", []),
             has_instructions=data.get("has_instructions", False),
             append_context=data.get("append_context"),
+            full_install=data.get("full_install", True),
         )
 
 

--- a/src/lola/prompts.py
+++ b/src/lola/prompts.py
@@ -83,19 +83,17 @@ def select_module_items(
     mcps: list[str],
 ) -> dict[str, list[str]] | None:
     """
-    Show a multi-select picker for cherry-picking module items.
+    Show a fuzzy-searchable multi-select picker for cherry-picking module items.
 
-    The first choice is "All" (pre-selected). When kept selected, the user
-    accepts the full module; when deselected, the user picks a subset.
     Items are listed with type prefixes (skill:, cmd:, agent:, mcp:) so a
-    single picker covers every category at once.
+    single picker covers every category at once. Type to fuzzy-search; Tab
+    toggles an item; Enter confirms. Pressing Enter with nothing selected
+    means "install everything" — there is no separate "All" entry.
 
     Returns a dict with keys "skills", "commands", "agents", "mcps", or None
-    if the user cancelled. If "All" remains selected, every list is returned
-    in full regardless of which individual items the user toggled.
+    if the user cancelled.
     """
-    all_token = "__all__"  # nosec B105 - sentinel string, not a credential
-    choices: list[Choice] = [Choice(value=all_token, name="All", enabled=True)]
+    choices: list[Choice] = []
     for s in skills:
         choices.append(Choice(value=f"skill:{s}", name=f"skill: {s}"))
     for c in commands:
@@ -105,14 +103,19 @@ def select_module_items(
     for m in mcps:
         choices.append(Choice(value=f"mcp:{m}", name=f"mcp: {m}"))
 
-    result = inquirer.checkbox(
-        message="Select items to install (Space to toggle, Enter to confirm):",
+    result = inquirer.fuzzy(
+        message=(
+            "Select items to install "
+            "(Type to search, Tab to toggle, Enter with no selection = all):"
+        ),
         choices=choices,
+        multiselect=True,
+        border=True,
     ).execute()
     if result is None:
         return None
 
-    if all_token in result:
+    if not result:
         return {
             "skills": list(skills),
             "commands": list(commands),

--- a/src/lola/prompts.py
+++ b/src/lola/prompts.py
@@ -97,6 +97,8 @@ def select_module_items(
     commands: list[str],
     agents: list[str],
     mcps: list[str],
+    current: dict[str, list[str]] | None = None,
+    has_instructions: bool = False,
 ) -> dict[str, list[str]] | None:
     """
     Show a fuzzy-searchable multi-select picker for cherry-picking module items.
@@ -106,25 +108,59 @@ def select_module_items(
     toggles an item; Alt-A toggles all currently-filtered items on; Enter
     confirms.
 
-    Returns a dict with keys "skills", "commands", "agents", "mcps", or None
-    if the user cancelled.
+    When ``has_instructions`` is True, a single ``instructions: AGENTS.md``
+    entry is appended.
+
+    When ``current`` is provided (dict keyed by "skills"/"commands"/"agents"/
+    "mcps"/"instructions"), items already in that set are suffixed
+    " (installed)" and pre-selected, while items not in it are suffixed
+    " (new)" and start deselected. When ``current`` is None, no suffix is
+    applied; every entry (including instructions, if shown) starts checked.
+
+    Returns a dict with keys "skills", "commands", "agents", "mcps",
+    "instructions", or None if the user cancelled. The "instructions" value
+    is ``["yes"]`` when selected and ``[]`` otherwise.
     """
+    current_sets: dict[str, set[str]] = {
+        "skills": set((current or {}).get("skills", [])),
+        "commands": set((current or {}).get("commands", [])),
+        "agents": set((current or {}).get("agents", [])),
+        "mcps": set((current or {}).get("mcps", [])),
+        "instructions": set((current or {}).get("instructions", [])),
+    }
+
+    def _make_choice(value: str, label: str, kind: str, name: str) -> Choice:
+        if current is None:
+            return Choice(value=value, name=label, enabled=True)
+        installed = name in current_sets[kind]
+        suffix = " (installed)" if installed else " (new)"
+        return Choice(value=value, name=label + suffix, enabled=installed)
+
     choices: list[Choice] = []
     for s in skills:
-        choices.append(Choice(value=f"skill:{s}", name=f"skill: {s}"))
+        choices.append(_make_choice(f"skill:{s}", f"skill: {s}", "skills", s))
     for c in commands:
-        choices.append(Choice(value=f"cmd:{c}", name=f"cmd: /{c}"))
+        choices.append(_make_choice(f"cmd:{c}", f"cmd: /{c}", "commands", c))
     for a in agents:
-        choices.append(Choice(value=f"agent:{a}", name=f"agent: @{a}"))
+        choices.append(_make_choice(f"agent:{a}", f"agent: @{a}", "agents", a))
     for m in mcps:
-        choices.append(Choice(value=f"mcp:{m}", name=f"mcp: {m}"))
+        choices.append(_make_choice(f"mcp:{m}", f"mcp: {m}", "mcps", m))
+    if has_instructions:
+        choices.append(
+            _make_choice(
+                "instructions:", "instructions: AGENTS.md", "instructions", "yes"
+            )
+        )
+
+    long_instruction = (
+        "Tab: toggle  ·  Alt-A: select all  ·  Type: fuzzy search  ·  Enter: confirm"
+    )
+    if current is not None:
+        long_instruction += "  ·  (installed) items pre-selected"
 
     result = inquirer.fuzzy(
         message="Select items to install:",
-        long_instruction=(
-            "Tab: toggle  ·  Alt-A: select all  ·  "
-            "Type: fuzzy search  ·  Enter: confirm"
-        ),
+        long_instruction=long_instruction,
         choices=choices,
         multiselect=True,
         border=True,
@@ -137,6 +173,7 @@ def select_module_items(
         "commands": [],
         "agents": [],
         "mcps": [],
+        "instructions": [],
     }
     for value in result:
         kind, _, name = value.partition(":")
@@ -148,6 +185,8 @@ def select_module_items(
             selected["agents"].append(name)
         elif kind == "mcp":
             selected["mcps"].append(name)
+        elif kind == "instructions":
+            selected["instructions"].append("yes")
     return selected
 
 
@@ -195,53 +234,50 @@ def select_marketplace(matches: list[tuple[dict, str]]) -> str | None:
     return str(result) if result is not None else None
 
 
-def prompt_command_conflict(cmd_name: str, module_name: str) -> tuple[str, str]:
-    """Prompt when a command file already exists.
+def _prompt_conflict(
+    kind: str, name: str, module_name: str, rename_sep: str
+) -> tuple[str, str]:
+    """Prompt when a file already exists during install.
 
-    Returns:
-        ("overwrite", "")         — replace existing file
-        ("rename",    "new_name") — install under new_name
-        ("skip",      "")         — do not install
+    Returns one of:
+        ("overwrite_all", "")     — overwrite this and every subsequent collision
+        ("overwrite",     "")     — replace existing file
+        ("rename",        "new")  — install under ``new``
+        ("skip",          "")     — do not install
     """
     action = inquirer.select(
-        message=f"'{cmd_name}' already exists. What would you like to do?",
+        message=f"'{name}' ({kind}) already exists. What would you like to do?",
         choices=[
+            Choice("overwrite_all", name="Overwrite All"),
             Choice("overwrite", name="Overwrite"),
-            Choice("rename", name="Rename command"),
+            Choice("rename", name=f"Rename {kind}"),
             Choice("skip", name="Skip"),
         ],
     ).execute()
     if action == "rename":
         new_name = inquirer.text(
-            message="New command name:",
-            default=f"{module_name}-{cmd_name}",
+            message=f"New {kind} name:",
+            default=f"{module_name}{rename_sep}{name}",
             validate=EmptyInputValidator(),
         ).execute()
         return "rename", str(new_name)
     return str(action) if action is not None else "skip", ""
+
+
+def prompt_command_conflict(cmd_name: str, module_name: str) -> tuple[str, str]:
+    """Prompt when a command file already exists. See ``_prompt_conflict``."""
+    return _prompt_conflict("command", cmd_name, module_name, rename_sep="-")
 
 
 def prompt_agent_conflict(agent_name: str, module_name: str) -> tuple[str, str]:
-    """Prompt when an agent file already exists.
+    """Prompt when an agent file already exists. See ``_prompt_conflict``."""
+    return _prompt_conflict("agent", agent_name, module_name, rename_sep="-")
 
-    Returns:
-        ("overwrite", "")         — replace existing file
-        ("rename",    "new_name") — install under new_name
-        ("skip",      "")         — do not install
+
+def prompt_skill_conflict(skill_name: str, module_name: str) -> tuple[str, str]:
+    """Prompt when a skill directory already exists. See ``_prompt_conflict``.
+
+    Defaults the rename to ``f"{module_name}_{skill_name}"`` to match the
+    historical prefix convention for skills.
     """
-    action = inquirer.select(
-        message=f"'{agent_name}' already exists. What would you like to do?",
-        choices=[
-            Choice("overwrite", name="Overwrite"),
-            Choice("rename", name="Rename agent"),
-            Choice("skip", name="Skip"),
-        ],
-    ).execute()
-    if action == "rename":
-        new_name = inquirer.text(
-            message="New agent name:",
-            default=f"{module_name}-{agent_name}",
-            validate=EmptyInputValidator(),
-        ).execute()
-        return "rename", str(new_name)
-    return str(action) if action is not None else "skip", ""
+    return _prompt_conflict("skill", skill_name, module_name, rename_sep="_")

--- a/src/lola/prompts.py
+++ b/src/lola/prompts.py
@@ -105,8 +105,8 @@ def select_module_items(
 
     Items are listed with type prefixes (skill:, cmd:, agent:, mcp:) so a
     single picker covers every category at once. Type to fuzzy-search; Tab
-    toggles an item; Alt-A toggles all currently-filtered items on; Enter
-    confirms.
+    toggles an item; Alt-A inverts the current selection (toggle-all);
+    Enter confirms.
 
     When ``has_instructions`` is True, a single ``instructions: AGENTS.md``
     entry is appended.
@@ -115,7 +115,7 @@ def select_module_items(
     "mcps"/"instructions"), items already in that set are suffixed
     " (installed)" and pre-selected, while items not in it are suffixed
     " (new)" and start deselected. When ``current`` is None, no suffix is
-    applied; every entry (including instructions, if shown) starts checked.
+    applied and every entry starts deselected — use Alt-A to toggle all on.
 
     Returns a dict with keys "skills", "commands", "agents", "mcps",
     "instructions", or None if the user cancelled. The "instructions" value
@@ -131,7 +131,7 @@ def select_module_items(
 
     def _make_choice(value: str, label: str, kind: str, name: str) -> Choice:
         if current is None:
-            return Choice(value=value, name=label, enabled=True)
+            return Choice(value=value, name=label, enabled=False)
         installed = name in current_sets[kind]
         suffix = " (installed)" if installed else " (new)"
         return Choice(value=value, name=label + suffix, enabled=installed)
@@ -153,17 +153,24 @@ def select_module_items(
         )
 
     long_instruction = (
-        "Tab: toggle  ·  Alt-A: select all  ·  Type: fuzzy search  ·  Enter: confirm"
+        "Tab: toggle  ·  Alt-A: toggle all  ·  Type: fuzzy search  ·  Enter: confirm"
     )
     if current is not None:
         long_instruction += "  ·  (installed) items pre-selected"
 
+    # Rebind Alt-A from the default "select all" to "toggle all" so users
+    # can deselect everything in one keystroke when the picker pre-selects
+    # items (e.g. on update).
     result = inquirer.fuzzy(
         message="Select items to install:",
         long_instruction=long_instruction,
         choices=choices,
         multiselect=True,
         border=True,
+        keybindings={
+            "toggle-all": [{"key": "alt-a"}, {"key": "c-a"}],
+            "toggle-all-true": [],
+        },
     ).execute()
     if result is None:
         return None

--- a/src/lola/prompts.py
+++ b/src/lola/prompts.py
@@ -105,8 +105,11 @@ def select_module_items(
 
     Items are listed with type prefixes (skill:, cmd:, agent:, mcp:) so a
     single picker covers every category at once. Type to fuzzy-search; Tab
-    toggles an item; Alt-A inverts the current selection (toggle-all);
-    Enter confirms.
+    toggles an item. We rely on InquirerPy's built-in shortcuts: Alt-A /
+    Ctrl-A select all, Alt-R / Ctrl-R invert. Enter confirms. (InquirerPy's
+    fuzzy picker has no working deselect-all — its ``toggle-all-false``
+    action is broken upstream — so we lean on "pre-select everything, then
+    invert" to achieve clear-the-list.)
 
     When ``has_instructions`` is True, a single ``instructions: AGENTS.md``
     entry is appended.
@@ -114,8 +117,9 @@ def select_module_items(
     When ``current`` is provided (dict keyed by "skills"/"commands"/"agents"/
     "mcps"/"instructions"), items already in that set are suffixed
     " (installed)" and pre-selected, while items not in it are suffixed
-    " (new)" and start deselected. When ``current`` is None, no suffix is
-    applied and every entry starts deselected — use Alt-A to toggle all on.
+    " (new)" and start deselected. When ``current`` is None (a fresh install),
+    every entry starts pre-selected so confirming installs everything by
+    default — use Ctrl-R to invert (clears the list on a fresh install).
 
     Returns a dict with keys "skills", "commands", "agents", "mcps",
     "instructions", or None if the user cancelled. The "instructions" value
@@ -131,7 +135,10 @@ def select_module_items(
 
     def _make_choice(value: str, label: str, kind: str, name: str) -> Choice:
         if current is None:
-            return Choice(value=value, name=label, enabled=False)
+            # Fresh install: pre-select everything so Enter installs all by
+            # default; the picker becomes a tool for deselecting unwanted
+            # items rather than building up a selection from scratch.
+            return Choice(value=value, name=label, enabled=True)
         installed = name in current_sets[kind]
         suffix = " (installed)" if installed else " (new)"
         return Choice(value=value, name=label + suffix, enabled=installed)
@@ -152,25 +159,23 @@ def select_module_items(
             )
         )
 
-    long_instruction = (
-        "Tab: toggle  ·  Alt-A: toggle all  ·  Type: fuzzy search  ·  Enter: confirm"
-    )
-    if current is not None:
-        long_instruction += "  ·  (installed) items pre-selected"
+    # Surface the most-useful shortcuts inline at the top so users discover
+    # them without having to read the bottom help line. Keep this short so
+    # it fits on one line in typical terminal widths.
+    instruction = "(^A all · ^R invert · Tab toggle)"
+    long_instruction = "Type to fuzzy-search. Tab toggles; Enter confirms."
 
-    # Rebind Alt-A from the default "select all" to "toggle all" so users
-    # can deselect everything in one keystroke when the picker pre-selects
-    # items (e.g. on update).
+    # Rely on InquirerPy's defaults: Alt-A/Ctrl-A select-all,
+    # Alt-R/Ctrl-R invert. No deselect-all binding — fuzzy's
+    # toggle-all-false handler is broken upstream (treats `False` as
+    # falsy and inverts instead of clearing).
     result = inquirer.fuzzy(
         message="Select items to install:",
+        instruction=instruction,
         long_instruction=long_instruction,
         choices=choices,
         multiselect=True,
         border=True,
-        keybindings={
-            "toggle-all": [{"key": "alt-a"}, {"key": "c-a"}],
-            "toggle-all-true": [],
-        },
     ).execute()
     if result is None:
         return None
@@ -247,15 +252,20 @@ def _prompt_conflict(
     """Prompt when a file already exists during install.
 
     Returns one of:
-        ("overwrite_all", "")     — overwrite this and every subsequent collision
-        ("overwrite",     "")     — replace existing file
-        ("rename",        "new")  — install under ``new``
-        ("skip",          "")     — do not install
+        ("overwrite_all", "")        — overwrite this and every subsequent
+                                       collision
+        ("prefix_all",    "prefix")  — apply ``f"{prefix}{sep}{name}"`` to this
+                                       and every subsequent collision; the
+                                       caller knows ``sep`` for its kind
+        ("overwrite",     "")        — replace existing file
+        ("rename",        "new")     — install under ``new``
+        ("skip",          "")        — do not install
     """
     action = inquirer.select(
         message=f"'{name}' ({kind}) already exists. What would you like to do?",
         choices=[
             Choice("overwrite_all", name="Overwrite All"),
+            Choice("prefix_all", name="Prefix All"),
             Choice("overwrite", name="Overwrite"),
             Choice("rename", name=f"Rename {kind}"),
             Choice("skip", name="Skip"),
@@ -268,6 +278,13 @@ def _prompt_conflict(
             validate=EmptyInputValidator(),
         ).execute()
         return "rename", str(new_name)
+    if action == "prefix_all":
+        prefix = inquirer.text(
+            message=f"Prefix for all conflicting {kind}s (joined with '{rename_sep}'):",
+            default=module_name,
+            validate=EmptyInputValidator(),
+        ).execute()
+        return "prefix_all", str(prefix)
     return str(action) if action is not None else "skip", ""
 
 

--- a/src/lola/prompts.py
+++ b/src/lola/prompts.py
@@ -76,6 +76,69 @@ def select_marketplace_name(names: list[str]) -> str | None:
     return str(result) if result is not None else None
 
 
+def select_module_items(
+    skills: list[str],
+    commands: list[str],
+    agents: list[str],
+    mcps: list[str],
+) -> dict[str, list[str]] | None:
+    """
+    Show a multi-select picker for cherry-picking module items.
+
+    The first choice is "All" (pre-selected). When kept selected, the user
+    accepts the full module; when deselected, the user picks a subset.
+    Items are listed with type prefixes (skill:, cmd:, agent:, mcp:) so a
+    single picker covers every category at once.
+
+    Returns a dict with keys "skills", "commands", "agents", "mcps", or None
+    if the user cancelled. If "All" remains selected, every list is returned
+    in full regardless of which individual items the user toggled.
+    """
+    all_token = "__all__"  # nosec B105 - sentinel string, not a credential
+    choices: list[Choice] = [Choice(value=all_token, name="All", enabled=True)]
+    for s in skills:
+        choices.append(Choice(value=f"skill:{s}", name=f"skill: {s}"))
+    for c in commands:
+        choices.append(Choice(value=f"cmd:{c}", name=f"cmd: /{c}"))
+    for a in agents:
+        choices.append(Choice(value=f"agent:{a}", name=f"agent: @{a}"))
+    for m in mcps:
+        choices.append(Choice(value=f"mcp:{m}", name=f"mcp: {m}"))
+
+    result = inquirer.checkbox(
+        message="Select items to install (Space to toggle, Enter to confirm):",
+        choices=choices,
+    ).execute()
+    if result is None:
+        return None
+
+    if all_token in result:
+        return {
+            "skills": list(skills),
+            "commands": list(commands),
+            "agents": list(agents),
+            "mcps": list(mcps),
+        }
+
+    selected: dict[str, list[str]] = {
+        "skills": [],
+        "commands": [],
+        "agents": [],
+        "mcps": [],
+    }
+    for value in result:
+        kind, _, name = value.partition(":")
+        if kind == "skill":
+            selected["skills"].append(name)
+        elif kind == "cmd":
+            selected["commands"].append(name)
+        elif kind == "agent":
+            selected["agents"].append(name)
+        elif kind == "mcp":
+            selected["mcps"].append(name)
+    return selected
+
+
 def select_installations(
     installations: list[tuple[str, str, str]],
 ) -> list[tuple[str, str, str]]:

--- a/src/lola/prompts.py
+++ b/src/lola/prompts.py
@@ -87,8 +87,8 @@ def select_module_items(
 
     Items are listed with type prefixes (skill:, cmd:, agent:, mcp:) so a
     single picker covers every category at once. Type to fuzzy-search; Tab
-    toggles an item; Enter confirms. Pressing Enter with nothing selected
-    means "install everything" — there is no separate "All" entry.
+    toggles an item; Alt-A toggles all currently-filtered items on; Enter
+    confirms.
 
     Returns a dict with keys "skills", "commands", "agents", "mcps", or None
     if the user cancelled.
@@ -104,9 +104,10 @@ def select_module_items(
         choices.append(Choice(value=f"mcp:{m}", name=f"mcp: {m}"))
 
     result = inquirer.fuzzy(
-        message=(
-            "Select items to install "
-            "(Type to search, Tab to toggle, Enter with no selection = all):"
+        message="Select items to install:",
+        long_instruction=(
+            "Tab: toggle  ·  Alt-A: select all  ·  "
+            "Type: fuzzy search  ·  Enter: confirm"
         ),
         choices=choices,
         multiselect=True,
@@ -114,14 +115,6 @@ def select_module_items(
     ).execute()
     if result is None:
         return None
-
-    if not result:
-        return {
-            "skills": list(skills),
-            "commands": list(commands),
-            "agents": list(agents),
-            "mcps": list(mcps),
-        }
 
     selected: dict[str, list[str]] = {
         "skills": [],

--- a/src/lola/prompts.py
+++ b/src/lola/prompts.py
@@ -76,6 +76,22 @@ def select_marketplace_name(names: list[str]) -> str | None:
     return str(result) if result is not None else None
 
 
+def select_install_mode() -> str | None:
+    """
+    Ask whether to install every module item or cherry-pick specific items.
+
+    Returns "all", "cherry-pick", or None if cancelled.
+    """
+    result = inquirer.select(
+        message="Install module items:",
+        choices=[
+            Choice(value="all", name="Install all"),
+            Choice(value="cherry-pick", name="Choose items"),
+        ],
+    ).execute()
+    return str(result) if result is not None else None
+
+
 def select_module_items(
     skills: list[str],
     commands: list[str],

--- a/src/lola/targets/__init__.py
+++ b/src/lola/targets/__init__.py
@@ -40,6 +40,7 @@ from lola.targets.install import (
     copy_module_to_local,
     get_registry,
     install_to_assistant,
+    uninstall_assistant_outputs,
     uninstall_from_assistant,
 )
 
@@ -88,6 +89,7 @@ __all__ = [
     "console",
     "copy_module_to_local",
     "install_to_assistant",
+    "uninstall_assistant_outputs",
     "uninstall_from_assistant",
     # Helpers (used by tests and cli/install.py)
     "_get_content_path",

--- a/src/lola/targets/install.py
+++ b/src/lola/targets/install.py
@@ -187,6 +187,17 @@ def _check_skill_exists(
             return (skill_dest / skill_name).exists()
 
 
+def _filter_selected(items: list[str], selected: set[str] | None) -> list[str]:
+    """Apply a cherry-pick filter, preserving source order.
+
+    ``selected is None`` means "install everything" (the historical default);
+    any set (even empty) restricts to that subset.
+    """
+    if selected is None:
+        return list(items)
+    return [x for x in items if x in selected]
+
+
 def _install_skills(
     target: AssistantTarget,
     module: Module,
@@ -194,9 +205,11 @@ def _install_skills(
     project_path: str | None,
     scope: str = "project",
     force: bool = False,
+    selected: set[str] | None = None,
 ) -> tuple[list[str], list[str]]:
     """Install skills for a target. Returns (installed, failed) lists."""
-    if not module.skills:
+    skills_to_install = _filter_selected(module.skills, selected)
+    if not skills_to_install:
         return [], []
 
     installed: list[str] = []
@@ -211,7 +224,7 @@ def _install_skills(
     # Batch updates for managed section targets (Gemini, OpenCode)
     if target.uses_managed_section:
         batch_skills: list[tuple[str, str, Path]] = []
-        for skill in module.skills:
+        for skill in skills_to_install:
             source = _skill_source_dir(local_module_path, skill, content_dirname)
             if source.exists():
                 batch_skills.append((skill, _get_skill_description(source), source))
@@ -223,7 +236,7 @@ def _install_skills(
                 skill_dest, module.name, batch_skills, project_path
             )
     else:
-        for skill in module.skills:
+        for skill in skills_to_install:
             source = _skill_source_dir(local_module_path, skill, content_dirname)
             skill_name = skill  # Use unprefixed name by default
 
@@ -262,9 +275,11 @@ def _install_commands(
     project_path: str | None,
     force: bool = False,
     scope: str = "project",
+    selected: set[str] | None = None,
 ) -> tuple[list[str], list[str]]:
     """Install commands for a target. Returns (installed, failed) lists."""
-    if not module.commands:
+    commands_to_install = _filter_selected(module.commands, selected)
+    if not commands_to_install:
         return [], []
 
     installed: list[str] = []
@@ -276,7 +291,7 @@ def _install_commands(
     content_dirname = _get_content_dirname(module)
     content_path = _get_content_path(local_module_path, content_dirname)
     commands_dir = content_path / "commands"
-    for cmd in module.commands:
+    for cmd in commands_to_install:
         source = commands_dir / f"{cmd}.md"
         effective_cmd = cmd
 
@@ -307,9 +322,14 @@ def _install_agents(
     project_path: str | None,
     force: bool = False,
     scope: str = "project",
+    selected: set[str] | None = None,
 ) -> tuple[list[str], list[str]]:
     """Install agents for a target. Returns (installed, failed) lists."""
-    if not module.agents or not target.supports_agents:
+    if not target.supports_agents:
+        return [], []
+
+    agents_to_install = _filter_selected(module.agents, selected)
+    if not agents_to_install:
         return [], []
 
     path_context = project_path or ""
@@ -323,7 +343,7 @@ def _install_agents(
     content_dirname = _get_content_dirname(module)
     content_path = _get_content_path(local_module_path, content_dirname)
     agents_dir = content_path / "agents"
-    for agent in module.agents:
+    for agent in agents_to_install:
         source = agents_dir / f"{agent}.md"
         effective_agent = agent
 
@@ -405,9 +425,11 @@ def _install_mcps(
     local_module_path: Path,
     project_path: str | None,
     scope: str = "project",
+    selected: set[str] | None = None,
 ) -> tuple[list[str], list[str]]:
     """Install MCPs for a target. Returns (installed, failed) lists."""
-    if not module.mcps:
+    mcps_to_install = _filter_selected(module.mcps, selected)
+    if not mcps_to_install:
         return [], []
 
     path_context = project_path or ""
@@ -415,25 +437,27 @@ def _install_mcps(
     if not mcp_dest:
         return [], []
 
-    # Load mcps.json from local module (respecting module/ subdirectory)
     content_dirname = _get_content_dirname(module)
     content_path = _get_content_path(local_module_path, content_dirname)
     mcps_file = content_path / config.MCPS_FILE
     if not mcps_file.exists():
-        return [], list(module.mcps)
+        return [], mcps_to_install
 
     try:
         mcps_data = json.loads(mcps_file.read_text())
         servers = mcps_data.get("mcpServers", {})
     except json.JSONDecodeError:
-        return [], list(module.mcps)
+        return [], mcps_to_install
 
-    # Generate MCPs
-    if target.generate_mcps(servers, mcp_dest, module.name):
-        installed = list(servers.keys())
-        return installed, []
+    wanted = set(mcps_to_install)
+    filtered_servers = {k: v for k, v in servers.items() if k in wanted}
+    if not filtered_servers:
+        return [], mcps_to_install
 
-    return [], list(module.mcps)
+    if target.generate_mcps(filtered_servers, mcp_dest, module.name):
+        return list(filtered_servers.keys()), []
+
+    return [], mcps_to_install
 
 
 def _print_summary(
@@ -517,14 +541,30 @@ def install_to_assistant(
     pre_install_script: Optional[str] = None,
     post_install_script: Optional[str] = None,
     append_context: Optional[str] = None,
+    selected_skills: set[str] | None = None,
+    selected_commands: set[str] | None = None,
+    selected_agents: set[str] | None = None,
+    selected_mcps: set[str] | None = None,
 ) -> int:
-    """Install module to a specific assistant."""
+    """Install module to a specific assistant.
+
+    When all four ``selected_*`` arguments are ``None``, every item in the
+    module is installed (the historical default). Passing any non-``None``
+    set marks this as a cherry-picked install and stamps
+    ``Installation.full_install = False`` so subsequent updates lock to the
+    original selection.
+    """
     # Late import to avoid circular imports - get_target is defined in __init__.py
     from lola.targets import get_target
 
     target = get_target(assistant)
 
     local_module_path = copy_module_to_local(module, local_modules)
+
+    full_install = all(
+        s is None
+        for s in (selected_skills, selected_commands, selected_agents, selected_mcps)
+    )
 
     if pre_install_script:
         try:
@@ -543,16 +583,39 @@ def install_to_assistant(
             raise
 
     installed_skills, failed_skills = _install_skills(
-        target, module, local_module_path, project_path, scope, force
+        target,
+        module,
+        local_module_path,
+        project_path,
+        scope,
+        force,
+        selected=selected_skills,
     )
     installed_commands, failed_commands = _install_commands(
-        target, module, local_module_path, project_path, force, scope
+        target,
+        module,
+        local_module_path,
+        project_path,
+        force,
+        scope,
+        selected=selected_commands,
     )
     installed_agents, failed_agents = _install_agents(
-        target, module, local_module_path, project_path, force, scope
+        target,
+        module,
+        local_module_path,
+        project_path,
+        force,
+        scope,
+        selected=selected_agents,
     )
     installed_mcps, failed_mcps = _install_mcps(
-        target, module, local_module_path, project_path, scope
+        target,
+        module,
+        local_module_path,
+        project_path,
+        scope,
+        selected=selected_mcps,
     )
     instructions_installed = _install_instructions(
         target, module, local_module_path, project_path, append_context, scope
@@ -592,6 +655,7 @@ def install_to_assistant(
                 mcps=installed_mcps,
                 has_instructions=instructions_installed,
                 append_context=append_context,
+                full_install=full_install,
             )
         )
 

--- a/src/lola/targets/install.py
+++ b/src/lola/targets/install.py
@@ -206,14 +206,15 @@ def _install_skills(
     scope: str = "project",
     force: bool = False,
     selected: set[str] | None = None,
-) -> tuple[list[str], list[str]]:
+) -> tuple[list[str], list[str], dict[str, str]]:
     """Install skills for a target. Returns (installed, failed) lists."""
     skills_to_install = _filter_selected(module.skills, selected)
     if not skills_to_install:
-        return [], []
+        return [], [], {}
 
     installed: list[str] = []
     failed: list[str] = []
+    source_map: dict[str, str] = {}
 
     # For user scope, project_path may be None
     path_context = project_path or ""
@@ -229,6 +230,7 @@ def _install_skills(
             if source.exists():
                 batch_skills.append((skill, _get_skill_description(source), source))
                 installed.append(skill)
+                source_map[skill] = skill
             else:
                 failed.append(skill)
         if batch_skills:
@@ -262,10 +264,11 @@ def _install_skills(
 
             if target.generate_skill(source, skill_dest, skill_name, project_path):
                 installed.append(skill_name)
+                source_map[skill_name] = skill
             else:
                 failed.append(skill)
 
-    return installed, failed
+    return installed, failed, source_map
 
 
 def _install_commands(
@@ -276,14 +279,15 @@ def _install_commands(
     force: bool = False,
     scope: str = "project",
     selected: set[str] | None = None,
-) -> tuple[list[str], list[str]]:
+) -> tuple[list[str], list[str], dict[str, str]]:
     """Install commands for a target. Returns (installed, failed) lists."""
     commands_to_install = _filter_selected(module.commands, selected)
     if not commands_to_install:
-        return [], []
+        return [], [], {}
 
     installed: list[str] = []
     failed: list[str] = []
+    source_map: dict[str, str] = {}
 
     path_context = project_path or ""
     command_dest = target.get_command_path(path_context, scope)
@@ -309,10 +313,11 @@ def _install_commands(
 
         if target.generate_command(source, command_dest, effective_cmd, module.name):
             installed.append(effective_cmd)
+            source_map[effective_cmd] = cmd
         else:
             failed.append(cmd)
 
-    return installed, failed
+    return installed, failed, source_map
 
 
 def _install_agents(
@@ -323,22 +328,23 @@ def _install_agents(
     force: bool = False,
     scope: str = "project",
     selected: set[str] | None = None,
-) -> tuple[list[str], list[str]]:
+) -> tuple[list[str], list[str], dict[str, str]]:
     """Install agents for a target. Returns (installed, failed) lists."""
     if not target.supports_agents:
-        return [], []
+        return [], [], {}
 
     agents_to_install = _filter_selected(module.agents, selected)
     if not agents_to_install:
-        return [], []
+        return [], [], {}
 
     path_context = project_path or ""
     agent_dest = target.get_agent_path(path_context, scope)
     if not agent_dest:
-        return [], []
+        return [], [], {}
 
     installed: list[str] = []
     failed: list[str] = []
+    source_map: dict[str, str] = {}
 
     content_dirname = _get_content_dirname(module)
     content_path = _get_content_path(local_module_path, content_dirname)
@@ -361,10 +367,11 @@ def _install_agents(
 
         if target.generate_agent(source, agent_dest, effective_agent, module.name):
             installed.append(effective_agent)
+            source_map[effective_agent] = agent
         else:
             failed.append(agent)
 
-    return installed, failed
+    return installed, failed, source_map
 
 
 def _install_instructions(
@@ -426,38 +433,39 @@ def _install_mcps(
     project_path: str | None,
     scope: str = "project",
     selected: set[str] | None = None,
-) -> tuple[list[str], list[str]]:
+) -> tuple[list[str], list[str], dict[str, str]]:
     """Install MCPs for a target. Returns (installed, failed) lists."""
     mcps_to_install = _filter_selected(module.mcps, selected)
     if not mcps_to_install:
-        return [], []
+        return [], [], {}
 
     path_context = project_path or ""
     mcp_dest = target.get_mcp_path(path_context, scope)
     if not mcp_dest:
-        return [], []
+        return [], [], {}
 
     content_dirname = _get_content_dirname(module)
     content_path = _get_content_path(local_module_path, content_dirname)
     mcps_file = content_path / config.MCPS_FILE
     if not mcps_file.exists():
-        return [], mcps_to_install
+        return [], mcps_to_install, {}
 
     try:
         mcps_data = json.loads(mcps_file.read_text())
         servers = mcps_data.get("mcpServers", {})
     except json.JSONDecodeError:
-        return [], mcps_to_install
+        return [], mcps_to_install, {}
 
     wanted = set(mcps_to_install)
     filtered_servers = {k: v for k, v in servers.items() if k in wanted}
     if not filtered_servers:
-        return [], mcps_to_install
+        return [], mcps_to_install, {}
 
     if target.generate_mcps(filtered_servers, mcp_dest, module.name):
-        return list(filtered_servers.keys()), []
+        installed = list(filtered_servers.keys())
+        return installed, [], {name: name for name in installed}
 
-    return [], mcps_to_install
+    return [], mcps_to_install, {}
 
 
 def _print_summary(
@@ -582,7 +590,7 @@ def install_to_assistant(
                 shutil.rmtree(local_module_path)
             raise
 
-    installed_skills, failed_skills = _install_skills(
+    installed_skills, failed_skills, skill_sources = _install_skills(
         target,
         module,
         local_module_path,
@@ -591,7 +599,7 @@ def install_to_assistant(
         force,
         selected=selected_skills,
     )
-    installed_commands, failed_commands = _install_commands(
+    installed_commands, failed_commands, command_sources = _install_commands(
         target,
         module,
         local_module_path,
@@ -600,7 +608,7 @@ def install_to_assistant(
         scope,
         selected=selected_commands,
     )
-    installed_agents, failed_agents = _install_agents(
+    installed_agents, failed_agents, agent_sources = _install_agents(
         target,
         module,
         local_module_path,
@@ -609,7 +617,7 @@ def install_to_assistant(
         scope,
         selected=selected_agents,
     )
-    installed_mcps, failed_mcps = _install_mcps(
+    installed_mcps, failed_mcps, mcp_sources = _install_mcps(
         target,
         module,
         local_module_path,
@@ -653,6 +661,10 @@ def install_to_assistant(
                 commands=installed_commands,
                 agents=installed_agents,
                 mcps=installed_mcps,
+                skill_sources=skill_sources,
+                command_sources=command_sources,
+                agent_sources=agent_sources,
+                mcp_sources=mcp_sources,
                 has_instructions=instructions_installed,
                 append_context=append_context,
                 full_install=full_install,

--- a/src/lola/targets/install.py
+++ b/src/lola/targets/install.py
@@ -21,7 +21,7 @@ from rich.console import Console
 
 import lola.config as config
 from lola.exceptions import InstallationError
-from lola.models import Installation, InstallationRegistry, Module
+from lola.models import Installation, InstallationKey, InstallationRegistry, Module
 from lola.prompts import (
     is_interactive,
     prompt_agent_conflict,
@@ -202,6 +202,35 @@ def _filter_selected(items: list[str], selected: set[str] | None) -> list[str]:
     return [x for x in items if x in selected]
 
 
+def _installed_name_for_source(
+    source_name: str, installed_items: list[str], source_map: dict[str, str]
+) -> str | None:
+    """Return the installed name previously recorded for a source item."""
+    for installed_name in installed_items:
+        if source_map.get(installed_name, installed_name) == source_name:
+            return installed_name
+    return None
+
+
+def _existing_installation(
+    registry: InstallationRegistry,
+    module_name: str,
+    assistant: str,
+    scope: str,
+    project_path: str | None,
+) -> Installation | None:
+    """Find the exact installation currently being refreshed, if any."""
+    key = InstallationKey(module_name, assistant, scope, project_path)
+    return next(
+        (
+            inst
+            for inst in registry.find(module_name)
+            if InstallationKey.from_installation(inst) == key
+        ),
+        None,
+    )
+
+
 def _install_skills(
     target: AssistantTarget,
     module: Module,
@@ -210,6 +239,7 @@ def _install_skills(
     scope: str = "project",
     force: bool = False,
     selected: set[str] | None = None,
+    existing: Installation | None = None,
 ) -> tuple[list[str], list[str], dict[str, str]]:
     """Install skills for a target. Returns (installed, failed) lists."""
     skills_to_install = _filter_selected(module.skills, selected)
@@ -243,13 +273,24 @@ def _install_skills(
             )
     else:
         overwrite_all = False
+        prefix_all: str | None = None
         for skill in skills_to_install:
             source = _skill_source_dir(local_module_path, skill, content_dirname)
-            skill_name = skill  # Use unprefixed name by default
+            existing_name = (
+                _installed_name_for_source(
+                    skill, existing.skills, existing.skill_sources
+                )
+                if existing
+                else None
+            )
+            skill_name = existing_name or skill
+            owns_existing = existing_name is not None
 
             if _check_skill_exists(target, skill_name, project_path, scope):
-                if force or overwrite_all:
+                if owns_existing or force or overwrite_all:
                     pass
+                elif prefix_all is not None:
+                    skill_name = f"{prefix_all}_{skill}"
                 elif not is_interactive():
                     failed.append(skill)
                     continue
@@ -260,6 +301,9 @@ def _install_skills(
                         continue
                     elif action == "rename":
                         skill_name = new_name
+                    elif action == "prefix_all":
+                        prefix_all = new_name  # user-chosen prefix
+                        skill_name = f"{prefix_all}_{skill}"
                     elif action == "overwrite_all":
                         overwrite_all = True
 
@@ -280,6 +324,7 @@ def _install_commands(
     force: bool = False,
     scope: str = "project",
     selected: set[str] | None = None,
+    existing: Installation | None = None,
 ) -> tuple[list[str], list[str], dict[str, str]]:
     """Install commands for a target. Returns (installed, failed) lists."""
     commands_to_install = _filter_selected(module.commands, selected)
@@ -297,23 +342,38 @@ def _install_commands(
     content_path = _get_content_path(local_module_path, content_dirname)
     commands_dir = content_path / "commands"
     overwrite_all = False
+    prefix_all: str | None = None
     for cmd in commands_to_install:
         source = commands_dir / f"{cmd}.md"
-        effective_cmd = cmd
+        existing_name = (
+            _installed_name_for_source(cmd, existing.commands, existing.command_sources)
+            if existing
+            else None
+        )
+        effective_cmd = existing_name or cmd
+        owns_existing = existing_name is not None
 
-        dest_file = command_dest / target.get_command_filename(module.name, cmd)
-        if dest_file.exists() and not force and not overwrite_all:
-            if not is_interactive():
+        dest_file = command_dest / target.get_command_filename(
+            module.name, effective_cmd
+        )
+        if dest_file.exists() and not owns_existing and not force and not overwrite_all:
+            if prefix_all is not None:
+                effective_cmd = f"{prefix_all}-{cmd}"
+            elif not is_interactive():
                 failed.append(cmd)
                 continue
-            action, new_name = prompt_command_conflict(cmd, module.name)
-            if action == "skip":
-                failed.append(cmd)
-                continue
-            elif action == "rename":
-                effective_cmd = new_name
-            elif action == "overwrite_all":
-                overwrite_all = True
+            else:
+                action, new_name = prompt_command_conflict(cmd, module.name)
+                if action == "skip":
+                    failed.append(cmd)
+                    continue
+                elif action == "rename":
+                    effective_cmd = new_name
+                elif action == "prefix_all":
+                    prefix_all = new_name  # user-chosen prefix
+                    effective_cmd = f"{prefix_all}-{cmd}"
+                elif action == "overwrite_all":
+                    overwrite_all = True
 
         if target.generate_command(source, command_dest, effective_cmd, module.name):
             installed.append(effective_cmd)
@@ -332,6 +392,7 @@ def _install_agents(
     force: bool = False,
     scope: str = "project",
     selected: set[str] | None = None,
+    existing: Installation | None = None,
 ) -> tuple[list[str], list[str], dict[str, str]]:
     """Install agents for a target. Returns (installed, failed) lists."""
     if not target.supports_agents:
@@ -354,23 +415,36 @@ def _install_agents(
     content_path = _get_content_path(local_module_path, content_dirname)
     agents_dir = content_path / "agents"
     overwrite_all = False
+    prefix_all: str | None = None
     for agent in agents_to_install:
         source = agents_dir / f"{agent}.md"
-        effective_agent = agent
+        existing_name = (
+            _installed_name_for_source(agent, existing.agents, existing.agent_sources)
+            if existing
+            else None
+        )
+        effective_agent = existing_name or agent
+        owns_existing = existing_name is not None
 
-        dest_file = agent_dest / target.get_agent_filename(module.name, agent)
-        if dest_file.exists() and not force and not overwrite_all:
-            if not is_interactive():
+        dest_file = agent_dest / target.get_agent_filename(module.name, effective_agent)
+        if dest_file.exists() and not owns_existing and not force and not overwrite_all:
+            if prefix_all is not None:
+                effective_agent = f"{prefix_all}-{agent}"
+            elif not is_interactive():
                 failed.append(agent)
                 continue
-            action, new_name = prompt_agent_conflict(agent, module.name)
-            if action == "skip":
-                failed.append(agent)
-                continue
-            elif action == "rename":
-                effective_agent = new_name
-            elif action == "overwrite_all":
-                overwrite_all = True
+            else:
+                action, new_name = prompt_agent_conflict(agent, module.name)
+                if action == "skip":
+                    failed.append(agent)
+                    continue
+                elif action == "rename":
+                    effective_agent = new_name
+                elif action == "prefix_all":
+                    prefix_all = new_name  # user-chosen prefix
+                    effective_agent = f"{prefix_all}-{agent}"
+                elif action == "overwrite_all":
+                    overwrite_all = True
 
         if target.generate_agent(source, agent_dest, effective_agent, module.name):
             installed.append(effective_agent)
@@ -607,6 +681,10 @@ def install_to_assistant(
                 shutil.rmtree(local_module_path)
             raise
 
+    existing_installation = _existing_installation(
+        registry, module.name, assistant, scope, project_path
+    )
+
     installed_skills, failed_skills, skill_sources = _install_skills(
         target,
         module,
@@ -615,6 +693,7 @@ def install_to_assistant(
         scope,
         force,
         selected=selected_skills,
+        existing=existing_installation,
     )
     installed_commands, failed_commands, command_sources = _install_commands(
         target,
@@ -624,6 +703,7 @@ def install_to_assistant(
         force,
         scope,
         selected=selected_commands,
+        existing=existing_installation,
     )
     installed_agents, failed_agents, agent_sources = _install_agents(
         target,
@@ -633,6 +713,7 @@ def install_to_assistant(
         force,
         scope,
         selected=selected_agents,
+        existing=existing_installation,
     )
     installed_mcps, failed_mcps, mcp_sources = _install_mcps(
         target,
@@ -671,7 +752,7 @@ def install_to_assistant(
         or installed_mcps
         or instructions_installed
     ):
-        registry.add(
+        registry.upsert_installation(
             Installation(
                 module_name=module.name,
                 assistant=assistant,
@@ -688,7 +769,8 @@ def install_to_assistant(
                 has_instructions=instructions_installed,
                 append_context=append_context,
                 full_install=full_install,
-            )
+            ),
+            cache_path=local_module_path,
         )
 
     if post_install_script:
@@ -737,6 +819,11 @@ def _uninstall_skills(
     path_context = inst.project_path or ""
     scope = inst.scope
     skill_dest = target.get_skill_path(path_context, scope)
+
+    if target.uses_managed_section:
+        if target.remove_skill(skill_dest, inst.module_name):
+            return list(inst.skills), []
+        return [], list(inst.skills)
 
     for skill in inst.skills:
         if target.remove_skill(skill_dest, skill):
@@ -884,23 +971,8 @@ def _print_uninstall_summary(
             console.print("    [dim]- instructions[/dim]")
 
 
-def uninstall_from_assistant(
-    inst: Installation,
-    registry: InstallationRegistry,
-    verbose: bool = False,
-    local_modules: Optional[Path] = None,
-) -> int:
-    """Uninstall module from a specific assistant.
-
-    Args:
-        inst: Installation record describing what to remove
-        registry: Registry to remove installation from
-        verbose: Print detailed output
-        local_modules: Optional path to local modules directory for cleanup
-
-    Returns:
-        Count of items removed
-    """
+def uninstall_assistant_outputs(inst: Installation, verbose: bool = False) -> int:
+    """Remove assistant-owned files for one installation."""
     # Late import to avoid circular imports
     from lola.targets import get_target
 
@@ -923,17 +995,6 @@ def uninstall_from_assistant(
         verbose,
     )
 
-    # Clean up local module copy if requested
-    if local_modules:
-        source_module = local_modules / inst.module_name
-        if source_module.is_symlink():
-            source_module.unlink()
-        elif source_module.exists():
-            shutil.rmtree(source_module)
-
-    # Remove from registry
-    registry.remove(inst.module_name, inst.assistant)
-
     return (
         len(removed_skills)
         + len(removed_commands)
@@ -941,3 +1002,28 @@ def uninstall_from_assistant(
         + len(removed_mcps)
         + (1 if instructions_removed else 0)
     )
+
+
+def uninstall_from_assistant(
+    inst: Installation,
+    registry: InstallationRegistry,
+    verbose: bool = False,
+    local_modules: Optional[Path] = None,
+) -> int:
+    """Compatibility wrapper for uninstalling one assistant installation."""
+    removed = uninstall_assistant_outputs(inst, verbose)
+    plan = registry.remove_installation(InstallationKey.from_installation(inst))
+
+    # Older callers could pass an explicit local_modules path. Prefer the v2
+    # registry plan, but honor the legacy argument when the registry has no
+    # cache metadata for this installation.
+    cache_paths = plan.cache_paths_to_remove
+    if local_modules and not cache_paths:
+        cache_paths = [local_modules / inst.module_name]
+    for source_module in cache_paths:
+        if source_module.is_symlink():
+            source_module.unlink()
+        elif source_module.exists():
+            shutil.rmtree(source_module)
+
+    return removed

--- a/src/lola/targets/install.py
+++ b/src/lola/targets/install.py
@@ -17,13 +17,17 @@ import subprocess  # nosec B404 - required for running install hook scripts
 from pathlib import Path
 from typing import Optional, cast
 
-import click
 from rich.console import Console
 
 import lola.config as config
 from lola.exceptions import InstallationError
 from lola.models import Installation, InstallationRegistry, Module
-from lola.prompts import is_interactive, prompt_agent_conflict, prompt_command_conflict
+from lola.prompts import (
+    is_interactive,
+    prompt_agent_conflict,
+    prompt_command_conflict,
+    prompt_skill_conflict,
+)
 
 from .base import (
     AssistantTarget,
@@ -238,29 +242,26 @@ def _install_skills(
                 skill_dest, module.name, batch_skills, project_path
             )
     else:
+        overwrite_all = False
         for skill in skills_to_install:
             source = _skill_source_dir(local_module_path, skill, content_dirname)
             skill_name = skill  # Use unprefixed name by default
 
-            # Check if skill already exists
             if _check_skill_exists(target, skill_name, project_path, scope):
-                if force:
-                    # Force mode: overwrite without prompting
+                if force or overwrite_all:
                     pass
-                elif click.confirm(
-                    f"Skill '{skill_name}' already exists. Overwrite?", default=False
-                ):
-                    # User chose to overwrite
-                    pass
-                elif click.confirm(
-                    f"Use prefixed name '{module.name}_{skill}' instead?", default=True
-                ):
-                    # User chose to use prefixed name
-                    skill_name = f"{module.name}_{skill}"
-                else:
-                    # User declined both options, skip this skill
-                    console.print(f"  [yellow]Skipped {skill}[/yellow]")
+                elif not is_interactive():
+                    failed.append(skill)
                     continue
+                else:
+                    action, new_name = prompt_skill_conflict(skill, module.name)
+                    if action == "skip":
+                        console.print(f"  [yellow]Skipped {skill}[/yellow]")
+                        continue
+                    elif action == "rename":
+                        skill_name = new_name
+                    elif action == "overwrite_all":
+                        overwrite_all = True
 
             if target.generate_skill(source, skill_dest, skill_name, project_path):
                 installed.append(skill_name)
@@ -295,12 +296,13 @@ def _install_commands(
     content_dirname = _get_content_dirname(module)
     content_path = _get_content_path(local_module_path, content_dirname)
     commands_dir = content_path / "commands"
+    overwrite_all = False
     for cmd in commands_to_install:
         source = commands_dir / f"{cmd}.md"
         effective_cmd = cmd
 
         dest_file = command_dest / target.get_command_filename(module.name, cmd)
-        if dest_file.exists() and not force:
+        if dest_file.exists() and not force and not overwrite_all:
             if not is_interactive():
                 failed.append(cmd)
                 continue
@@ -310,6 +312,8 @@ def _install_commands(
                 continue
             elif action == "rename":
                 effective_cmd = new_name
+            elif action == "overwrite_all":
+                overwrite_all = True
 
         if target.generate_command(source, command_dest, effective_cmd, module.name):
             installed.append(effective_cmd)
@@ -349,12 +353,13 @@ def _install_agents(
     content_dirname = _get_content_dirname(module)
     content_path = _get_content_path(local_module_path, content_dirname)
     agents_dir = content_path / "agents"
+    overwrite_all = False
     for agent in agents_to_install:
         source = agents_dir / f"{agent}.md"
         effective_agent = agent
 
         dest_file = agent_dest / target.get_agent_filename(module.name, agent)
-        if dest_file.exists() and not force:
+        if dest_file.exists() and not force and not overwrite_all:
             if not is_interactive():
                 failed.append(agent)
                 continue
@@ -364,6 +369,8 @@ def _install_agents(
                 continue
             elif action == "rename":
                 effective_agent = new_name
+            elif action == "overwrite_all":
+                overwrite_all = True
 
         if target.generate_agent(source, agent_dest, effective_agent, module.name):
             installed.append(effective_agent)
@@ -553,14 +560,18 @@ def install_to_assistant(
     selected_commands: set[str] | None = None,
     selected_agents: set[str] | None = None,
     selected_mcps: set[str] | None = None,
+    selected_instructions: bool | None = None,
 ) -> int:
     """Install module to a specific assistant.
 
-    When all four ``selected_*`` arguments are ``None``, every item in the
+    When all ``selected_*`` arguments are ``None``, every item in the
     module is installed (the historical default). Passing any non-``None``
-    set marks this as a cherry-picked install and stamps
+    value marks this as a cherry-picked install and stamps
     ``Installation.full_install = False`` so subsequent updates lock to the
-    original selection.
+    original selection. ``selected_instructions`` is a tristate:
+    ``None`` (full install — install if module has instructions),
+    ``True`` (cherry-pick: install instructions),
+    ``False`` (cherry-pick: skip instructions).
     """
     # Late import to avoid circular imports - get_target is defined in __init__.py
     from lola.targets import get_target
@@ -571,7 +582,13 @@ def install_to_assistant(
 
     full_install = all(
         s is None
-        for s in (selected_skills, selected_commands, selected_agents, selected_mcps)
+        for s in (
+            selected_skills,
+            selected_commands,
+            selected_agents,
+            selected_mcps,
+            selected_instructions,
+        )
     )
 
     if pre_install_script:
@@ -625,9 +642,12 @@ def install_to_assistant(
         scope,
         selected=selected_mcps,
     )
-    instructions_installed = _install_instructions(
-        target, module, local_module_path, project_path, append_context, scope
-    )
+    if selected_instructions is False:
+        instructions_installed = False
+    else:
+        instructions_installed = _install_instructions(
+            target, module, local_module_path, project_path, append_context, scope
+        )
 
     _print_summary(
         assistant,

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -875,7 +875,7 @@ class TestInstallCmdInteractive:
             ) as mock_select,
         ):
             mock_registry.return_value = InstallationRegistry(installed_file)
-            result = cli_runner.invoke(install_cmd, ["sample-module"])
+            result = cli_runner.invoke(install_cmd, ["sample-module", "-y"])
 
         assert result.exit_code == 0
         mock_select.assert_called_once()
@@ -900,7 +900,7 @@ class TestInstallCmdInteractive:
         ):
             mock_registry.return_value = InstallationRegistry(installed_file)
             result = cli_runner.invoke(
-                install_cmd, ["sample-module", "-a", "claude-code"]
+                install_cmd, ["sample-module", "-a", "claude-code", "-y"]
             )
 
         assert result.exit_code == 0
@@ -925,7 +925,7 @@ class TestInstallCmdInteractive:
             patch("lola.cli.install.select_assistants", return_value=[]),
         ):
             mock_registry.return_value = InstallationRegistry(installed_file)
-            result = cli_runner.invoke(install_cmd, ["sample-module"])
+            result = cli_runner.invoke(install_cmd, ["sample-module", "-y"])
 
         assert result.exit_code == 130
         mock_install.assert_not_called()

--- a/tests/test_cli_install_cherry_pick.py
+++ b/tests/test_cli_install_cherry_pick.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 from lola.cli.install import _expand_csv, install_cmd, update_cmd
 from lola.models import Installation, InstallationRegistry
-from lola.prompts import select_module_items
+from lola.prompts import select_install_mode, select_module_items
 
 
 class TestExpandCsv:
@@ -34,6 +34,36 @@ class TestExpandCsv:
 
 
 class TestSelectModuleItems:
+    def test_install_mode_all(self):
+        from unittest.mock import MagicMock
+
+        mock_prompt = MagicMock()
+        mock_prompt.execute.return_value = "all"
+        with patch("lola.prompts.inquirer.select", return_value=mock_prompt):
+            result = select_install_mode()
+
+        assert result == "all"
+
+    def test_install_mode_cherry_pick(self):
+        from unittest.mock import MagicMock
+
+        mock_prompt = MagicMock()
+        mock_prompt.execute.return_value = "cherry-pick"
+        with patch("lola.prompts.inquirer.select", return_value=mock_prompt):
+            result = select_install_mode()
+
+        assert result == "cherry-pick"
+
+    def test_install_mode_cancel_returns_none(self):
+        from unittest.mock import MagicMock
+
+        mock_prompt = MagicMock()
+        mock_prompt.execute.return_value = None
+        with patch("lola.prompts.inquirer.select", return_value=mock_prompt):
+            result = select_install_mode()
+
+        assert result is None
+
     def test_alt_a_select_all_returns_full_lists(self):
         """After Alt-A toggles everything on, the prompt returns every value."""
         from unittest.mock import MagicMock
@@ -89,6 +119,26 @@ class TestSelectModuleItems:
                 skills=["foo"], commands=[], agents=[], mcps=[]
             )
         assert result is None
+
+    def test_empty_selection_returns_empty_items(self):
+        from unittest.mock import MagicMock
+
+        mock_prompt = MagicMock()
+        mock_prompt.execute.return_value = []
+        with patch("lola.prompts.inquirer.fuzzy", return_value=mock_prompt):
+            result = select_module_items(
+                skills=["foo"],
+                commands=["c1"],
+                agents=["a1"],
+                mcps=["m1"],
+            )
+
+        assert result == {
+            "skills": [],
+            "commands": [],
+            "agents": [],
+            "mcps": [],
+        }
 
 
 class TestInstallationFullInstallField:
@@ -184,6 +234,7 @@ class TestInstallFlagPicker:
                 "lola.cli.install.install_to_assistant", return_value=1
             ) as mock_install,
             patch("lola.cli.install.is_interactive", return_value=True),
+            patch("lola.cli.install.select_install_mode") as mock_mode,
             patch("lola.cli.install.select_module_items") as mock_picker,
         ):
             mock_registry.return_value = InstallationRegistry(installed_file)
@@ -192,11 +243,80 @@ class TestInstallFlagPicker:
             )
 
         assert result.exit_code == 0
+        mock_mode.assert_not_called()
         mock_picker.assert_not_called()
         kwargs = mock_install.call_args.kwargs
         assert kwargs["selected_skills"] is None  # full install
         assert kwargs["selected_commands"] is None
         assert kwargs["selected_agents"] is None
+
+    def test_interactive_all_mode_installs_everything_without_picker(
+        self, cli_runner, sample_module, tmp_path
+    ):
+        modules_dir, installed_file = self._setup(tmp_path, sample_module)
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry") as mock_registry,
+            patch("lola.cli.install.get_local_modules_path", return_value=modules_dir),
+            patch(
+                "lola.cli.install.install_to_assistant", return_value=1
+            ) as mock_install,
+            patch("lola.cli.install.is_interactive", return_value=True),
+            patch("lola.cli.install.select_install_mode", return_value="all"),
+            patch("lola.cli.install.select_module_items") as mock_picker,
+        ):
+            mock_registry.return_value = InstallationRegistry(installed_file)
+            result = cli_runner.invoke(
+                install_cmd, ["sample-module", "-a", "claude-code"]
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_picker.assert_not_called()
+        kwargs = mock_install.call_args.kwargs
+        assert kwargs["selected_skills"] is None
+        assert kwargs["selected_commands"] is None
+        assert kwargs["selected_agents"] is None
+        assert kwargs["selected_mcps"] is None
+
+    def test_interactive_cherry_pick_mode_opens_item_picker(
+        self, cli_runner, sample_module, tmp_path
+    ):
+        modules_dir, installed_file = self._setup(tmp_path, sample_module)
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry") as mock_registry,
+            patch("lola.cli.install.get_local_modules_path", return_value=modules_dir),
+            patch(
+                "lola.cli.install.install_to_assistant", return_value=1
+            ) as mock_install,
+            patch("lola.cli.install.is_interactive", return_value=True),
+            patch("lola.cli.install.select_install_mode", return_value="cherry-pick"),
+            patch(
+                "lola.cli.install.select_module_items",
+                return_value={
+                    "skills": ["skill1"],
+                    "commands": [],
+                    "agents": [],
+                    "mcps": [],
+                },
+            ) as mock_picker,
+        ):
+            mock_registry.return_value = InstallationRegistry(installed_file)
+            result = cli_runner.invoke(
+                install_cmd, ["sample-module", "-a", "claude-code"]
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_picker.assert_called_once()
+        kwargs = mock_install.call_args.kwargs
+        assert kwargs["selected_skills"] == {"skill1"}
+        assert kwargs["selected_commands"] == set()
+        assert kwargs["selected_agents"] == set()
+        assert kwargs["selected_mcps"] == set()
 
     def test_skill_flag_filters_other_categories_to_empty(
         self, cli_runner, sample_module, tmp_path
@@ -513,6 +633,198 @@ class TestUpdateLockToSelection:
         updated_inst = registry.find("rename-module")[0]
         assert updated_inst.commands == ["ship"]
         assert updated_inst.command_sources == {"ship": "deploy"}
+
+    def test_update_preserves_identity_and_renamed_cherry_pick_after_reload(
+        self, cli_runner, tmp_path
+    ):
+        """Compact source maps must not make update drop identity-mapped picks."""
+        modules_dir = tmp_path / ".lola" / "modules"
+        commands_dir = modules_dir / "mixed-module" / "commands"
+        commands_dir.mkdir(parents=True)
+        (commands_dir / "keep.md").write_text(
+            "---\ndescription: Keep things\n---\n\n# Keep\n"
+        )
+        (commands_dir / "deploy.md").write_text(
+            "---\ndescription: Deploy things\n---\n\n# Deploy\n"
+        )
+        (commands_dir / "new.md").write_text(
+            "---\ndescription: New things\n---\n\n# New\n"
+        )
+
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        project_path = tmp_path / "project"
+        project_path.mkdir()
+        registry = InstallationRegistry(installed_file)
+        registry.add(
+            Installation(
+                module_name="mixed-module",
+                assistant="claude-code",
+                scope="project",
+                project_path=str(project_path),
+                commands=["keep", "ship"],
+                command_sources={"keep": "keep", "ship": "deploy"},
+                full_install=False,
+            )
+        )
+        registry = InstallationRegistry(installed_file)
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry", return_value=registry),
+            patch("lola.cli.install.get_local_modules_path", return_value=modules_dir),
+            patch(
+                "lola.cli.install.copy_module_to_local",
+                return_value=modules_dir / "mixed-module",
+            ),
+        ):
+            from lola.targets import claude_code
+
+            with (
+                patch.object(
+                    claude_code.ClaudeCodeTarget, "generate_command", return_value=True
+                ) as gen_command,
+                patch.object(
+                    claude_code.ClaudeCodeTarget,
+                    "generate_instructions",
+                    return_value=False,
+                ),
+            ):
+                result = cli_runner.invoke(update_cmd, ["mixed-module"])
+
+        assert result.exit_code == 0, result.output
+        assert {c.args[0].name for c in gen_command.call_args_list} == {
+            "keep.md",
+            "deploy.md",
+        }
+        assert {c.args[2] for c in gen_command.call_args_list} == {"keep", "ship"}
+
+        updated_inst = registry.find("mixed-module")[0]
+        assert set(updated_inst.commands) == {"keep", "ship"}
+        assert updated_inst.command_sources == {"keep": "keep", "ship": "deploy"}
+
+    def test_full_update_preserves_renamed_command_registry_name_after_reload(
+        self, cli_runner, tmp_path
+    ):
+        """Full command updates should store installed names, not source names."""
+        modules_dir = tmp_path / ".lola" / "modules"
+        commands_dir = modules_dir / "full-rename-module" / "commands"
+        commands_dir.mkdir(parents=True)
+        (commands_dir / "deploy.md").write_text(
+            "---\ndescription: Deploy things\n---\n\n# Deploy\n"
+        )
+        (commands_dir / "status.md").write_text(
+            "---\ndescription: Check status\n---\n\n# Status\n"
+        )
+
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        project_path = tmp_path / "project"
+        project_path.mkdir()
+        registry = InstallationRegistry(installed_file)
+        registry.add(
+            Installation(
+                module_name="full-rename-module",
+                assistant="claude-code",
+                scope="project",
+                project_path=str(project_path),
+                commands=["ship", "status"],
+                command_sources={"ship": "deploy", "status": "status"},
+                full_install=True,
+            )
+        )
+        registry = InstallationRegistry(installed_file)
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry", return_value=registry),
+            patch("lola.cli.install.get_local_modules_path", return_value=modules_dir),
+            patch(
+                "lola.cli.install.copy_module_to_local",
+                return_value=modules_dir / "full-rename-module",
+            ),
+        ):
+            from lola.targets import claude_code
+
+            with (
+                patch.object(
+                    claude_code.ClaudeCodeTarget, "generate_command", return_value=True
+                ),
+                patch.object(
+                    claude_code.ClaudeCodeTarget,
+                    "generate_instructions",
+                    return_value=False,
+                ),
+            ):
+                result = cli_runner.invoke(update_cmd, ["full-rename-module"])
+
+        assert result.exit_code == 0, result.output
+        updated_inst = registry.find("full-rename-module")[0]
+        assert set(updated_inst.commands) == {"ship", "status"}
+        assert updated_inst.command_sources == {"ship": "deploy", "status": "status"}
+
+    def test_full_update_preserves_renamed_agent_registry_name_after_reload(
+        self, cli_runner, tmp_path
+    ):
+        """Full agent updates should store installed names, not source names."""
+        modules_dir = tmp_path / ".lola" / "modules"
+        agents_dir = modules_dir / "full-agent-module" / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "reviewer.md").write_text(
+            "---\ndescription: Review code\n---\n\n# Reviewer\n"
+        )
+        (agents_dir / "helper.md").write_text(
+            "---\ndescription: Help with work\n---\n\n# Helper\n"
+        )
+
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        project_path = tmp_path / "project"
+        project_path.mkdir()
+        registry = InstallationRegistry(installed_file)
+        registry.add(
+            Installation(
+                module_name="full-agent-module",
+                assistant="claude-code",
+                scope="project",
+                project_path=str(project_path),
+                agents=["code-reviewer", "helper"],
+                agent_sources={"code-reviewer": "reviewer", "helper": "helper"},
+                full_install=True,
+            )
+        )
+        registry = InstallationRegistry(installed_file)
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry", return_value=registry),
+            patch("lola.cli.install.get_local_modules_path", return_value=modules_dir),
+            patch(
+                "lola.cli.install.copy_module_to_local",
+                return_value=modules_dir / "full-agent-module",
+            ),
+        ):
+            from lola.targets import claude_code
+
+            with (
+                patch.object(
+                    claude_code.ClaudeCodeTarget, "generate_agent", return_value=True
+                ),
+                patch.object(
+                    claude_code.ClaudeCodeTarget,
+                    "generate_instructions",
+                    return_value=False,
+                ),
+            ):
+                result = cli_runner.invoke(update_cmd, ["full-agent-module"])
+
+        assert result.exit_code == 0, result.output
+        updated_inst = registry.find("full-agent-module")[0]
+        assert set(updated_inst.agents) == {"code-reviewer", "helper"}
+        assert updated_inst.agent_sources == {
+            "code-reviewer": "reviewer",
+            "helper": "helper",
+        }
 
     def test_full_update_preserves_agents_when_target_skips_them(
         self, cli_runner, tmp_path

--- a/tests/test_cli_install_cherry_pick.py
+++ b/tests/test_cli_install_cherry_pick.py
@@ -34,12 +34,18 @@ class TestExpandCsv:
 
 
 class TestSelectModuleItems:
-    def test_empty_selection_returns_full_lists(self):
-        """Submitting with nothing toggled means 'install everything'."""
+    def test_alt_a_select_all_returns_full_lists(self):
+        """After Alt-A toggles everything on, the prompt returns every value."""
         from unittest.mock import MagicMock
 
         mock_prompt = MagicMock()
-        mock_prompt.execute.return_value = []
+        mock_prompt.execute.return_value = [
+            "skill:foo",
+            "skill:bar",
+            "cmd:c1",
+            "agent:a1",
+            "mcp:m1",
+        ]
         with patch("lola.prompts.inquirer.fuzzy", return_value=mock_prompt):
             result = select_module_items(
                 skills=["foo", "bar"],

--- a/tests/test_cli_install_cherry_pick.py
+++ b/tests/test_cli_install_cherry_pick.py
@@ -293,6 +293,67 @@ class TestSelectModuleItems:
         assert "(installed)" not in choices[0].name
         assert "(new)" not in choices[0].name
 
+    def test_picker_fresh_install_pre_selects_every_item(self):
+        """Fresh install (current=None) should pre-select all items so Enter
+        installs everything by default; users deselect what they don't want."""
+        from unittest.mock import MagicMock
+
+        mock_prompt = MagicMock()
+        mock_prompt.execute.return_value = []
+        with patch(
+            "lola.prompts.inquirer.fuzzy", return_value=mock_prompt
+        ) as mock_fuzzy:
+            select_module_items(
+                skills=["foo", "bar"],
+                commands=["c1"],
+                agents=["a1"],
+                mcps=["m1"],
+                has_instructions=True,
+            )
+
+        choices = mock_fuzzy.call_args.kwargs["choices"]
+        assert all(c.enabled is True for c in choices), [
+            (c.value, c.enabled) for c in choices
+        ]
+
+    def test_picker_uses_inquirerpy_defaults_for_keybindings(self):
+        """No custom `keybindings` are passed — we rely on InquirerPy's
+        built-in Alt-A/Ctrl-A (select-all) and Alt-R/Ctrl-R (invert).
+
+        We deliberately do NOT bind ``toggle-all-false`` because InquirerPy's
+        fuzzy ``_handle_toggle_all`` treats ``False`` as falsy and inverts
+        instead of clearing (prompts/fuzzy.py: ``value if value else
+        not enabled``). Pre-selecting everything + invert covers the
+        clear-all case on a fresh install.
+        """
+        from unittest.mock import MagicMock
+
+        mock_prompt = MagicMock()
+        mock_prompt.execute.return_value = []
+        with patch(
+            "lola.prompts.inquirer.fuzzy", return_value=mock_prompt
+        ) as mock_fuzzy:
+            select_module_items(skills=["foo"], commands=[], agents=[], mcps=[])
+
+        assert "keybindings" not in mock_fuzzy.call_args.kwargs
+
+    def test_picker_surfaces_top_instruction_with_shortcuts(self):
+        """The fuzzy prompt receives an `instruction` string that names the
+        primary shortcuts so users see them at the top of the prompt."""
+        from unittest.mock import MagicMock
+
+        mock_prompt = MagicMock()
+        mock_prompt.execute.return_value = []
+        with patch(
+            "lola.prompts.inquirer.fuzzy", return_value=mock_prompt
+        ) as mock_fuzzy:
+            select_module_items(skills=["foo"], commands=[], agents=[], mcps=[])
+
+        instruction = mock_fuzzy.call_args.kwargs.get("instruction", "")
+        # Mentions select-all and invert (the working built-in shortcuts).
+        assert "^A" in instruction or "Ctrl-A" in instruction
+        assert "^R" in instruction or "Ctrl-R" in instruction
+
 
 class TestInstallationFullInstallField:
     """The Installation dataclass gained a full_install flag that defaults to True."""

--- a/tests/test_cli_install_cherry_pick.py
+++ b/tests/test_cli_install_cherry_pick.py
@@ -4,6 +4,7 @@ flags, the interactive picker, and lock-to-original-selection on update.
 
 from __future__ import annotations
 
+import json
 import shutil
 from unittest.mock import patch
 
@@ -443,3 +444,158 @@ class TestUpdateLockToSelection:
         assert result.exit_code == 0, result.output
         called_names = [c.args[2] for c in gen_skill.call_args_list]
         assert set(called_names) == {"skill1", "new-skill"}, called_names
+
+    def test_update_preserves_renamed_cherry_picked_command(self, cli_runner, tmp_path):
+        """A renamed cherry-picked command tracks source and installed names."""
+        modules_dir = tmp_path / ".lola" / "modules"
+        commands_dir = modules_dir / "rename-module" / "commands"
+        commands_dir.mkdir(parents=True)
+        (commands_dir / "deploy.md").write_text(
+            "---\ndescription: Deploy things\n---\n\n# Deploy\n"
+        )
+        (commands_dir / "status.md").write_text(
+            "---\ndescription: Check status\n---\n\n# Status\n"
+        )
+
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        project_path = tmp_path / "project"
+        project_path.mkdir()
+        registry = InstallationRegistry(installed_file)
+        registry.add(
+            Installation(
+                module_name="rename-module",
+                assistant="claude-code",
+                scope="project",
+                project_path=str(project_path),
+                skills=[],
+                commands=["ship"],
+                command_sources={"ship": "deploy"},
+                agents=[],
+                mcps=[],
+                full_install=False,
+            )
+        )
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry", return_value=registry),
+            patch("lola.cli.install.get_local_modules_path", return_value=modules_dir),
+            patch(
+                "lola.targets.install.copy_module_to_local",
+                return_value=modules_dir / "rename-module",
+            ),
+            patch(
+                "lola.cli.install.copy_module_to_local",
+                return_value=modules_dir / "rename-module",
+            ),
+        ):
+            from lola.targets import claude_code
+
+            with (
+                patch.object(
+                    claude_code.ClaudeCodeTarget, "generate_command", return_value=True
+                ) as gen_command,
+                patch.object(
+                    claude_code.ClaudeCodeTarget,
+                    "generate_instructions",
+                    return_value=False,
+                ),
+            ):
+                result = cli_runner.invoke(update_cmd, ["rename-module"])
+
+        assert result.exit_code == 0, result.output
+        assert [c.args[0].name for c in gen_command.call_args_list] == ["deploy.md"]
+        assert [c.args[2] for c in gen_command.call_args_list] == ["ship"]
+
+        updated_inst = registry.find("rename-module")[0]
+        assert updated_inst.commands == ["ship"]
+        assert updated_inst.command_sources == {"ship": "deploy"}
+
+    def test_full_update_preserves_agents_when_target_skips_them(
+        self, cli_runner, tmp_path
+    ):
+        """A full install keeps registered agents if the target cannot update them."""
+        modules_dir = tmp_path / ".lola" / "modules"
+        agents_dir = modules_dir / "agent-module" / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "agent1.md").write_text(
+            "---\ndescription: A test agent\n---\n\n# Agent\n"
+        )
+
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        project_path = tmp_path / "project"
+        project_path.mkdir()
+        registry = InstallationRegistry(installed_file)
+        registry.add(
+            Installation(
+                module_name="agent-module",
+                assistant="gemini-cli",
+                scope="project",
+                project_path=str(project_path),
+                agents=["agent1"],
+                agent_sources={"agent1": "agent1"},
+                full_install=True,
+            )
+        )
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry", return_value=registry),
+            patch("lola.cli.install.get_local_modules_path", return_value=modules_dir),
+            patch(
+                "lola.cli.install.copy_module_to_local",
+                return_value=modules_dir / "agent-module",
+            ),
+        ):
+            result = cli_runner.invoke(update_cmd, ["agent-module"])
+
+        assert result.exit_code == 0, result.output
+        updated_inst = registry.find("agent-module")[0]
+        assert updated_inst.agents == ["agent1"]
+        assert updated_inst.agent_sources == {"agent1": "agent1"}
+
+    def test_full_update_preserves_mcps_when_target_skips_them(
+        self, cli_runner, tmp_path
+    ):
+        """A full install keeps registered MCPs if the target cannot update them."""
+        modules_dir = tmp_path / ".lola" / "modules"
+        module_dir = modules_dir / "mcp-module"
+        module_dir.mkdir(parents=True)
+        (module_dir / "mcps.json").write_text(
+            json.dumps({"mcpServers": {"github": {"command": "npx", "args": []}}})
+        )
+
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        project_path = tmp_path / "project"
+        project_path.mkdir()
+        registry = InstallationRegistry(installed_file)
+        registry.add(
+            Installation(
+                module_name="mcp-module",
+                assistant="openclaw",
+                scope="project",
+                project_path=str(project_path),
+                mcps=["github"],
+                mcp_sources={"github": "github"},
+                full_install=True,
+            )
+        )
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry", return_value=registry),
+            patch("lola.cli.install.get_local_modules_path", return_value=modules_dir),
+            patch(
+                "lola.cli.install.copy_module_to_local",
+                return_value=module_dir,
+            ),
+        ):
+            result = cli_runner.invoke(update_cmd, ["mcp-module"])
+
+        assert result.exit_code == 0, result.output
+        updated_inst = registry.find("mcp-module")[0]
+        assert updated_inst.mcps == ["github"]
+        assert updated_inst.mcp_sources == {"github": "github"}

--- a/tests/test_cli_install_cherry_pick.py
+++ b/tests/test_cli_install_cherry_pick.py
@@ -34,17 +34,13 @@ class TestExpandCsv:
 
 
 class TestSelectModuleItems:
-    def test_keep_all_returns_full_lists(self):
-        """When the All token is selected, every list is returned in full.
-
-        Leaving the 'All' token selected accepts every item
-        regardless of which individual entries the user happened to toggle.
-        """
+    def test_empty_selection_returns_full_lists(self):
+        """Submitting with nothing toggled means 'install everything'."""
         from unittest.mock import MagicMock
 
         mock_prompt = MagicMock()
-        mock_prompt.execute.return_value = ["__all__", "skill:foo"]
-        with patch("lola.prompts.inquirer.checkbox", return_value=mock_prompt):
+        mock_prompt.execute.return_value = []
+        with patch("lola.prompts.inquirer.fuzzy", return_value=mock_prompt):
             result = select_module_items(
                 skills=["foo", "bar"],
                 commands=["c1"],
@@ -63,7 +59,7 @@ class TestSelectModuleItems:
 
         mock_prompt = MagicMock()
         mock_prompt.execute.return_value = ["skill:foo", "cmd:c1"]
-        with patch("lola.prompts.inquirer.checkbox", return_value=mock_prompt):
+        with patch("lola.prompts.inquirer.fuzzy", return_value=mock_prompt):
             result = select_module_items(
                 skills=["foo", "bar"],
                 commands=["c1", "c2"],
@@ -82,7 +78,7 @@ class TestSelectModuleItems:
 
         mock_prompt = MagicMock()
         mock_prompt.execute.return_value = None
-        with patch("lola.prompts.inquirer.checkbox", return_value=mock_prompt):
+        with patch("lola.prompts.inquirer.fuzzy", return_value=mock_prompt):
             result = select_module_items(
                 skills=["foo"], commands=[], agents=[], mcps=[]
             )

--- a/tests/test_cli_install_cherry_pick.py
+++ b/tests/test_cli_install_cherry_pick.py
@@ -1,0 +1,445 @@
+"""Tests for cherry-pick install (issue #119): --skill/--command/--agent/--mcp
+flags, the interactive picker, and lock-to-original-selection on update.
+"""
+
+from __future__ import annotations
+
+import shutil
+from unittest.mock import patch
+
+from lola.cli.install import _expand_csv, install_cmd, update_cmd
+from lola.models import Installation, InstallationRegistry
+from lola.prompts import select_module_items
+
+
+class TestExpandCsv:
+    def test_empty_tuple(self):
+        assert _expand_csv(()) == []
+
+    def test_single_value(self):
+        assert _expand_csv(("foo",)) == ["foo"]
+
+    def test_multiple_repeats(self):
+        assert _expand_csv(("foo", "bar")) == ["foo", "bar"]
+
+    def test_comma_separated(self):
+        assert _expand_csv(("foo,bar,baz",)) == ["foo", "bar", "baz"]
+
+    def test_mixed_repeats_and_comma(self):
+        assert _expand_csv(("foo,bar", "baz")) == ["foo", "bar", "baz"]
+
+    def test_strips_whitespace_and_drops_empty(self):
+        assert _expand_csv(("  foo , , bar ",)) == ["foo", "bar"]
+
+
+class TestSelectModuleItems:
+    def test_keep_all_returns_full_lists(self):
+        """When the All token is selected, every list is returned in full.
+
+        Leaving the 'All' token selected accepts every item
+        regardless of which individual entries the user happened to toggle.
+        """
+        from unittest.mock import MagicMock
+
+        mock_prompt = MagicMock()
+        mock_prompt.execute.return_value = ["__all__", "skill:foo"]
+        with patch("lola.prompts.inquirer.checkbox", return_value=mock_prompt):
+            result = select_module_items(
+                skills=["foo", "bar"],
+                commands=["c1"],
+                agents=["a1"],
+                mcps=["m1"],
+            )
+        assert result == {
+            "skills": ["foo", "bar"],
+            "commands": ["c1"],
+            "agents": ["a1"],
+            "mcps": ["m1"],
+        }
+
+    def test_subset_selection(self):
+        from unittest.mock import MagicMock
+
+        mock_prompt = MagicMock()
+        mock_prompt.execute.return_value = ["skill:foo", "cmd:c1"]
+        with patch("lola.prompts.inquirer.checkbox", return_value=mock_prompt):
+            result = select_module_items(
+                skills=["foo", "bar"],
+                commands=["c1", "c2"],
+                agents=["a1"],
+                mcps=[],
+            )
+        assert result == {
+            "skills": ["foo"],
+            "commands": ["c1"],
+            "agents": [],
+            "mcps": [],
+        }
+
+    def test_cancel_returns_none(self):
+        from unittest.mock import MagicMock
+
+        mock_prompt = MagicMock()
+        mock_prompt.execute.return_value = None
+        with patch("lola.prompts.inquirer.checkbox", return_value=mock_prompt):
+            result = select_module_items(
+                skills=["foo"], commands=[], agents=[], mcps=[]
+            )
+        assert result is None
+
+
+class TestInstallationFullInstallField:
+    """The Installation dataclass gained a full_install flag that defaults to True."""
+
+    def test_defaults_to_full(self):
+        inst = Installation(module_name="m", assistant="claude-code", scope="project")
+        assert inst.full_install is True
+
+    def test_to_dict_omits_full_install_when_true(self):
+        inst = Installation(module_name="m", assistant="claude-code", scope="project")
+        assert "full_install" not in inst.to_dict()
+
+    def test_to_dict_emits_full_install_when_false(self):
+        inst = Installation(
+            module_name="m",
+            assistant="claude-code",
+            scope="project",
+            full_install=False,
+        )
+        assert inst.to_dict()["full_install"] is False
+
+    def test_from_dict_legacy_record_defaults_to_full(self):
+        """Existing installed.yml entries without the field load as full installs."""
+        inst = Installation.from_dict(
+            {"module": "m", "assistant": "claude-code", "scope": "project"}
+        )
+        assert inst.full_install is True
+
+    def test_round_trip_cherry_picked(self):
+        original = Installation(
+            module_name="m",
+            assistant="claude-code",
+            scope="project",
+            skills=["only-this-one"],
+            full_install=False,
+        )
+        roundtripped = Installation.from_dict(original.to_dict())
+        assert roundtripped.full_install is False
+        assert roundtripped.skills == ["only-this-one"]
+
+
+class TestInstallFlagPicker:
+    """Selection flags should drive install_to_assistant's selected_* params."""
+
+    def _setup(self, tmp_path, sample_module):
+        modules_dir = tmp_path / ".lola" / "modules"
+        modules_dir.mkdir(parents=True)
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        shutil.copytree(sample_module, modules_dir / "sample-module")
+        return modules_dir, installed_file
+
+    def test_no_flags_no_yes_in_noninteractive_installs_everything(
+        self, cli_runner, sample_module, tmp_path
+    ):
+        """Non-interactive + no flags: selected_* are all None (full install)."""
+        modules_dir, installed_file = self._setup(tmp_path, sample_module)
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry") as mock_registry,
+            patch("lola.cli.install.get_local_modules_path", return_value=modules_dir),
+            patch(
+                "lola.cli.install.install_to_assistant", return_value=1
+            ) as mock_install,
+            patch("lola.cli.install.is_interactive", return_value=False),
+        ):
+            mock_registry.return_value = InstallationRegistry(installed_file)
+            result = cli_runner.invoke(
+                install_cmd, ["sample-module", "-a", "claude-code"]
+            )
+
+        assert result.exit_code == 0
+        kwargs = mock_install.call_args.kwargs
+        assert kwargs["selected_skills"] is None
+        assert kwargs["selected_commands"] is None
+        assert kwargs["selected_agents"] is None
+        assert kwargs["selected_mcps"] is None
+
+    def test_yes_flag_skips_picker_in_interactive_mode(
+        self, cli_runner, sample_module, tmp_path
+    ):
+        """`-y` short-circuits the picker even when stdin is a TTY."""
+        modules_dir, installed_file = self._setup(tmp_path, sample_module)
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry") as mock_registry,
+            patch("lola.cli.install.get_local_modules_path", return_value=modules_dir),
+            patch(
+                "lola.cli.install.install_to_assistant", return_value=1
+            ) as mock_install,
+            patch("lola.cli.install.is_interactive", return_value=True),
+            patch("lola.cli.install.select_module_items") as mock_picker,
+        ):
+            mock_registry.return_value = InstallationRegistry(installed_file)
+            result = cli_runner.invoke(
+                install_cmd, ["sample-module", "-a", "claude-code", "-y"]
+            )
+
+        assert result.exit_code == 0
+        mock_picker.assert_not_called()
+        kwargs = mock_install.call_args.kwargs
+        assert kwargs["selected_skills"] is None  # full install
+        assert kwargs["selected_commands"] is None
+        assert kwargs["selected_agents"] is None
+
+    def test_skill_flag_filters_other_categories_to_empty(
+        self, cli_runner, sample_module, tmp_path
+    ):
+        """--skill with no --command means commands install nothing of that type.
+
+        sample_module has skill1, cmd1, agent1. Asking for `--skill skill1`
+        should plumb through as ``{skill1}`` for skills and an empty set for
+        each of commands/agents/mcps so they're not silently installed too.
+        """
+        modules_dir, installed_file = self._setup(tmp_path, sample_module)
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry") as mock_registry,
+            patch("lola.cli.install.get_local_modules_path", return_value=modules_dir),
+            patch(
+                "lola.cli.install.install_to_assistant", return_value=1
+            ) as mock_install,
+            patch("lola.cli.install.is_interactive", return_value=False),
+        ):
+            mock_registry.return_value = InstallationRegistry(installed_file)
+            result = cli_runner.invoke(
+                install_cmd,
+                ["sample-module", "-a", "claude-code", "--skill", "skill1"],
+            )
+
+        assert result.exit_code == 0, result.output
+        kwargs = mock_install.call_args.kwargs
+        assert kwargs["selected_skills"] == {"skill1"}
+        assert kwargs["selected_commands"] == set()
+        assert kwargs["selected_agents"] == set()
+        assert kwargs["selected_mcps"] == set()
+
+    def test_comma_separated_skill_flag(self, cli_runner, sample_module, tmp_path):
+        """`--skill foo,bar` is equivalent to `--skill foo --skill bar`."""
+        # Add a second skill for this test
+        modules_dir, installed_file = self._setup(tmp_path, sample_module)
+        skills_dir = modules_dir / "sample-module" / "skills"
+        (skills_dir / "skill2").mkdir()
+        (skills_dir / "skill2" / "SKILL.md").write_text(
+            "---\ndescription: A second test skill\n---\n\n# Skill 2\n"
+        )
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry") as mock_registry,
+            patch("lola.cli.install.get_local_modules_path", return_value=modules_dir),
+            patch(
+                "lola.cli.install.install_to_assistant", return_value=1
+            ) as mock_install,
+            patch("lola.cli.install.is_interactive", return_value=False),
+        ):
+            mock_registry.return_value = InstallationRegistry(installed_file)
+            result = cli_runner.invoke(
+                install_cmd,
+                [
+                    "sample-module",
+                    "-a",
+                    "claude-code",
+                    "--skill",
+                    "skill1,skill2",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        kwargs = mock_install.call_args.kwargs
+        assert kwargs["selected_skills"] == {"skill1", "skill2"}
+
+    def test_unknown_skill_name_errors(self, cli_runner, sample_module, tmp_path):
+        """Asking for a skill that the module doesn't expose is a hard error."""
+        modules_dir, installed_file = self._setup(tmp_path, sample_module)
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry") as mock_registry,
+            patch("lola.cli.install.get_local_modules_path", return_value=modules_dir),
+            patch("lola.cli.install.install_to_assistant", return_value=1),
+            patch("lola.cli.install.is_interactive", return_value=False),
+        ):
+            mock_registry.return_value = InstallationRegistry(installed_file)
+            result = cli_runner.invoke(
+                install_cmd,
+                ["sample-module", "-a", "claude-code", "--skill", "no-such-skill"],
+            )
+
+        assert result.exit_code == 1
+        assert "Unknown items" in result.output
+
+
+class TestUpdateLockToSelection:
+    """`lola update` must NOT silently expand a cherry-picked selection when the
+    upstream module gains new items. Items removed upstream are still cleaned up.
+    """
+
+    def test_update_skips_new_upstream_skill_for_cherry_pick(
+        self, cli_runner, sample_module, tmp_path
+    ):
+        """A cherry-picked install (full_install=False) locks to its skill list.
+
+        Set up an Installation that originally selected only "skill1", drop a
+        brand-new "skill2" into the source module, and confirm `lola update`
+        regenerates only skill1.
+        """
+        modules_dir = tmp_path / ".lola" / "modules"
+        modules_dir.mkdir(parents=True)
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        shutil.copytree(sample_module, modules_dir / "sample-module")
+
+        # Add an upstream skill that was NOT in the original selection.
+        skills_dir = modules_dir / "sample-module" / "skills"
+        (skills_dir / "new-skill").mkdir()
+        (skills_dir / "new-skill" / "SKILL.md").write_text(
+            "---\ndescription: A brand new upstream skill\n---\n\n# New\n"
+        )
+
+        # Pre-seed the registry with a cherry-picked install of just skill1.
+        project_path = tmp_path / "project"
+        project_path.mkdir()
+        registry = InstallationRegistry(installed_file)
+        registry.add(
+            Installation(
+                module_name="sample-module",
+                assistant="claude-code",
+                scope="project",
+                project_path=str(project_path),
+                skills=["skill1"],
+                commands=[],
+                agents=[],
+                mcps=[],
+                full_install=False,
+            )
+        )
+
+        # Stub out the file-generating side of update: we only care about which
+        # names get fed to it.
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry", return_value=registry),
+            patch("lola.cli.install.get_local_modules_path", return_value=modules_dir),
+            patch(
+                "lola.targets.install.copy_module_to_local",
+                return_value=modules_dir / "sample-module",
+            ),
+            patch(
+                "lola.cli.install.copy_module_to_local",
+                return_value=modules_dir / "sample-module",
+            ),
+        ):
+            # Patch the actual generation methods on the AssistantTarget the
+            # update flow obtains from the registry.
+            from lola.targets import claude_code
+
+            with (
+                patch.object(
+                    claude_code.ClaudeCodeTarget, "generate_skill", return_value=True
+                ) as gen_skill,
+                patch.object(
+                    claude_code.ClaudeCodeTarget, "generate_command", return_value=True
+                ),
+                patch.object(
+                    claude_code.ClaudeCodeTarget, "generate_agent", return_value=True
+                ),
+                patch.object(
+                    claude_code.ClaudeCodeTarget,
+                    "generate_instructions",
+                    return_value=False,
+                ),
+            ):
+                result = cli_runner.invoke(update_cmd, ["sample-module"])
+
+        assert result.exit_code == 0, result.output
+        # generate_skill should have been called for skill1 only.
+        called_names = [c.args[2] for c in gen_skill.call_args_list]
+        assert called_names == ["skill1"], called_names
+
+    def test_update_full_install_picks_up_new_upstream_skill(
+        self, cli_runner, sample_module, tmp_path
+    ):
+        """A full install (full_install=True) does pick up new upstream skills."""
+        modules_dir = tmp_path / ".lola" / "modules"
+        modules_dir.mkdir(parents=True)
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        shutil.copytree(sample_module, modules_dir / "sample-module")
+
+        skills_dir = modules_dir / "sample-module" / "skills"
+        (skills_dir / "new-skill").mkdir()
+        (skills_dir / "new-skill" / "SKILL.md").write_text(
+            "---\ndescription: A brand new upstream skill\n---\n\n# New\n"
+        )
+
+        project_path = tmp_path / "project"
+        project_path.mkdir()
+        registry = InstallationRegistry(installed_file)
+        registry.add(
+            Installation(
+                module_name="sample-module",
+                assistant="claude-code",
+                scope="project",
+                project_path=str(project_path),
+                skills=["skill1"],
+                commands=[],
+                agents=[],
+                mcps=[],
+                full_install=True,  # original install was full, not cherry-picked
+            )
+        )
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry", return_value=registry),
+            patch("lola.cli.install.get_local_modules_path", return_value=modules_dir),
+            patch(
+                "lola.targets.install.copy_module_to_local",
+                return_value=modules_dir / "sample-module",
+            ),
+            patch(
+                "lola.cli.install.copy_module_to_local",
+                return_value=modules_dir / "sample-module",
+            ),
+        ):
+            from lola.targets import claude_code
+
+            with (
+                patch.object(
+                    claude_code.ClaudeCodeTarget, "generate_skill", return_value=True
+                ) as gen_skill,
+                patch.object(
+                    claude_code.ClaudeCodeTarget, "generate_command", return_value=True
+                ),
+                patch.object(
+                    claude_code.ClaudeCodeTarget, "generate_agent", return_value=True
+                ),
+                patch.object(
+                    claude_code.ClaudeCodeTarget,
+                    "generate_instructions",
+                    return_value=False,
+                ),
+            ):
+                result = cli_runner.invoke(update_cmd, ["sample-module"])
+
+        assert result.exit_code == 0, result.output
+        called_names = [c.args[2] for c in gen_skill.call_args_list]
+        assert set(called_names) == {"skill1", "new-skill"}, called_names

--- a/tests/test_cli_install_cherry_pick.py
+++ b/tests/test_cli_install_cherry_pick.py
@@ -88,6 +88,7 @@ class TestSelectModuleItems:
             "commands": ["c1"],
             "agents": ["a1"],
             "mcps": ["m1"],
+            "instructions": [],
         }
 
     def test_subset_selection(self):
@@ -107,6 +108,7 @@ class TestSelectModuleItems:
             "commands": ["c1"],
             "agents": [],
             "mcps": [],
+            "instructions": [],
         }
 
     def test_cancel_returns_none(self):
@@ -138,7 +140,158 @@ class TestSelectModuleItems:
             "commands": [],
             "agents": [],
             "mcps": [],
+            "instructions": [],
         }
+
+    def test_picker_includes_instructions_when_module_has_them(self):
+        from unittest.mock import MagicMock
+
+        mock_prompt = MagicMock()
+        mock_prompt.execute.return_value = []
+        with patch(
+            "lola.prompts.inquirer.fuzzy", return_value=mock_prompt
+        ) as mock_fuzzy:
+            select_module_items(
+                skills=["foo"],
+                commands=[],
+                agents=[],
+                mcps=[],
+                has_instructions=True,
+            )
+        choices = mock_fuzzy.call_args.kwargs["choices"]
+        values = [c.value for c in choices]
+        assert "instructions:" in values
+        instr_choice = next(c for c in choices if c.value == "instructions:")
+        assert instr_choice.name.startswith("instructions: AGENTS.md")
+
+    def test_picker_omits_instructions_when_module_has_none(self):
+        from unittest.mock import MagicMock
+
+        mock_prompt = MagicMock()
+        mock_prompt.execute.return_value = []
+        with patch(
+            "lola.prompts.inquirer.fuzzy", return_value=mock_prompt
+        ) as mock_fuzzy:
+            select_module_items(
+                skills=["foo"],
+                commands=[],
+                agents=[],
+                mcps=[],
+                has_instructions=False,
+            )
+        choices = mock_fuzzy.call_args.kwargs["choices"]
+        assert all(c.value != "instructions:" for c in choices)
+
+    def test_picker_instructions_pre_selected_when_current_has_them(self):
+        from unittest.mock import MagicMock
+
+        mock_prompt = MagicMock()
+        mock_prompt.execute.return_value = []
+        with patch(
+            "lola.prompts.inquirer.fuzzy", return_value=mock_prompt
+        ) as mock_fuzzy:
+            select_module_items(
+                skills=["foo"],
+                commands=[],
+                agents=[],
+                mcps=[],
+                has_instructions=True,
+                current={
+                    "skills": [],
+                    "commands": [],
+                    "agents": [],
+                    "mcps": [],
+                    "instructions": ["yes"],
+                },
+            )
+        choices = mock_fuzzy.call_args.kwargs["choices"]
+        instr_choice = next(c for c in choices if c.value == "instructions:")
+        assert instr_choice.name.endswith("(installed)")
+        assert instr_choice.enabled is True
+
+    def test_picker_instructions_marked_new_when_current_lacks_them(self):
+        from unittest.mock import MagicMock
+
+        mock_prompt = MagicMock()
+        mock_prompt.execute.return_value = []
+        with patch(
+            "lola.prompts.inquirer.fuzzy", return_value=mock_prompt
+        ) as mock_fuzzy:
+            select_module_items(
+                skills=["foo"],
+                commands=[],
+                agents=[],
+                mcps=[],
+                has_instructions=True,
+                current={
+                    "skills": ["foo"],
+                    "commands": [],
+                    "agents": [],
+                    "mcps": [],
+                    "instructions": [],
+                },
+            )
+        choices = mock_fuzzy.call_args.kwargs["choices"]
+        instr_choice = next(c for c in choices if c.value == "instructions:")
+        assert instr_choice.name.endswith("(new)")
+        assert instr_choice.enabled is False
+
+    def test_picker_returns_instructions_yes_when_selected(self):
+        from unittest.mock import MagicMock
+
+        mock_prompt = MagicMock()
+        mock_prompt.execute.return_value = ["skill:foo", "instructions:"]
+        with patch("lola.prompts.inquirer.fuzzy", return_value=mock_prompt):
+            result = select_module_items(
+                skills=["foo"],
+                commands=[],
+                agents=[],
+                mcps=[],
+                has_instructions=True,
+            )
+        assert result is not None
+        assert result["instructions"] == ["yes"]
+        assert result["skills"] == ["foo"]
+
+    def test_picker_annotates_current_items(self):
+        """When current= is passed, installed items get suffix + pre-select."""
+        from unittest.mock import MagicMock
+
+        mock_prompt = MagicMock()
+        mock_prompt.execute.return_value = []
+        with patch(
+            "lola.prompts.inquirer.fuzzy", return_value=mock_prompt
+        ) as mock_fuzzy:
+            select_module_items(
+                skills=["foo", "bar"],
+                commands=["c1"],
+                agents=[],
+                mcps=[],
+                current={"skills": ["foo"], "commands": [], "agents": [], "mcps": []},
+            )
+
+        choices = mock_fuzzy.call_args.kwargs["choices"]
+        choice_by_value = {c.value: c for c in choices}
+        assert choice_by_value["skill:foo"].name.endswith("(installed)")
+        assert choice_by_value["skill:foo"].enabled is True
+        assert choice_by_value["skill:bar"].name.endswith("(new)")
+        assert choice_by_value["skill:bar"].enabled is False
+        assert choice_by_value["cmd:c1"].name.endswith("(new)")
+        assert choice_by_value["cmd:c1"].enabled is False
+
+    def test_picker_without_current_has_no_annotations(self):
+        from unittest.mock import MagicMock
+
+        mock_prompt = MagicMock()
+        mock_prompt.execute.return_value = []
+        with patch(
+            "lola.prompts.inquirer.fuzzy", return_value=mock_prompt
+        ) as mock_fuzzy:
+            select_module_items(skills=["foo"], commands=[], agents=[], mcps=[])
+
+        choices = mock_fuzzy.call_args.kwargs["choices"]
+        assert "(installed)" not in choices[0].name
+        assert "(new)" not in choices[0].name
 
 
 class TestInstallationFullInstallField:
@@ -302,6 +455,7 @@ class TestInstallFlagPicker:
                     "commands": [],
                     "agents": [],
                     "mcps": [],
+                    "instructions": [],
                 },
             ) as mock_picker,
         ):
@@ -387,6 +541,144 @@ class TestInstallFlagPicker:
         assert result.exit_code == 0, result.output
         kwargs = mock_install.call_args.kwargs
         assert kwargs["selected_skills"] == {"skill1", "skill2"}
+
+    def test_no_flags_full_install_passes_none_for_instructions(
+        self, cli_runner, sample_module, tmp_path
+    ):
+        modules_dir, installed_file = self._setup(tmp_path, sample_module)
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry") as mock_registry,
+            patch("lola.cli.install.get_local_modules_path", return_value=modules_dir),
+            patch(
+                "lola.cli.install.install_to_assistant", return_value=1
+            ) as mock_install,
+            patch("lola.cli.install.is_interactive", return_value=False),
+        ):
+            mock_registry.return_value = InstallationRegistry(installed_file)
+            result = cli_runner.invoke(
+                install_cmd, ["sample-module", "-a", "claude-code"]
+            )
+
+        assert result.exit_code == 0, result.output
+        kwargs = mock_install.call_args.kwargs
+        assert kwargs["selected_instructions"] is None
+
+    def test_skill_flag_without_instructions_skips_instructions(
+        self, cli_runner, sample_module, tmp_path
+    ):
+        """--skill alone means cherry-pick mode; instructions default to False."""
+        modules_dir, installed_file = self._setup(tmp_path, sample_module)
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry") as mock_registry,
+            patch("lola.cli.install.get_local_modules_path", return_value=modules_dir),
+            patch(
+                "lola.cli.install.install_to_assistant", return_value=1
+            ) as mock_install,
+            patch("lola.cli.install.is_interactive", return_value=False),
+        ):
+            mock_registry.return_value = InstallationRegistry(installed_file)
+            result = cli_runner.invoke(
+                install_cmd,
+                ["sample-module", "-a", "claude-code", "--skill", "skill1"],
+            )
+
+        assert result.exit_code == 0, result.output
+        kwargs = mock_install.call_args.kwargs
+        assert kwargs["selected_instructions"] is False
+
+    def test_skill_flag_with_instructions_installs_both(
+        self, cli_runner, sample_module, tmp_path
+    ):
+        modules_dir, installed_file = self._setup(tmp_path, sample_module)
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry") as mock_registry,
+            patch("lola.cli.install.get_local_modules_path", return_value=modules_dir),
+            patch(
+                "lola.cli.install.install_to_assistant", return_value=1
+            ) as mock_install,
+            patch("lola.cli.install.is_interactive", return_value=False),
+        ):
+            mock_registry.return_value = InstallationRegistry(installed_file)
+            result = cli_runner.invoke(
+                install_cmd,
+                [
+                    "sample-module",
+                    "-a",
+                    "claude-code",
+                    "--skill",
+                    "skill1",
+                    "--instructions",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        kwargs = mock_install.call_args.kwargs
+        assert kwargs["selected_skills"] == {"skill1"}
+        assert kwargs["selected_instructions"] is True
+
+    def test_instructions_flag_alone_is_cherry_pick(
+        self, cli_runner, sample_module, tmp_path
+    ):
+        """`--instructions` alone is a valid cherry-pick: empty sets + instructions."""
+        modules_dir, installed_file = self._setup(tmp_path, sample_module)
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry") as mock_registry,
+            patch("lola.cli.install.get_local_modules_path", return_value=modules_dir),
+            patch(
+                "lola.cli.install.install_to_assistant", return_value=1
+            ) as mock_install,
+            patch("lola.cli.install.is_interactive", return_value=False),
+        ):
+            mock_registry.return_value = InstallationRegistry(installed_file)
+            result = cli_runner.invoke(
+                install_cmd,
+                ["sample-module", "-a", "claude-code", "--instructions"],
+            )
+
+        assert result.exit_code == 0, result.output
+        kwargs = mock_install.call_args.kwargs
+        assert kwargs["selected_skills"] == set()
+        assert kwargs["selected_commands"] == set()
+        assert kwargs["selected_agents"] == set()
+        assert kwargs["selected_mcps"] == set()
+        assert kwargs["selected_instructions"] is True
+
+    def test_no_instructions_flag_alone_is_cherry_pick_skipping_instructions(
+        self, cli_runner, sample_module, tmp_path
+    ):
+        modules_dir, installed_file = self._setup(tmp_path, sample_module)
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry") as mock_registry,
+            patch("lola.cli.install.get_local_modules_path", return_value=modules_dir),
+            patch(
+                "lola.cli.install.install_to_assistant", return_value=1
+            ) as mock_install,
+            patch("lola.cli.install.is_interactive", return_value=False),
+        ):
+            mock_registry.return_value = InstallationRegistry(installed_file)
+            result = cli_runner.invoke(
+                install_cmd,
+                ["sample-module", "-a", "claude-code", "--no-instructions"],
+            )
+
+        assert result.exit_code == 0, result.output
+        kwargs = mock_install.call_args.kwargs
+        assert kwargs["selected_instructions"] is False
 
     def test_unknown_skill_name_errors(self, cli_runner, sample_module, tmp_path):
         """Asking for a skill that the module doesn't expose is a hard error."""

--- a/tests/test_cli_install_cherry_pick.py
+++ b/tests/test_cli_install_cherry_pick.py
@@ -1205,3 +1205,154 @@ class TestUpdateLockToSelection:
         updated_inst = registry.find("mcp-module")[0]
         assert updated_inst.mcps == ["github"]
         assert updated_inst.mcp_sources == {"github": "github"}
+
+    def test_update_skips_instructions_for_cherry_pick_without_them(
+        self, cli_runner, sample_module, tmp_path
+    ):
+        """A cherry-picked install that omitted instructions stays opted out.
+
+        Upstream gaining AGENTS.md must not silently flip an existing install
+        from has_instructions=False to True on update.
+        """
+        modules_dir = tmp_path / ".lola" / "modules"
+        modules_dir.mkdir(parents=True)
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        shutil.copytree(sample_module, modules_dir / "sample-module")
+
+        # Upstream now has AGENTS.md instructions.
+        (modules_dir / "sample-module" / "AGENTS.md").write_text(
+            "# Upstream instructions\n"
+        )
+
+        project_path = tmp_path / "project"
+        project_path.mkdir()
+        registry = InstallationRegistry(installed_file)
+        registry.add(
+            Installation(
+                module_name="sample-module",
+                assistant="claude-code",
+                scope="project",
+                project_path=str(project_path),
+                skills=["skill1"],
+                commands=[],
+                agents=[],
+                mcps=[],
+                full_install=False,
+                has_instructions=False,
+            )
+        )
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry", return_value=registry),
+            patch("lola.cli.install.get_local_modules_path", return_value=modules_dir),
+            patch(
+                "lola.targets.install.copy_module_to_local",
+                return_value=modules_dir / "sample-module",
+            ),
+            patch(
+                "lola.cli.install.copy_module_to_local",
+                return_value=modules_dir / "sample-module",
+            ),
+        ):
+            from lola.targets import claude_code
+
+            with (
+                patch.object(
+                    claude_code.ClaudeCodeTarget, "generate_skill", return_value=True
+                ),
+                patch.object(
+                    claude_code.ClaudeCodeTarget,
+                    "generate_instructions",
+                    return_value=True,
+                ) as gen_instructions,
+                patch.object(
+                    claude_code.ClaudeCodeTarget,
+                    "remove_instructions",
+                    return_value=True,
+                ),
+            ):
+                result = cli_runner.invoke(update_cmd, ["sample-module"])
+
+        assert result.exit_code == 0, result.output
+        gen_instructions.assert_not_called()
+        updated_inst = registry.find("sample-module")[0]
+        assert updated_inst.has_instructions is False
+
+
+class TestCurrentForPickerSourceMap:
+    """`_current_for_picker` must expand compacted source maps correctly.
+
+    `Installation` source-map dicts only store renamed entries (identity
+    mappings are implicit). Picker pre-selection therefore needs to fall back
+    to the installed name when an entry is absent from the source map.
+    """
+
+    def test_compacted_source_map_includes_identity_mapped_items(
+        self, cli_runner, tmp_path
+    ):
+        modules_dir = tmp_path / ".lola" / "modules"
+        commands_dir = modules_dir / "mix-module" / "commands"
+        commands_dir.mkdir(parents=True)
+        (commands_dir / "deploy.md").write_text(
+            "---\ndescription: Deploy things\n---\n\n# Deploy\n"
+        )
+        (commands_dir / "keep.md").write_text(
+            "---\ndescription: Keep things\n---\n\n# Keep\n"
+        )
+        (commands_dir / "extra.md").write_text(
+            "---\ndescription: Extra command\n---\n\n# Extra\n"
+        )
+
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        project_path = tmp_path / "project"
+        project_path.mkdir()
+        registry = InstallationRegistry(installed_file)
+        # commands=["keep", "ship"] with source map only storing the rename.
+        # "keep" is identity-mapped (absent from command_sources) — the picker
+        # must still see "keep" pre-selected.
+        registry.add(
+            Installation(
+                module_name="mix-module",
+                assistant="claude-code",
+                scope="project",
+                project_path=str(project_path),
+                commands=["keep", "ship"],
+                command_sources={"ship": "deploy"},
+                full_install=False,
+            )
+        )
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry", return_value=registry),
+            patch("lola.cli.install.get_local_modules_path", return_value=modules_dir),
+            patch("lola.cli.install.install_to_assistant", return_value=1),
+            patch("lola.cli.install.is_interactive", return_value=True),
+            patch("lola.cli.install.select_install_mode", return_value="cherry-pick"),
+            patch(
+                "lola.cli.install.select_module_items",
+                return_value={
+                    "skills": [],
+                    "commands": ["keep"],
+                    "agents": [],
+                    "mcps": [],
+                    "instructions": [],
+                },
+            ) as mock_picker,
+        ):
+            result = cli_runner.invoke(
+                install_cmd,
+                [
+                    "mix-module",
+                    str(project_path),
+                    "-a",
+                    "claude-code",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        current = mock_picker.call_args.kwargs["current"]
+        assert set(current["commands"]) == {"deploy", "keep"}

--- a/tests/test_cli_mod.py
+++ b/tests/test_cli_mod.py
@@ -1090,7 +1090,7 @@ class TestModRemoveAdvanced:
         with (
             patch("lola.cli.mod.MODULES_DIR", modules_dir),
             patch("lola.cli.mod.INSTALLED_FILE", installed_file),
-            patch("lola.cli.mod.get_target", return_value=mock_target),
+            patch("lola.targets.get_target", return_value=mock_target),
             patch("lola.cli.mod.ensure_lola_dirs"),
         ):
             result = cli_runner.invoke(mod, ["rm", "sample-module", "-f"])

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -4,7 +4,7 @@ from unittest.mock import patch, MagicMock
 
 
 from lola.targets import get_registry, copy_module_to_local, install_to_assistant
-from lola.models import Module, InstallationRegistry
+from lola.models import Module, Installation, InstallationRegistry
 
 
 class TestGetRegistry:
@@ -109,7 +109,9 @@ class TestInstallToAssistant:
         """Set up test fixtures."""
         self.console_mock = MagicMock()
 
-    def create_test_module(self, tmp_path, name="testmod", skills=None, commands=None):
+    def create_test_module(
+        self, tmp_path, name="testmod", skills=None, commands=None, agents=None
+    ):
         """Helper to create a test module structure."""
         module_dir = tmp_path / "modules" / name
         module_dir.mkdir(parents=True)
@@ -140,6 +142,20 @@ description: {cmd} command
 ---
 
 Do {cmd}.
+""")
+
+        # Create agent files (auto-discovered from agents/*.md)
+        if agents:
+            agents_dir = module_dir / "agents"
+            agents_dir.mkdir()
+            for agent in agents:
+                (agents_dir / f"{agent}.md").write_text(f"""---
+name: {agent}
+description: {agent} agent
+model: inherit
+---
+
+Instructions for {agent}.
 """)
 
         return Module.from_path(module_dir)
@@ -259,6 +275,152 @@ Do {cmd}.
         assert installations[0].scope == "project"
         assert "skill1" in installations[0].skills
         assert "cmd1" in installations[0].commands
+
+    def test_reinstall_owned_skill_overwrites_without_conflict_prompt(self, tmp_path):
+        """Existing registry ownership lets reinstall refresh a skill quietly."""
+        module = self.create_test_module(tmp_path, skills=["cargo-fuzz"])
+        project = tmp_path / "project"
+        project.mkdir()
+        local_modules = tmp_path / "local" / ".lola" / "modules"
+        registry = InstallationRegistry(tmp_path / "installed.yml")
+        registry.add(
+            Installation(
+                module_name="testmod",
+                assistant="claude-code",
+                scope="project",
+                project_path=str(project),
+                skills=["cargo-fuzz"],
+                full_install=False,
+            )
+        )
+
+        skill_dest = project / ".claude" / "skills" / "cargo-fuzz"
+        skill_dest.mkdir(parents=True)
+        (skill_dest / "SKILL.md").write_text("old content")
+
+        with (
+            patch("lola.targets.install.is_interactive", return_value=True),
+            patch("lola.targets.install.prompt_skill_conflict") as mock_conflict,
+        ):
+            count = install_to_assistant(
+                module=module,
+                assistant="claude-code",
+                scope="project",
+                project_path=str(project),
+                local_modules=local_modules,
+                registry=registry,
+                selected_skills={"cargo-fuzz"},
+                selected_commands=set(),
+                selected_agents=set(),
+                selected_mcps=set(),
+                selected_instructions=False,
+            )
+
+        assert count == 1
+        mock_conflict.assert_not_called()
+        assert "# cargo-fuzz" in (skill_dest / "SKILL.md").read_text()
+
+    def test_reinstall_owned_renamed_command_keeps_name_without_conflict_prompt(
+        self, tmp_path
+    ):
+        """A source command previously installed under another name is refreshed."""
+        module = self.create_test_module(tmp_path, commands=["deploy"])
+        project = tmp_path / "project"
+        project.mkdir()
+        local_modules = tmp_path / "local" / ".lola" / "modules"
+        registry = InstallationRegistry(tmp_path / "installed.yml")
+        registry.add(
+            Installation(
+                module_name="testmod",
+                assistant="claude-code",
+                scope="project",
+                project_path=str(project),
+                commands=["ship"],
+                command_sources={"ship": "deploy"},
+                full_install=False,
+            )
+        )
+
+        command_dest = project / ".claude" / "commands"
+        command_dest.mkdir(parents=True)
+        (command_dest / "ship.md").write_text("old content")
+
+        with (
+            patch("lola.targets.install.is_interactive", return_value=True),
+            patch("lola.targets.install.prompt_command_conflict") as mock_conflict,
+        ):
+            count = install_to_assistant(
+                module=module,
+                assistant="claude-code",
+                scope="project",
+                project_path=str(project),
+                local_modules=local_modules,
+                registry=registry,
+                selected_skills=set(),
+                selected_commands={"deploy"},
+                selected_agents=set(),
+                selected_mcps=set(),
+                selected_instructions=False,
+            )
+
+        assert count == 1
+        mock_conflict.assert_not_called()
+        assert "Do deploy." in (command_dest / "ship.md").read_text()
+        assert not (command_dest / "deploy.md").exists()
+        [updated] = registry.find("testmod")
+        assert updated.commands == ["ship"]
+        assert updated.command_sources == {"ship": "deploy"}
+
+    def test_reinstall_owned_renamed_agent_keeps_name_without_conflict_prompt(
+        self, tmp_path
+    ):
+        """A source agent previously installed under another name is refreshed."""
+        module = self.create_test_module(tmp_path, agents=["reviewer"])
+        project = tmp_path / "project"
+        project.mkdir()
+        local_modules = tmp_path / "local" / ".lola" / "modules"
+        registry = InstallationRegistry(tmp_path / "installed.yml")
+        registry.add(
+            Installation(
+                module_name="testmod",
+                assistant="claude-code",
+                scope="project",
+                project_path=str(project),
+                agents=["review"],
+                agent_sources={"review": "reviewer"},
+                full_install=False,
+            )
+        )
+
+        agent_dest = project / ".claude" / "agents"
+        agent_dest.mkdir(parents=True)
+        (agent_dest / "review.md").write_text("old content")
+
+        with (
+            patch("lola.targets.install.is_interactive", return_value=True),
+            patch("lola.targets.install.prompt_agent_conflict") as mock_conflict,
+        ):
+            count = install_to_assistant(
+                module=module,
+                assistant="claude-code",
+                scope="project",
+                project_path=str(project),
+                local_modules=local_modules,
+                registry=registry,
+                selected_skills=set(),
+                selected_commands=set(),
+                selected_agents={"reviewer"},
+                selected_mcps=set(),
+                selected_instructions=False,
+            )
+
+        assert count == 1
+        mock_conflict.assert_not_called()
+        assert "Instructions for reviewer." in (agent_dest / "review.md").read_text()
+        assert not (agent_dest / "reviewer.md").exists()
+        [updated] = registry.find("testmod")
+        assert updated.agents == ["review"]
+        assert updated.agent_sources == {"review": "reviewer"}
 
     # Note: test_install_missing_skill_source and test_install_missing_command_source
     # were removed because with auto-discovery, skills and commands are only

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -563,7 +563,7 @@ class TestUninstallWithInstructions:
         with (
             patch("lola.cli.install.ensure_lola_dirs"),
             patch("lola.cli.install.get_registry", return_value=registry),
-            patch("lola.cli.install.get_target", return_value=mock_target),
+            patch("lola.targets.get_target", return_value=mock_target),
         ):
             result = runner.invoke(uninstall_cmd, ["test-module", "-f"])
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -21,6 +21,7 @@ import frontmatter as pyfrontmatter
 import yaml
 
 from lola.cli.install import install_cmd, uninstall_cmd, update_cmd
+from lola.cli.mod import mod
 
 
 # =============================================================================
@@ -250,6 +251,69 @@ class TestUninstall:
         names = [i["module"] for i in _read_registry(integration_env)]
         assert "test-module" not in names
 
+    def test_managed_section_skill_removed(self, integration_env):
+        _install(integration_env, "gemini-cli")
+        gemini_md = integration_env["project"] / "GEMINI.md"
+        assert "test-module" in gemini_md.read_text()
+
+        _uninstall(integration_env, "gemini-cli")
+
+        assert "test-module" not in gemini_md.read_text()
+
+    def test_mod_rm_removes_all_scopes_outputs_and_caches(
+        self, integration_env, monkeypatch, tmp_path
+    ):
+        """mod rm reuses uninstall behavior for project and user installs."""
+        env = integration_env
+        (env["modules"] / env["module_name"] / "AGENTS.md").write_text(
+            "# Test module instructions\n"
+        )
+        fake_home = tmp_path / "fakehome"
+        fake_home.mkdir()
+        user_cwd = tmp_path / "user-cwd"
+        user_cwd.mkdir()
+
+        project_result = env["runner"].invoke(
+            install_cmd,
+            [env["module_name"], str(env["project"]), "-a", "claude-code", "-f"],
+        )
+        assert project_result.exit_code == 0, project_result.output
+
+        monkeypatch.chdir(user_cwd)
+        with monkeypatch.context() as m:
+            m.setattr(Path, "home", lambda: fake_home)
+            user_result = env["runner"].invoke(
+                install_cmd,
+                [env["module_name"], "--scope", "user", "-a", "claude-code", "-f"],
+            )
+            assert user_result.exit_code == 0, user_result.output
+
+            rm_result = env["runner"].invoke(mod, ["rm", env["module_name"], "-f"])
+
+        assert rm_result.exit_code == 0, rm_result.output
+        project = env["project"]
+        assert not (project / ".claude" / "skills" / "git-review").exists()
+        assert not (project / ".claude" / "commands" / "review-pr.md").exists()
+        assert not (project / ".claude" / "agents" / "code-reviewer.md").exists()
+        assert not (project / ".mcp.json").exists()
+        assert "test-module" not in (project / "CLAUDE.md").read_text()
+
+        assert not (fake_home / ".claude" / "skills" / "git-review").exists()
+        assert not (fake_home / ".claude" / "commands" / "review-pr.md").exists()
+        assert not (fake_home / ".claude" / "agents" / "code-reviewer.md").exists()
+        assert not (fake_home / ".mcp.json").exists()
+        user_instructions = fake_home / ".claude" / "CLAUDE.md"
+        if user_instructions.exists():
+            assert "test-module" not in user_instructions.read_text()
+
+        assert not (project / ".lola" / "modules" / env["module_name"]).exists()
+        assert not (user_cwd / ".lola" / "modules" / env["module_name"]).exists()
+        assert not (env["modules"] / env["module_name"]).exists()
+
+        saved = yaml.safe_load(env["installed_file"].read_text()) or {}
+        assert saved.get("installations") == []
+        assert saved.get("module_caches") == []
+
 
 # =============================================================================
 # TestUninstallLegacyFallback
@@ -397,13 +461,24 @@ class TestUpdateOrphans:
 
 
 class TestInstallCollision:
-    """Command/agent files already exist → prompt user on re-install."""
+    """Unowned command/agent files already exist → prompt user on install."""
+
+    def _write_unowned_command(
+        self,
+        integration_env: dict,
+        command_name: str,
+        content: str = "sentinel content",
+    ) -> Path:
+        cmd_file = (
+            integration_env["project"] / ".claude" / "commands" / f"{command_name}.md"
+        )
+        cmd_file.parent.mkdir(parents=True, exist_ok=True)
+        cmd_file.write_text(content)
+        return cmd_file
 
     def test_command_overwrite_prompt(self, integration_env, monkeypatch):
         """When overwrite is chosen, the file content is replaced."""
-        _install(integration_env, "claude-code")
-        cmd_file = integration_env["project"] / ".claude" / "commands" / "review-pr.md"
-        cmd_file.write_text("sentinel content")
+        cmd_file = self._write_unowned_command(integration_env, "review-pr")
 
         # Suppress the existing skill collision prompt (not under test here)
         monkeypatch.setattr(
@@ -433,7 +508,7 @@ class TestInstallCollision:
 
     def test_command_rename_prompt(self, integration_env, monkeypatch):
         """When rename is chosen, a new file is created under the new name."""
-        _install(integration_env, "claude-code")
+        self._write_unowned_command(integration_env, "review-pr")
         renamed_file = (
             integration_env["project"]
             / ".claude"
@@ -469,9 +544,7 @@ class TestInstallCollision:
 
     def test_command_skip_prompt(self, integration_env, monkeypatch):
         """When skip is chosen, the existing file is not modified."""
-        _install(integration_env, "claude-code")
-        cmd_file = integration_env["project"] / ".claude" / "commands" / "review-pr.md"
-        cmd_file.write_text("sentinel content")
+        cmd_file = self._write_unowned_command(integration_env, "review-pr")
 
         # Suppress the existing skill collision prompt (not under test here)
         monkeypatch.setattr(
@@ -501,9 +574,7 @@ class TestInstallCollision:
 
     def test_non_interactive_skips(self, integration_env, monkeypatch):
         """In non-interactive mode, collisions are skipped without prompting."""
-        _install(integration_env, "claude-code")
-        cmd_file = integration_env["project"] / ".claude" / "commands" / "review-pr.md"
-        cmd_file.write_text("sentinel content")
+        cmd_file = self._write_unowned_command(integration_env, "review-pr")
 
         # Suppress the existing skill collision prompt (not under test here)
         monkeypatch.setattr(
@@ -553,12 +624,11 @@ class TestInstallCollision:
         self, integration_env, monkeypatch
     ):
         """`Overwrite All` on the first collision auto-overwrites the rest."""
-        _install(integration_env, "claude-code")
         cmds_dir = integration_env["project"] / ".claude" / "commands"
-        # Two commands installed: both already exist after the first install,
-        # so the second install run will hit two collisions.
-        (cmds_dir / "review-pr.md").write_text("sentinel one")
-        (cmds_dir / "quick-commit.md").write_text("sentinel two")
+        # Two unowned command files already exist, so install will hit two
+        # collisions.
+        self._write_unowned_command(integration_env, "review-pr", "sentinel one")
+        self._write_unowned_command(integration_env, "quick-commit", "sentinel two")
 
         monkeypatch.setattr(
             "lola.targets.install._check_skill_exists", lambda *a, **k: False

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -549,6 +549,109 @@ class TestInstallCollision:
         assert cmd_file.read_text() != "sentinel content"
         prompt_mock.assert_not_called()
 
+    def test_command_overwrite_all_skips_subsequent_prompts(
+        self, integration_env, monkeypatch
+    ):
+        """`Overwrite All` on the first collision auto-overwrites the rest."""
+        _install(integration_env, "claude-code")
+        cmds_dir = integration_env["project"] / ".claude" / "commands"
+        # Two commands installed: both already exist after the first install,
+        # so the second install run will hit two collisions.
+        (cmds_dir / "review-pr.md").write_text("sentinel one")
+        (cmds_dir / "quick-commit.md").write_text("sentinel two")
+
+        monkeypatch.setattr(
+            "lola.targets.install._check_skill_exists", lambda *a, **k: False
+        )
+        monkeypatch.setattr("lola.targets.install.is_interactive", lambda: True)
+        prompt_mock = MagicMock(return_value=("overwrite_all", ""))
+        monkeypatch.setattr("lola.targets.install.prompt_command_conflict", prompt_mock)
+        monkeypatch.setattr(
+            "lola.targets.install.prompt_agent_conflict",
+            lambda agent_name, module_name: ("overwrite", ""),
+        )
+
+        result = integration_env["runner"].invoke(
+            install_cmd,
+            [
+                integration_env["module_name"],
+                str(integration_env["project"]),
+                "-a",
+                "claude-code",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        # Only one prompt despite two collisions.
+        assert prompt_mock.call_count == 1
+        assert (cmds_dir / "review-pr.md").read_text() != "sentinel one"
+        assert (cmds_dir / "quick-commit.md").read_text() != "sentinel two"
+
+
+# =============================================================================
+# TestCherryPickInstructions
+# =============================================================================
+
+
+class TestCherryPickInstructions:
+    """`--instructions` cherry-pick semantics."""
+
+    def _add_agents_md(self, env: dict) -> None:
+        """Drop an AGENTS.md into the registered test-module."""
+        agents_md = env["modules"] / env["module_name"] / "AGENTS.md"
+        agents_md.write_text("# Test module instructions\n")
+
+    def test_flag_install_skips_instructions_when_not_requested(self, integration_env):
+        """`--skill X` alone is a cherry-pick: AGENTS.md is NOT installed."""
+        self._add_agents_md(integration_env)
+
+        result = integration_env["runner"].invoke(
+            install_cmd,
+            [
+                integration_env["module_name"],
+                str(integration_env["project"]),
+                "-a",
+                "claude-code",
+                "--skill",
+                "git-review",
+                "-f",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+        inst = _find_inst(integration_env, "claude-code")
+        assert inst.get("has_instructions") is not True
+
+    def test_flag_install_includes_instructions_when_requested(self, integration_env):
+        """`--skill X --instructions` cherry-picks both."""
+        self._add_agents_md(integration_env)
+
+        result = integration_env["runner"].invoke(
+            install_cmd,
+            [
+                integration_env["module_name"],
+                str(integration_env["project"]),
+                "-a",
+                "claude-code",
+                "--skill",
+                "git-review",
+                "--instructions",
+                "-f",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+        inst = _find_inst(integration_env, "claude-code")
+        assert inst["has_instructions"] is True
+
+    def test_full_install_still_includes_instructions(self, integration_env):
+        """No flags: full install path keeps the historical behavior."""
+        self._add_agents_md(integration_env)
+
+        _install(integration_env, "claude-code")
+
+        inst = _find_inst(integration_env, "claude-code")
+        assert inst["has_instructions"] is True
+
 
 # =============================================================================
 # TestRegistryState

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,6 +7,7 @@ from lola.models import (
     Command,
     Module,
     Installation,
+    InstallationKey,
     InstallationRegistry,
 )
 from lola.frontmatter import validate_skill
@@ -487,6 +488,40 @@ class TestInstallation:
         assert inst.skills == ["skill1", "skill2"]
         assert inst.commands == ["cmd1"]
 
+    def test_user_symlink_dir_roundtrip(self):
+        """user_symlink_dir survives to_dict / from_dict."""
+        inst = Installation(
+            module_name="mymodule",
+            assistant="claude-code",
+            scope="user",
+            user_symlink_dir="/some/cwd/.lola/modules",
+        )
+        d = inst.to_dict()
+        assert d["user_symlink_dir"] == "/some/cwd/.lola/modules"
+        restored = Installation.from_dict(d)
+        assert restored.user_symlink_dir == "/some/cwd/.lola/modules"
+
+    def test_user_symlink_dir_omitted_when_none(self):
+        """to_dict drops user_symlink_dir when None (keeps YAML clean)."""
+        inst = Installation(
+            module_name="mymodule",
+            assistant="claude-code",
+            scope="project",
+            project_path="/path/to/project",
+        )
+        d = inst.to_dict()
+        assert "user_symlink_dir" not in d
+
+    def test_from_dict_missing_user_symlink_dir(self):
+        """Old YAML records without user_symlink_dir load as None."""
+        d = {
+            "module": "mymodule",
+            "assistant": "claude-code",
+            "scope": "user",
+        }
+        inst = Installation.from_dict(d)
+        assert inst.user_symlink_dir is None
+
 
 class TestInstallationRegistry:
     """Tests for InstallationRegistry."""
@@ -602,6 +637,132 @@ class TestInstallationRegistry:
         registry = InstallationRegistry(registry_path)
         assert len(registry.all()) == 2
 
+    def test_v1_project_and_user_records_migrate_to_cache_records(self, tmp_path):
+        """Legacy project/user records gain v2 cache keys in memory."""
+        registry_path = tmp_path / "installed.yml"
+        project_path = tmp_path / "project"
+        user_modules = tmp_path / "install-cwd" / ".lola" / "modules"
+        data = {
+            "version": "1.0",
+            "installations": [
+                {
+                    "module": "mod1",
+                    "assistant": "claude-code",
+                    "scope": "project",
+                    "project_path": str(project_path),
+                },
+                {
+                    "module": "mod1",
+                    "assistant": "cursor",
+                    "scope": "user",
+                    "user_symlink_dir": str(user_modules),
+                },
+            ],
+        }
+        registry_path.write_text(yaml.dump(data))
+
+        registry = InstallationRegistry(registry_path)
+
+        assert len(registry.all()) == 2
+        assert all(inst.cache_key is not None for inst in registry.all())
+        cache_paths = {cache.path for cache in registry.module_caches()}
+        assert cache_paths == {
+            str(project_path / ".lola" / "modules" / "mod1"),
+            str(user_modules / "mod1"),
+        }
+
+    def test_v1_user_record_without_symlink_dir_gets_no_cache_record(self, tmp_path):
+        """Legacy user records without a recorded cache path stay ambiguous."""
+        registry_path = tmp_path / "installed.yml"
+        data = {
+            "version": "1.0",
+            "installations": [
+                {
+                    "module": "mod1",
+                    "assistant": "claude-code",
+                    "scope": "user",
+                },
+            ],
+        }
+        registry_path.write_text(yaml.dump(data))
+
+        registry = InstallationRegistry(registry_path)
+
+        assert registry.all()[0].cache_key is None
+        assert registry.module_caches() == []
+
+    def test_next_write_saves_v2_registry(self, tmp_path):
+        """A legacy registry is rewritten as v2 on the next write."""
+        registry_path = tmp_path / "installed.yml"
+        project_path = tmp_path / "project"
+        data = {
+            "version": "1.0",
+            "installations": [
+                {
+                    "module": "mod1",
+                    "assistant": "claude-code",
+                    "scope": "project",
+                    "project_path": str(project_path),
+                },
+            ],
+        }
+        registry_path.write_text(yaml.dump(data))
+
+        registry = InstallationRegistry(registry_path)
+        registry.upsert_installation(registry.all()[0])
+
+        saved = yaml.safe_load(registry_path.read_text())
+        assert saved["version"] == "2.0"
+        assert saved["module_caches"] == [
+            {
+                "module": "mod1",
+                "scope": "project",
+                "project_path": str(project_path),
+                "path": str(project_path / ".lola" / "modules" / "mod1"),
+            }
+        ]
+        assert saved["installations"][0]["cache_key"] == {
+            "module": "mod1",
+            "scope": "project",
+            "project_path": str(project_path),
+        }
+
+    def test_removing_one_shared_cache_install_does_not_delete_cache(self, tmp_path):
+        """A cache shared by another assistant is not scheduled for cleanup."""
+        registry_path = tmp_path / "installed.yml"
+        project_path = tmp_path / "project"
+        registry = InstallationRegistry(registry_path)
+        registry.add(Installation("mod1", "claude-code", "project", str(project_path)))
+        registry.add(Installation("mod1", "cursor", "project", str(project_path)))
+
+        plan = registry.remove_installation(
+            InstallationKey("mod1", "claude-code", "project", str(project_path))
+        )
+
+        assert len(plan.removed_installations) == 1
+        assert plan.cache_paths_to_remove == []
+        assert len(registry.module_caches()) == 1
+
+    def test_removing_last_shared_cache_install_deletes_cache_once(self, tmp_path):
+        """The last installation referencing a cache schedules one deletion."""
+        registry_path = tmp_path / "installed.yml"
+        project_path = tmp_path / "project"
+        expected_cache = project_path / ".lola" / "modules" / "mod1"
+        registry = InstallationRegistry(registry_path)
+        registry.add(Installation("mod1", "claude-code", "project", str(project_path)))
+        registry.add(Installation("mod1", "cursor", "project", str(project_path)))
+
+        plan = registry.remove_installations(
+            [
+                InstallationKey("mod1", "claude-code", "project", str(project_path)),
+                InstallationKey("mod1", "cursor", "project", str(project_path)),
+            ]
+        )
+
+        assert len(plan.removed_installations) == 2
+        assert plan.cache_paths_to_remove == [expected_cache]
+        assert registry.module_caches() == []
+
     def test_atomic_save_no_temp_files(self, tmp_path):
         """Verify atomic save doesn't leave temporary files behind."""
         registry_path = tmp_path / "installed.yml"
@@ -621,7 +782,8 @@ class TestInstallationRegistry:
         # Verify the file is valid YAML and contains our data
         with open(registry_path) as f:
             data = yaml.safe_load(f)
-        assert data["version"] == "1.0"
+        assert data["version"] == "2.0"
+        assert "module_caches" in data
         assert len(data["installations"]) == 2
 
     def test_atomic_save_creates_parent_dirs(self, tmp_path):

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -4,6 +4,9 @@ from unittest.mock import MagicMock, patch
 
 from lola.prompts import (
     is_interactive,
+    prompt_agent_conflict,
+    prompt_command_conflict,
+    prompt_skill_conflict,
     select_assistants,
     select_installations,
     select_marketplace,
@@ -222,3 +225,57 @@ def test_select_marketplace_name_cancelled_returns_none():
     with patch("lola.prompts.inquirer.select", return_value=mock_prompt):
         result = select_marketplace_name(["official", "community"])
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# conflict prompts (skill / command / agent)
+# ---------------------------------------------------------------------------
+
+
+def _make_inquirer_chain(action_value, rename_value=None):
+    """Build a side_effect list for `inquirer.select` then `inquirer.text`."""
+    select_mock = MagicMock()
+    select_mock.execute.return_value = action_value
+    text_mock = MagicMock()
+    text_mock.execute.return_value = rename_value
+    return select_mock, text_mock
+
+
+def test_prompt_skill_conflict_overwrite_all():
+    select_mock, _ = _make_inquirer_chain("overwrite_all")
+    with patch("lola.prompts.inquirer.select", return_value=select_mock):
+        action, new_name = prompt_skill_conflict("foo", "mod")
+    assert action == "overwrite_all"
+    assert new_name == ""
+
+
+def test_prompt_skill_conflict_rename_uses_underscore_default():
+    """Skill rename default is ``module_skill`` (underscore separator)."""
+    select_mock, text_mock = _make_inquirer_chain("rename", "mod_foo")
+    with (
+        patch("lola.prompts.inquirer.select", return_value=select_mock),
+        patch("lola.prompts.inquirer.text", return_value=text_mock) as mock_text,
+    ):
+        action, new_name = prompt_skill_conflict("foo", "mod")
+    assert action == "rename"
+    assert new_name == "mod_foo"
+    # The default passed to inquirer.text should use underscore.
+    assert mock_text.call_args.kwargs["default"] == "mod_foo"
+
+
+def test_prompt_command_conflict_offers_overwrite_all():
+    select_mock, _ = _make_inquirer_chain("overwrite_all")
+    with patch("lola.prompts.inquirer.select", return_value=select_mock) as mock_select:
+        action, _ = prompt_command_conflict("foo", "mod")
+    assert action == "overwrite_all"
+    choice_values = [c.value for c in mock_select.call_args.kwargs["choices"]]
+    assert "overwrite_all" in choice_values
+
+
+def test_prompt_agent_conflict_offers_overwrite_all():
+    select_mock, _ = _make_inquirer_chain("overwrite_all")
+    with patch("lola.prompts.inquirer.select", return_value=select_mock) as mock_select:
+        action, _ = prompt_agent_conflict("foo", "mod")
+    assert action == "overwrite_all"
+    choice_values = [c.value for c in mock_select.call_args.kwargs["choices"]]
+    assert "overwrite_all" in choice_values

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -263,6 +263,56 @@ def test_prompt_skill_conflict_rename_uses_underscore_default():
     assert mock_text.call_args.kwargs["default"] == "mod_foo"
 
 
+def test_prompt_skill_conflict_prefix_all_prompts_for_prefix():
+    """Selecting "Prefix All" asks the user for a prefix (defaulting to the
+    module name) and returns it; the caller then constructs the final names."""
+    select_mock, text_mock = _make_inquirer_chain("prefix_all", "myprefix")
+    with (
+        patch("lola.prompts.inquirer.select", return_value=select_mock),
+        patch("lola.prompts.inquirer.text", return_value=text_mock) as mock_text,
+    ):
+        action, prefix = prompt_skill_conflict("foo", "mod")
+    assert action == "prefix_all"
+    assert prefix == "myprefix"
+    # Default for the prefix input must be the module name.
+    assert mock_text.call_args.kwargs["default"] == "mod"
+
+
+def test_prompt_command_conflict_prefix_all_prompts_for_prefix():
+    """Commands also prompt for the prefix; default is the module name."""
+    select_mock, text_mock = _make_inquirer_chain("prefix_all", "myprefix")
+    with (
+        patch("lola.prompts.inquirer.select", return_value=select_mock),
+        patch("lola.prompts.inquirer.text", return_value=text_mock) as mock_text,
+    ):
+        action, prefix = prompt_command_conflict("foo", "mod")
+    assert action == "prefix_all"
+    assert prefix == "myprefix"
+    assert mock_text.call_args.kwargs["default"] == "mod"
+
+
+def test_prompt_agent_conflict_prefix_all_prompts_for_prefix():
+    """Agents also prompt for the prefix; default is the module name."""
+    select_mock, text_mock = _make_inquirer_chain("prefix_all", "myprefix")
+    with (
+        patch("lola.prompts.inquirer.select", return_value=select_mock),
+        patch("lola.prompts.inquirer.text", return_value=text_mock) as mock_text,
+    ):
+        action, prefix = prompt_agent_conflict("foo", "mod")
+    assert action == "prefix_all"
+    assert prefix == "myprefix"
+    assert mock_text.call_args.kwargs["default"] == "mod"
+
+
+def test_prompt_conflict_offers_prefix_all_below_overwrite_all():
+    """The "Prefix All" choice must appear directly below "Overwrite All"."""
+    select_mock, _ = _make_inquirer_chain("skip")
+    with patch("lola.prompts.inquirer.select", return_value=select_mock) as mock_select:
+        prompt_skill_conflict("foo", "mod")
+    choice_values = [c.value for c in mock_select.call_args.kwargs["choices"]]
+    assert choice_values[:2] == ["overwrite_all", "prefix_all"]
+
+
 def test_prompt_command_conflict_offers_overwrite_all():
     select_mock, _ = _make_inquirer_chain("overwrite_all")
     with patch("lola.prompts.inquirer.select", return_value=select_mock) as mock_select:

--- a/tests/test_scoped_install_integration.py
+++ b/tests/test_scoped_install_integration.py
@@ -4,13 +4,15 @@ These tests verify the end-to-end install workflow for both user and project
 scopes, including file creation in the correct locations and registry records.
 """
 
+import os
 import shutil
 from unittest.mock import patch
 
 import pytest
+import yaml
 from click.testing import CliRunner
 
-from lola.cli.install import install_cmd
+from lola.cli.install import install_cmd, uninstall_cmd, update_cmd
 from lola.models import InstallationRegistry
 
 
@@ -232,3 +234,289 @@ def test_install_both_scopes_coexist(isolated_lola_home, sample_module, tmp_path
     assert project_skill.exists(), (
         f"Expected project scope skill file at {project_skill}"
     )
+
+
+def test_user_scope_install_records_cache_path(
+    isolated_lola_home, sample_module, tmp_path
+):
+    """User-scope install records the cwd-based cache path for later cleanup."""
+    runner = CliRunner()
+    shutil.copytree(sample_module, isolated_lola_home / "modules" / "test-module")
+
+    fake_home = tmp_path / "fakehome"
+    fake_home.mkdir()
+    install_cwd = tmp_path / "install-cwd"
+    install_cwd.mkdir()
+
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(install_cwd)
+        with patch("pathlib.Path.home", return_value=fake_home):
+            result = runner.invoke(
+                install_cmd,
+                ["test-module", "--scope", "user", "-a", "claude-code"],
+                catch_exceptions=False,
+            )
+    finally:
+        os.chdir(old_cwd)
+
+    assert result.exit_code == 0
+
+    registry = InstallationRegistry(isolated_lola_home / "installed.yml")
+    insts = registry.all()
+    assert len(insts) == 1
+    expected_cache = install_cwd.resolve() / ".lola" / "modules" / "test-module"
+    assert insts[0].cache_key is not None
+    assert [cache.path for cache in registry.module_caches()] == [str(expected_cache)]
+
+    # Local module copy actually exists at the recorded location.
+    assert expected_cache.exists()
+
+
+def test_user_scope_uninstall_removes_cache_from_different_cwd(
+    isolated_lola_home, sample_module, tmp_path
+):
+    """Bug #1 regression: uninstall run from a different cwd than the install
+    must still find and remove the original cache via the v2 cache record."""
+    runner = CliRunner()
+    shutil.copytree(sample_module, isolated_lola_home / "modules" / "test-module")
+
+    fake_home = tmp_path / "fakehome"
+    fake_home.mkdir()
+    install_cwd = tmp_path / "install-cwd"
+    install_cwd.mkdir()
+    uninstall_cwd = tmp_path / "elsewhere"
+    uninstall_cwd.mkdir()
+
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(install_cwd)
+        with patch("pathlib.Path.home", return_value=fake_home):
+            install_result = runner.invoke(
+                install_cmd,
+                ["test-module", "--scope", "user", "-a", "claude-code"],
+                catch_exceptions=False,
+            )
+        assert install_result.exit_code == 0
+
+        original_copy = install_cwd / ".lola" / "modules" / "test-module"
+        assert original_copy.exists()
+
+        # Now run uninstall from a totally different directory.
+        os.chdir(uninstall_cwd)
+        with patch("pathlib.Path.home", return_value=fake_home):
+            uninstall_result = runner.invoke(
+                uninstall_cmd,
+                ["test-module", "-f"],
+                catch_exceptions=False,
+            )
+    finally:
+        os.chdir(old_cwd)
+
+    assert uninstall_result.exit_code == 0
+    # Original local copy is gone (the fix).
+    assert not original_copy.exists()
+
+
+def test_user_scope_uninstall_from_different_cwd_does_not_touch_unrelated_symlink(
+    isolated_lola_home, sample_module, tmp_path
+):
+    """A same-named symlink in the uninstall cwd must NOT be deleted — the old
+    code did exactly that. Verify the recorded path is used instead."""
+    runner = CliRunner()
+    shutil.copytree(sample_module, isolated_lola_home / "modules" / "test-module")
+
+    fake_home = tmp_path / "fakehome"
+    fake_home.mkdir()
+    install_cwd = tmp_path / "install-cwd"
+    install_cwd.mkdir()
+    uninstall_cwd = tmp_path / "elsewhere"
+    uninstall_cwd.mkdir()
+
+    # Plant an unrelated same-named symlink at uninstall_cwd/.lola/modules/.
+    decoy_target = tmp_path / "decoy-target"
+    decoy_target.mkdir()
+    decoy_modules = uninstall_cwd / ".lola" / "modules"
+    decoy_modules.mkdir(parents=True)
+    decoy_symlink = decoy_modules / "test-module"
+    decoy_symlink.symlink_to(decoy_target)
+
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(install_cwd)
+        with patch("pathlib.Path.home", return_value=fake_home):
+            runner.invoke(
+                install_cmd,
+                ["test-module", "--scope", "user", "-a", "claude-code"],
+                catch_exceptions=False,
+            )
+
+        os.chdir(uninstall_cwd)
+        with patch("pathlib.Path.home", return_value=fake_home):
+            runner.invoke(
+                uninstall_cmd,
+                ["test-module", "-f"],
+                catch_exceptions=False,
+            )
+    finally:
+        os.chdir(old_cwd)
+
+    # Decoy is untouched.
+    assert decoy_symlink.is_symlink()
+    assert decoy_symlink.resolve() == decoy_target.resolve()
+    # Original is gone.
+    original_symlink = install_cwd / ".lola" / "modules" / "test-module"
+    assert not original_symlink.exists()
+
+
+def test_user_scope_update_reuses_recorded_cache_from_different_cwd(
+    isolated_lola_home, sample_module, tmp_path
+):
+    """User-scope update refreshes the install-time cache, not the current cwd."""
+    runner = CliRunner()
+    registered = isolated_lola_home / "modules" / "test-module"
+    shutil.copytree(sample_module, registered)
+
+    fake_home = tmp_path / "fakehome"
+    fake_home.mkdir()
+    install_cwd = tmp_path / "install-cwd"
+    install_cwd.mkdir()
+    update_cwd = tmp_path / "update-cwd"
+    update_cwd.mkdir()
+
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(install_cwd)
+        with patch("pathlib.Path.home", return_value=fake_home):
+            install_result = runner.invoke(
+                install_cmd,
+                ["test-module", "--scope", "user", "-a", "claude-code"],
+                catch_exceptions=False,
+            )
+        assert install_result.exit_code == 0
+
+        registered_skill = registered / "skills" / "test-skill" / "SKILL.md"
+        registered_skill.write_text(
+            "---\n"
+            "name: test-skill\n"
+            "description: A changed test skill\n"
+            "---\n"
+            "\n"
+            "# Changed\n"
+        )
+
+        os.chdir(update_cwd)
+        with patch("pathlib.Path.home", return_value=fake_home):
+            update_result = runner.invoke(
+                update_cmd,
+                ["test-module"],
+                catch_exceptions=False,
+            )
+    finally:
+        os.chdir(old_cwd)
+
+    assert update_result.exit_code == 0, update_result.output
+    original_cache_skill = (
+        install_cwd
+        / ".lola"
+        / "modules"
+        / "test-module"
+        / "skills"
+        / "test-skill"
+        / "SKILL.md"
+    )
+    assert "# Changed" in original_cache_skill.read_text()
+    assert not (update_cwd / ".lola" / "modules" / "test-module").exists()
+
+
+def test_filtered_uninstall_keeps_cache_when_other_assistant_references_it(
+    isolated_lola_home, sample_module, tmp_path
+):
+    """Uninstalling one assistant leaves the shared project cache in place."""
+    runner = CliRunner()
+    shutil.copytree(sample_module, isolated_lola_home / "modules" / "test-module")
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    for assistant in ("claude-code", "cursor"):
+        result = runner.invoke(
+            install_cmd,
+            ["test-module", str(project_dir), "-a", assistant],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+
+    cache_path = project_dir / ".lola" / "modules" / "test-module"
+    assert cache_path.exists()
+
+    uninstall_result = runner.invoke(
+        uninstall_cmd,
+        ["test-module", str(project_dir), "-a", "claude-code", "-f"],
+        catch_exceptions=False,
+    )
+
+    assert uninstall_result.exit_code == 0, uninstall_result.output
+    assert cache_path.exists()
+    registry = InstallationRegistry(isolated_lola_home / "installed.yml")
+    remaining = registry.all()
+    assert len(remaining) == 1
+    assert remaining[0].assistant == "cursor"
+    assert [cache.path for cache in registry.module_caches()] == [str(cache_path)]
+
+
+def test_uninstall_legacy_record_without_user_symlink_dir_does_not_crash(
+    isolated_lola_home, sample_module, tmp_path
+):
+    """Old user records without cache path metadata uninstall without guessing."""
+    runner = CliRunner()
+    shutil.copytree(sample_module, isolated_lola_home / "modules" / "test-module")
+
+    fake_home = tmp_path / "fakehome"
+    fake_home.mkdir()
+    registry_path = isolated_lola_home / "installed.yml"
+    registry_path.write_text(
+        yaml.safe_dump(
+            {
+                "version": "1.0",
+                "installations": [
+                    {
+                        "module": "test-module",
+                        "assistant": "claude-code",
+                        "scope": "user",
+                        "skills": ["test-skill"],
+                    }
+                ],
+            }
+        )
+    )
+    skill_dest = fake_home / ".claude" / "skills" / "test-skill"
+    skill_dest.mkdir(parents=True)
+    (skill_dest / "SKILL.md").write_text("content")
+
+    old_cwd = os.getcwd()
+    try:
+        # Plant a decoy symlink in a fresh uninstall cwd — the legacy path
+        # must NOT delete it (the old bug would).
+        uninstall_cwd = tmp_path / "elsewhere"
+        uninstall_cwd.mkdir()
+        decoy_target = tmp_path / "decoy-target"
+        decoy_target.mkdir()
+        decoy_modules = uninstall_cwd / ".lola" / "modules"
+        decoy_modules.mkdir(parents=True)
+        decoy_symlink = decoy_modules / "test-module"
+        decoy_symlink.symlink_to(decoy_target)
+
+        os.chdir(uninstall_cwd)
+        with patch("pathlib.Path.home", return_value=fake_home):
+            uninstall_result = runner.invoke(
+                uninstall_cmd,
+                ["test-module", "-f"],
+                catch_exceptions=False,
+            )
+    finally:
+        os.chdir(old_cwd)
+
+    assert uninstall_result.exit_code == 0
+    # Decoy untouched.
+    assert decoy_symlink.is_symlink()
+    assert decoy_symlink.resolve() == decoy_target.resolve()


### PR DESCRIPTION
## Summary

Adds an interactive item selector to `lola install` so users can opt out of skills, commands, agents, MCPs, or `AGENTS.md` instructions they don't want without forking the module. Closes #119.

- New CLI flags: `--skill` / `--command` / `--agent` / `--mcp` (each repeatable and comma-separated), `--instructions / --no-instructions`, plus `-y/--yes` to skip the picker.
- In TTY mode, `lola install` first asks "install everything?"; choosing no opens a fuzzy-searchable multi-select picker. Entries are type-prefixed (`skill: …`, `cmd: /…`, `agent: @…`, `mcp: …`, `instructions: AGENTS.md`). All entries start **deselected**; **Tab** toggles a single item and **Alt-A** inverts the current selection (toggle-all). Submitting with nothing checked is treated as a cancel.
- On reinstall, the picker pre-selects items already installed for the module (annotated `(installed)`) and marks newly-upstream items `(new)` so users can see the delta at a glance.
- New `Installation.full_install` flag locks cherry-picked installs to the original selection on `lola update` — newly-upstream items (skills, commands, agents, MCPs, or AGENTS.md) are not silently picked up. Full installs keep tracking upstream. Renamed registry entries are reapplied so picks survive reloads. Legacy `installed.yml` entries load as `full_install=True`; the field is only emitted to YAML when `False`.
- File-conflict prompts (skill / command / agent) gain an **Overwrite All** action that auto-overwrites every remaining collision of that kind for the current install.

## Related Issues

Closes #119

## Test Plan

- [x] `pytest` — 962 tests passing (new tests in `tests/test_cli_install_cherry_pick.py`)
- [x] `ruff check src tests` — clean
- [x] `bandit -r src` — clean (false-positive `B105` on the `__all__` sentinel suppressed with `# nosec`)
- [ ] Manual: `lola install <module>` asks "install everything?"; declining opens the fuzzy picker with everything deselected; Alt-A toggles all on; subsetting writes only chosen files and `full_install: false` to `installed.yml`
- [ ] Manual: `lola install <module> --skill foo --command bar` installs just `foo` + `bar`; omitted categories install nothing; `AGENTS.md` instructions are only written when `--instructions` is passed
- [ ] Manual: cherry-pick install + add a new skill upstream + `lola update` does **not** pick up the new skill; same flow with a full install does
- [ ] Manual: cherry-pick install that skipped instructions + drop an `AGENTS.md` upstream + `lola update` does **not** install instructions

## CLI shape

```
lola install my-module                            # asks "install everything?", then picker if no
lola install my-module -y                         # install everything, no prompt
lola install my-module --skill pr-review --skill commit
lola install my-module --skill pr-review,commit --command review
lola install my-module --skill pr-review --instructions
```

## AI Disclosure

AI-assisted with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)