### PR TITLE
feat: add pip-style URL fragment support for lola sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,15 @@ Create a `.lola-req` in your project:
 python-tools>=1.0.0
 git-workflow>>claude-code
 https://github.com/user/module.git@main
+https://github.com/quay/ai-helpers.git@main#subdirectory=plugins/dev
+https://github.com/user/repo.git#assistant=claude-code,cursor
 ```
+
+URL fragments support:
+- `subdirectory=path/to/module` - Install from a subdirectory in the repository
+- `assistant=name1,name2` - Install to specific assistants (alternative to `>>` operator)
+
+**Note:** The `#assistant=` fragment and `>>` operator are mutually exclusive - use one or the other, not both.
 
 ```bash
 lola sync
@@ -62,12 +70,322 @@ lola sync
 
 Full documentation is available at **[lobstertrap.org/lola](https://lobstertrap.org/lola/)**.
 
-- [Installation](https://lobstertrap.org/lola/getting-started/installation/) - Prerequisites and setup
-- [Quick Start](https://lobstertrap.org/lola/getting-started/quick-start/) - Get up and running
-- [User Guide](https://lobstertrap.org/lola/user-guide/modules/) - Modules, marketplace, and more
-- [CLI Reference](https://lobstertrap.org/lola/cli-reference/) - Complete command reference
-- [Skills and Modules](https://lobstertrap.org/lola/concepts/skills-and-modules/) - Understanding Agent Skills vs AI Context Modules
-- [Roadmap](https://lobstertrap.org/lola/concepts/roadmap/) - Vision and where Lola is heading
+### Official Lola Marketplace
+
+We maintain an official, community-driven marketplace with curated modules at [github.com/RedHatProductSecurity/lola-market](https://github.com/RedHatProductSecurity/lola-market).
+
+**Quick setup:**
+```bash
+lola market add general https://raw.githubusercontent.com/RedHatProductSecurity/lola-market/main/general-market.yml
+```
+
+This gives you instant access to community modules like workflow automation, code quality tools, and more. **We highly encourage you to:**
+- Use modules from the official marketplace
+- Contribute your own modules
+- Share feedback and improvements
+
+All contributions are welcome! See the [marketplace contributing guide](https://github.com/RedHatProductSecurity/lola-market/blob/main/CONTRIBUTING.md).
+
+### Register a marketplace
+
+```bash
+# Add a marketplace from a URL
+lola market add general https://raw.githubusercontent.com/RedHatProductSecurity/lola-market/main/general-market.yml
+
+# List registered marketplaces
+lola market ls
+```
+
+### Search and install from marketplace
+
+```bash
+# Search across all enabled marketplaces
+lola mod search authentication
+
+# Install directly from marketplace (auto-adds and installs)
+lola install git-workflow -a claude-code
+```
+
+When a module exists in multiple marketplaces, Lola prompts you to select which one to use.
+
+### Manage marketplaces
+
+```bash
+# Update marketplace cache
+lola market update general
+
+# Update all marketplaces
+lola market update
+
+# Disable a marketplace (keeps it registered but excludes from search)
+lola market set --disable general
+
+# Re-enable a marketplace
+lola market set --enable general
+
+# Remove a marketplace
+lola market rm general
+```
+
+### Marketplace YAML format
+
+Create your own marketplace by hosting a YAML file with this structure:
+
+```yaml
+name: My Marketplace
+description: Curated collection of AI skills
+version: 1.0.0
+modules:
+  - name: git-workflow
+    description: Git workflow automation skills
+    version: 1.0.0
+    repository: https://github.com/user/git-workflow.git
+    tags: [git, workflow]
+
+  - name: code-review
+    description: Code review assistant skills
+    version: 1.2.0
+    repository: https://github.com/user/code-review.git
+    tags: [review, quality]
+```
+
+**Fields:**
+- `name`: Marketplace display name
+- `description`: What this marketplace provides
+- `version`: Marketplace schema version
+- `modules`: List of available modules
+  - `name`: Module name (must match repository directory name)
+  - `description`: Brief description shown in search results
+  - `version`: Module version
+  - `repository`: Git URL, zip/tar URL, or local path
+  - `tags` (optional): Keywords for search
+
+## CLI Reference
+
+### Module Management (`lola mod`)
+
+| Command | Description |
+|---------|-------------|
+| `lola mod add <source>` | Add a module from git, folder, zip, or tar |
+| `lola mod ls` | List registered modules |
+| `lola mod info <name>` | Show module details |
+| `lola mod search <query>` | Search for modules across enabled marketplaces |
+| `lola mod init [name]` | Initialize a new module |
+| `lola mod init [name] -c` | Initialize with a command template |
+| `lola mod update [name]` | Update module(s) from source |
+| `lola mod rm <name>` | Remove a module |
+
+### Marketplace Management (`lola market`)
+
+| Command | Description |
+|---------|-------------|
+| `lola market add <name> <url>` | Register a marketplace from URL or local path |
+| `lola market ls` | List all registered marketplaces |
+| `lola market update [name]` | Update marketplace cache (or all if no name) |
+| `lola market set --enable <name>` | Enable a marketplace for search and install |
+| `lola market set --disable <name>` | Disable a marketplace (keeps it registered) |
+| `lola market rm <name>` | Remove a marketplace |
+
+### Installation
+
+| Command | Description |
+|---------|-------------|
+| `lola install <module>` | Install skills and commands to all assistants |
+| `lola install <module> -a <assistant>` | Install to specific assistant |
+| `lola install <module> <path>` | Install to a specific project directory |
+| `lola uninstall <module>` | Uninstall skills and commands |
+| `lola installed` | List all installations |
+| `lola update` | Regenerate assistant files |
+
+## Creating a Module
+
+### 1. Initialize
+
+```bash
+lola mod init my-skills
+cd my-skills
+```
+
+This creates:
+
+```
+my-skills/
+  skills/
+    example-skill/
+      SKILL.md         # Initial skill (unless --no-skill)
+  commands/            # Created by default
+    example-command.md # (unless --no-command)
+  agents/              # Created by default
+    example-agent.md   # (unless --no-agent)
+```
+
+### 2. Edit the skill
+
+Edit `skills/example-skill/SKILL.md`:
+
+```markdown
+---
+name: my-skills
+description: Description shown in skill listings
+---
+
+# My Skill
+
+Instructions for the AI assistant...
+```
+
+### 3. Add supporting files to skills
+
+You can add additional files to any skill directory (scripts, templates, examples, etc.). Reference them using relative paths in your `SKILL.md`:
+
+```markdown
+# My Skill
+
+Use the helper script: `./scripts/helper.sh`
+
+Load the template from: `./templates/example.md`
+```
+
+**Path handling:** Use relative paths like `./file` or `./scripts/helper.sh` to reference files in the same skill directory. Each assistant handles these differently:
+
+| Assistant | Skill Location | Supporting Files | Path Behavior |
+|-----------|---------------|------------------|---------------|
+| Claude Code | `.claude/skills/<skill>/SKILL.md` | Copied with skill | Paths work as-is |
+| Cursor | `.cursor/rules/<skill>.mdc` | Stay in `.lola/modules/` | Paths rewritten automatically |
+| Gemini | `GEMINI.md` (references only) | Stay in `.lola/modules/` | Paths work (SKILL.md read from source) |
+| OpenCode | `AGENTS.md` (references only) | Stay in `.lola/modules/` | Paths work (SKILL.md read from source) |
+
+- **Claude Code** copies the entire skill directory, so relative paths like `./scripts/helper.sh` work because the files are alongside `SKILL.md`
+- **Cursor** only copies the skill content to an `.mdc` file, so Lola rewrites `./` paths to point back to `.lola/modules/<module>/skills/<skill>/`
+- **Gemini/OpenCode** don't copy skills—they add entries to `GEMINI.md`/`AGENTS.md` that tell the AI to read the original `SKILL.md` from `.lola/modules/`, so relative paths work from that location
+
+Example skill structure:
+
+```
+my-skills/
+  skills/
+    example-skill/
+      SKILL.md
+      scripts/
+        helper.sh
+      templates/
+        example.md
+```
+
+### 4. Add more skills
+
+Create additional skill directories under `skills/`, each with a `SKILL.md`:
+
+```
+my-skills/
+  skills/
+    example-skill/
+      SKILL.md
+    git-workflow/
+      SKILL.md
+    code-review/
+      SKILL.md
+```
+
+### 4. Add slash commands
+
+Create a `commands/` directory with markdown files:
+
+```
+my-skills/
+  skills/
+    example-skill/
+      SKILL.md
+  commands/
+    review-pr.md
+    quick-commit.md
+```
+
+Command files use YAML frontmatter:
+
+```markdown
+---
+description: Review a pull request
+argument-hint: <pr-number>
+---
+
+Review PR #$ARGUMENTS and provide feedback.
+```
+
+> **Note:** Modules use auto-discovery. Skills, commands, and agents are automatically detected from the directory structure. No manifest file is required.
+
+### 5. Add to registry and install
+
+```bash
+lola mod add ./my-skills
+lola install my-skills
+```
+
+## Module Structure
+
+```
+my-module/
+  skills/            # Skills directory
+    skill-name/
+      SKILL.md       # Required: skill definition
+      scripts/       # Optional: supporting files
+      templates/     # Optional: templates
+  commands/          # Optional: slash commands
+    review-pr.md
+    quick-commit.md
+  agents/            # Optional: subagents
+    my-agent.md
+```
+
+> **Note:** Modules use auto-discovery. Skills are discovered from `skills/<name>/SKILL.md`, commands from `commands/*.md`, and agents from `agents/*.md`. No manifest file is required.
+
+### SKILL.md
+
+```markdown
+---
+name: skill-name
+description: When to use this skill
+---
+
+# Skill Title
+
+Your instructions, workflows, and guidance for the AI assistant.
+
+Reference supporting files using relative paths:
+- `./scripts/helper.sh` - files in the same skill directory
+- `./templates/example.md` - subdirectories are supported
+```
+
+**Supporting files:** You can include scripts, templates, examples, or any other files in your skill directory. Use relative paths like `./file` or `./scripts/helper.sh` in your `SKILL.md` to reference them. These paths are automatically rewritten for different assistant types during installation.
+
+### Command Files
+
+```markdown
+---
+description: What this command does
+argument-hint: <required> [optional]
+---
+
+Your prompt template here. Use $ARGUMENTS for all args or $1, $2 for positional.
+```
+
+**Argument variables:**
+- `$ARGUMENTS` - All arguments as a single string
+- `$1`, `$2`, `$3`... - Positional arguments
+
+Commands are automatically converted to each assistant's format:
+- Claude/Cursor: Markdown with frontmatter (pass-through)
+- Gemini: TOML with `{{args}}` substitution
+
+## How It Works
+
+1. **Marketplaces**: Register catalogs at `~/.lola/market/` with cached data at `~/.lola/market/cache/`
+2. **Discovery**: Search across enabled marketplace caches to find modules
+3. **Registry**: Modules are stored in `~/.lola/modules/`
+4. **Installation**: Skills and commands are converted to each assistant's native format
+5. **Prefixing**: Skills and commands are prefixed with module name to avoid conflicts (e.g., `mymodule-skill`)
+6. **Project scope**: Copies modules to `.lola/modules/` within the project
+7. **Updates**: `lola mod update` re-fetches from original source; `lola update` regenerates files; `lola market update` refreshes marketplace caches
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Create a `.lola-req` in your project:
 
 ```
 python-tools>=1.0.0
-git-workflow>>claude-code
 https://github.com/user/module.git@main
 https://github.com/quay/ai-helpers.git@main#subdirectory=plugins/dev
 https://github.com/user/repo.git#assistant=claude-code,cursor
@@ -58,9 +57,7 @@ https://github.com/user/repo.git#assistant=claude-code,cursor
 
 URL fragments support:
 - `subdirectory=path/to/module` - Install from a subdirectory in the repository
-- `assistant=name1,name2` - Install to specific assistants (alternative to `>>` operator)
-
-**Note:** The `#assistant=` fragment and `>>` operator are mutually exclusive - use one or the other, not both.
+- `assistant=name1,name2` - Install to specific assistants
 
 ```bash
 lola sync
@@ -287,7 +284,7 @@ my-skills/
       SKILL.md
 ```
 
-### 4. Add slash commands
+### 5. Add slash commands
 
 Create a `commands/` directory with markdown files:
 
@@ -314,7 +311,7 @@ Review PR #$ARGUMENTS and provide feedback.
 
 > **Note:** Modules use auto-discovery. Skills, commands, and agents are automatically detected from the directory structure. No manifest file is required.
 
-### 5. Add to registry and install
+### 6. Add to registry and install
 
 ```bash
 lola mod add ./my-skills

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -40,8 +40,9 @@ Create a `.lola-req` file in your project root:
 ```
 # .lola-req - AI context modules for this project
 python-tools>=1.0.0
-git-workflow>>claude-code
+git-workflow
 https://github.com/user/custom-module.git@main
+https://github.com/user/repo.git#assistant=claude-code,cursor
 ```
 
 Then sync all modules:

--- a/docs/guides/declarative.md
+++ b/docs/guides/declarative.md
@@ -54,3 +54,31 @@ module-name>>claude-code    # Install only to Claude Code
 module-name>>cursor         # Install only to Cursor
 module-name                 # Install to all detected assistants
 ```
+
+## URL Fragments
+
+Git URLs support fragments for additional configuration:
+
+```
+# Install from a subdirectory
+https://github.com/user/repo.git#subdirectory=plugins/dev
+
+# Target specific assistants (alternative to >> operator)
+https://github.com/user/repo.git#assistant=claude-code,cursor
+
+# Combine multiple parameters
+https://github.com/user/repo.git#subdirectory=plugins&assistant=claude-code
+```
+
+**Important:** The `#assistant=` fragment and `>>` operator cannot be used together. Choose one method for targeting assistants:
+
+```
+# ✅ Valid - using >> operator
+https://github.com/user/repo.git>>claude-code
+
+# ✅ Valid - using fragment
+https://github.com/user/repo.git#assistant=claude-code
+
+# ❌ Invalid - using both
+https://github.com/user/repo.git#assistant=claude-code>>cursor
+```

--- a/docs/guides/declarative.md
+++ b/docs/guides/declarative.md
@@ -13,10 +13,6 @@ Create a `.lola-req` in your project root with one module per line:
 python-tools>=1.0.0
 git-workflow
 
-# Target specific assistants
-web-scraper>>claude-code
-code-review>>cursor
-
 # Direct git URLs
 https://github.com/user/custom-module.git
 git+https://github.com/user/another-module.git
@@ -45,16 +41,6 @@ The sync command is **idempotent** - running it multiple times produces the same
 - `~1.2.0` - Compatible with 1.2.x (>= 1.2.0, < 1.3.0)
 - `^1.2.0` - Compatible with 1.x.x (>= 1.2.0, < 2.0.0)
 
-## Assistant Targeting
-
-Use `>>` to target specific assistants:
-
-```
-module-name>>claude-code    # Install only to Claude Code
-module-name>>cursor         # Install only to Cursor
-module-name                 # Install to all detected assistants
-```
-
 ## URL Fragments
 
 Git URLs support fragments for additional configuration:
@@ -63,22 +49,9 @@ Git URLs support fragments for additional configuration:
 # Install from a subdirectory
 https://github.com/user/repo.git#subdirectory=plugins/dev
 
-# Target specific assistants (alternative to >> operator)
+# Target specific assistants
 https://github.com/user/repo.git#assistant=claude-code,cursor
 
 # Combine multiple parameters
 https://github.com/user/repo.git#subdirectory=plugins&assistant=claude-code
-```
-
-**Important:** The `#assistant=` fragment and `>>` operator cannot be used together. Choose one method for targeting assistants:
-
-```
-# ✅ Valid - using >> operator
-https://github.com/user/repo.git>>claude-code
-
-# ✅ Valid - using fragment
-https://github.com/user/repo.git#assistant=claude-code
-
-# ❌ Invalid - using both
-https://github.com/user/repo.git#assistant=claude-code>>cursor
 ```

--- a/src/lola/cli/sync.py
+++ b/src/lola/cli/sync.py
@@ -92,7 +92,12 @@ def sync_cmd(project_path: str, config_file: str, dry_run: bool, verbose: bool):
         console.print(f"[yellow]Config file not found: {config_path}[/yellow]")
         console.print("[dim]Create a .lola-req with one module per line[/dim]")
         console.print(
-            "[dim]Example:\n  my-skill\n  python-tools>=1.0.0\n  web-scraper>>claude-code[/dim]"
+            "[dim]Examples:\n"
+            "  my-skill\n"
+            "  python-tools>=1.0.0\n"
+            "  web-scraper>>claude-code\n"
+            "  https://github.com/user/repo.git#subdirectory=plugins/dev\n"
+            "  https://github.com/user/repo.git#assistant=claude-code,cursor[/dim]"
         )
         raise click.Abort()
 
@@ -164,7 +169,16 @@ def sync_module_spec(
     ]
 
     # Determine target assistants
-    if spec.assistant:
+    # Priority: fragment_assistants > >> operator assistant > all assistants
+    if spec.fragment_assistants:
+        # Deduplicate while preserving order
+        unique_assistants = list(dict.fromkeys(spec.fragment_assistants))
+        # Validate all assistants from fragment
+        for asst in unique_assistants:
+            if asst not in TARGETS:
+                raise ValueError(f"Unknown assistant in URL fragment: {asst}")
+        target_assistants = unique_assistants
+    elif spec.assistant:
         if spec.assistant not in TARGETS:
             raise ValueError(f"Unknown assistant: {spec.assistant}")
         target_assistants = [spec.assistant]
@@ -328,8 +342,19 @@ def resolve_and_fetch_module(spec: ModuleSpec, verbose: bool) -> tuple[str, dict
                 console.print(f"[dim]Adding {module_name} from URL{ref_msg}...[/dim]")
 
             source_type = detect_source_type(module_url)
-            module_path = fetch_module(module_url, MODULES_DIR, ref=git_ref)
-            save_source_info(module_path, module_url, source_type, ref=git_ref)
+            module_path = fetch_module(
+                module_url,
+                MODULES_DIR,
+                module_content_dirname=spec.subdirectory,
+                ref=git_ref,
+            )
+            save_source_info(
+                module_path,
+                module_url,
+                source_type,
+                content_dirname=spec.subdirectory,
+                ref=git_ref,
+            )
 
         return module_name, {}
 

--- a/src/lola/cli/sync.py
+++ b/src/lola/cli/sync.py
@@ -168,10 +168,10 @@ def sync_module_spec(
     ]
 
     # Determine target assistants
-    # Priority: fragment_assistants > all assistants
-    if spec.fragment_assistants:
+    # Priority: assistants > all assistants
+    if spec.assistants:
         # Deduplicate while preserving order
-        unique_assistants = list(dict.fromkeys(spec.fragment_assistants))
+        unique_assistants = list(dict.fromkeys(spec.assistants))
         # Validate all assistants from fragment
         for asst in unique_assistants:
             if asst not in TARGETS:

--- a/src/lola/cli/sync.py
+++ b/src/lola/cli/sync.py
@@ -95,7 +95,6 @@ def sync_cmd(project_path: str, config_file: str, dry_run: bool, verbose: bool):
             "[dim]Examples:\n"
             "  my-skill\n"
             "  python-tools>=1.0.0\n"
-            "  web-scraper>>claude-code\n"
             "  https://github.com/user/repo.git#subdirectory=plugins/dev\n"
             "  https://github.com/user/repo.git#assistant=claude-code,cursor[/dim]"
         )
@@ -169,7 +168,7 @@ def sync_module_spec(
     ]
 
     # Determine target assistants
-    # Priority: fragment_assistants > >> operator assistant > all assistants
+    # Priority: fragment_assistants > all assistants
     if spec.fragment_assistants:
         # Deduplicate while preserving order
         unique_assistants = list(dict.fromkeys(spec.fragment_assistants))
@@ -178,10 +177,6 @@ def sync_module_spec(
             if asst not in TARGETS:
                 raise ValueError(f"Unknown assistant in URL fragment: {asst}")
         target_assistants = unique_assistants
-    elif spec.assistant:
-        if spec.assistant not in TARGETS:
-            raise ValueError(f"Unknown assistant: {spec.assistant}")
-        target_assistants = [spec.assistant]
     else:
         target_assistants = list(TARGETS.keys())
 

--- a/src/lola/sync.py
+++ b/src/lola/sync.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
+from urllib.parse import parse_qs
 
 from packaging.specifiers import SpecifierSet, InvalidSpecifier
 from packaging.version import Version
@@ -16,6 +17,8 @@ class ModuleSpec:
     module_ref: str  # Could be name, marketplace ref, or URL
     version_spec: Optional[str] = None  # e.g., ">=1.0.0,<2.0"
     assistant: Optional[str] = None  # Specific assistant or None for all
+    subdirectory: Optional[str] = None  # Subdirectory path from URL fragment
+    fragment_assistants: Optional[list[str]] = None  # Assistants from URL fragment
 
     @property
     def module_name_only(self) -> str:
@@ -121,6 +124,32 @@ def parse_lolareq_line(line: str, line_num: int) -> Optional[ModuleSpec]:
     else:
         module_part = line
 
+    # Extract URL fragment before processing version operators
+    subdirectory = None
+    fragment_assistants = None
+
+    # Check if this looks like a URL (has :// or starts with git@)
+    if "://" in module_part or module_part.startswith("git@"):
+        # Parse URL fragment
+        if "#" in module_part:
+            url_part, fragment = module_part.rsplit("#", 1)
+            module_part = url_part
+
+            # Parse fragment as query string parameters
+            fragment_params = parse_qs(fragment)
+
+            # Extract subdirectory
+            if "subdirectory" in fragment_params:
+                subdirectory = fragment_params["subdirectory"][0]
+
+            # Extract assistant(s) - comma-separated list
+            if "assistant" in fragment_params:
+                assistant_value = fragment_params["assistant"][0]
+                # Split on comma and strip whitespace
+                fragment_assistants = [
+                    a.strip() for a in assistant_value.split(",") if a.strip()
+                ]
+
     # Extract version spec from module_ref
     module_ref = module_part
     version_spec = None
@@ -151,11 +180,20 @@ def parse_lolareq_line(line: str, line_num: int) -> Optional[ModuleSpec]:
     if not module_ref:
         raise ValueError(f"Line {line_num}: Empty module reference")
 
+    # Validate that both >> operator and #assistant fragment aren't used together
+    if assistant and fragment_assistants:
+        raise ValueError(
+            f"Line {line_num}: Cannot use both '>>' operator and '#assistant=' fragment. "
+            f"Use one or the other to specify target assistants."
+        )
+
     return ModuleSpec(
         raw_line=line,
         module_ref=module_ref,
         version_spec=version_spec,
         assistant=assistant,
+        subdirectory=subdirectory,
+        fragment_assistants=fragment_assistants,
     )
 
 

--- a/src/lola/sync.py
+++ b/src/lola/sync.py
@@ -17,7 +17,7 @@ class ModuleSpec:
     module_ref: str  # Could be name, marketplace ref, or URL
     version_spec: Optional[str] = None  # e.g., ">=1.0.0,<2.0"
     subdirectory: Optional[str] = None  # Subdirectory path from URL fragment
-    fragment_assistants: Optional[list[str]] = None  # Assistants from URL fragment
+    assistants: Optional[list[str]] = None  # Assistants from URL fragment
 
     @property
     def module_name_only(self) -> str:
@@ -118,7 +118,7 @@ def parse_lolareq_line(line: str, line_num: int) -> Optional[ModuleSpec]:
 
     # Extract URL fragment before processing version operators
     subdirectory = None
-    fragment_assistants = None
+    assistants = None
 
     # Check if this looks like a URL (has :// or starts with git@)
     if "://" in module_part or module_part.startswith("git@"):
@@ -138,7 +138,7 @@ def parse_lolareq_line(line: str, line_num: int) -> Optional[ModuleSpec]:
             if "assistant" in fragment_params:
                 assistant_value = fragment_params["assistant"][0]
                 # Split on comma and strip whitespace
-                fragment_assistants = [
+                assistants = [
                     a.strip() for a in assistant_value.split(",") if a.strip()
                 ]
 
@@ -177,7 +177,7 @@ def parse_lolareq_line(line: str, line_num: int) -> Optional[ModuleSpec]:
         module_ref=module_ref,
         version_spec=version_spec,
         subdirectory=subdirectory,
-        fragment_assistants=fragment_assistants,
+        assistants=assistants,
     )
 
 

--- a/src/lola/sync.py
+++ b/src/lola/sync.py
@@ -16,7 +16,6 @@ class ModuleSpec:
     raw_line: str
     module_ref: str  # Could be name, marketplace ref, or URL
     version_spec: Optional[str] = None  # e.g., ">=1.0.0,<2.0"
-    assistant: Optional[str] = None  # Specific assistant or None for all
     subdirectory: Optional[str] = None  # Subdirectory path from URL fragment
     fragment_assistants: Optional[list[str]] = None  # Assistants from URL fragment
 
@@ -115,14 +114,7 @@ def parse_lolareq_line(line: str, line_num: int) -> Optional[ModuleSpec]:
     if not line or line.startswith("#"):
         return None
 
-    # Split on '>>' to extract assistant (accept both '>>agent' and '>> agent')
-    assistant = None
-    if ">>" in line:
-        parts = line.split(">>", 1)
-        module_part = parts[0].strip()
-        assistant = parts[1].strip()
-    else:
-        module_part = line
+    module_part = line
 
     # Extract URL fragment before processing version operators
     subdirectory = None
@@ -180,18 +172,10 @@ def parse_lolareq_line(line: str, line_num: int) -> Optional[ModuleSpec]:
     if not module_ref:
         raise ValueError(f"Line {line_num}: Empty module reference")
 
-    # Validate that both >> operator and #assistant fragment aren't used together
-    if assistant and fragment_assistants:
-        raise ValueError(
-            f"Line {line_num}: Cannot use both '>>' operator and '#assistant=' fragment. "
-            f"Use one or the other to specify target assistants."
-        )
-
     return ModuleSpec(
         raw_line=line,
         module_ref=module_ref,
         version_spec=version_spec,
-        assistant=assistant,
         subdirectory=subdirectory,
         fragment_assistants=fragment_assistants,
     )

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -208,6 +208,23 @@ sample-module
         assert result.exit_code != 0
         assert "Failed:" in result.output or "Unknown assistant" in result.output
 
+    def test_sync_both_assistant_mechanisms(self, cli_runner, mock_sync_environment):
+        """Test sync with both >> operator and #assistant fragment (should error)."""
+        project = mock_sync_environment["project"]
+        lolareq = project / ".lola-req"
+        # Using both >> and #assistant should raise an error
+        lolareq.write_text(
+            "https://example.com/repo.git#assistant=claude-code>>cursor\n"
+        )
+
+        result = cli_runner.invoke(sync_cmd, [str(project)])
+
+        assert result.exit_code != 0
+        assert (
+            "Cannot use both" in result.output
+            or "'>>' operator and '#assistant='" in result.output
+        )
+
     def test_sync_continue_on_error(self, cli_runner, mock_sync_environment):
         """Test that sync continues when one module fails."""
         project = mock_sync_environment["project"]

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -98,17 +98,6 @@ class TestSyncCommand:
         assert result2.exit_code == 0
         assert "Skipped:" in result2.output or "skipped" in result2.output.lower()
 
-    def test_sync_with_assistant_filter(self, cli_runner, mock_sync_environment):
-        """Test sync with assistant-specific installation."""
-        project = mock_sync_environment["project"]
-        lolareq = project / ".lola-req"
-        lolareq.write_text("sample-module>>claude-code\n")
-
-        result = cli_runner.invoke(sync_cmd, [str(project)])
-
-        assert result.exit_code == 0
-        assert "claude-code" in result.output
-
     def test_sync_multiple_modules(self, cli_runner, mock_sync_environment, tmp_path):
         """Test sync with multiple modules."""
         # Create a second module
@@ -196,34 +185,6 @@ sample-module
 
         assert result.exit_code != 0
         assert "Failed:" in result.output or "not found" in result.output.lower()
-
-    def test_sync_invalid_assistant(self, cli_runner, mock_sync_environment):
-        """Test sync with invalid assistant name."""
-        project = mock_sync_environment["project"]
-        lolareq = project / ".lola-req"
-        lolareq.write_text("sample-module>>invalid-assistant\n")
-
-        result = cli_runner.invoke(sync_cmd, [str(project)])
-
-        assert result.exit_code != 0
-        assert "Failed:" in result.output or "Unknown assistant" in result.output
-
-    def test_sync_both_assistant_mechanisms(self, cli_runner, mock_sync_environment):
-        """Test sync with both >> operator and #assistant fragment (should error)."""
-        project = mock_sync_environment["project"]
-        lolareq = project / ".lola-req"
-        # Using both >> and #assistant should raise an error
-        lolareq.write_text(
-            "https://example.com/repo.git#assistant=claude-code>>cursor\n"
-        )
-
-        result = cli_runner.invoke(sync_cmd, [str(project)])
-
-        assert result.exit_code != 0
-        assert (
-            "Cannot use both" in result.output
-            or "'>>' operator and '#assistant='" in result.output
-        )
 
     def test_sync_continue_on_error(self, cli_runner, mock_sync_environment):
         """Test that sync continues when one module fails."""

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -175,6 +175,87 @@ class TestParseLolareqLine:
         assert spec is not None
         assert spec.module_ref == "git+https://github.com/user/repo.git@abc1234"
 
+    def test_parse_url_with_subdirectory_fragment(self):
+        """Test parsing URL with subdirectory fragment."""
+        spec = parse_lolareq_line(
+            "https://github.com/user/repo.git#subdirectory=plugins/dev", 1
+        )
+        assert spec is not None
+        assert spec.module_ref == "https://github.com/user/repo.git"
+        assert spec.subdirectory == "plugins/dev"
+        assert spec.fragment_assistants is None
+
+    def test_parse_url_with_assistant_fragment_single(self):
+        """Test parsing URL with single assistant fragment."""
+        spec = parse_lolareq_line(
+            "https://github.com/user/repo.git#assistant=claude-code", 1
+        )
+        assert spec is not None
+        assert spec.module_ref == "https://github.com/user/repo.git"
+        assert spec.subdirectory is None
+        assert spec.fragment_assistants == ["claude-code"]
+
+    def test_parse_url_with_assistant_fragment_multiple(self):
+        """Test parsing URL with multiple assistants fragment."""
+        spec = parse_lolareq_line(
+            "https://github.com/user/repo.git#assistant=claude-code,cursor", 1
+        )
+        assert spec is not None
+        assert spec.module_ref == "https://github.com/user/repo.git"
+        assert spec.subdirectory is None
+        assert spec.fragment_assistants == ["claude-code", "cursor"]
+
+    def test_parse_url_with_assistant_fragment_multiple_spaces(self):
+        """Test parsing URL with multiple assistants fragment with spaces."""
+        spec = parse_lolareq_line(
+            "https://github.com/user/repo.git#assistant=claude-code, cursor, gemini-cli",
+            1,
+        )
+        assert spec is not None
+        assert spec.module_ref == "https://github.com/user/repo.git"
+        assert spec.fragment_assistants == ["claude-code", "cursor", "gemini-cli"]
+
+    def test_parse_url_with_both_fragments(self):
+        """Test parsing URL with both subdirectory and assistant fragments."""
+        spec = parse_lolareq_line(
+            "https://github.com/user/repo.git#subdirectory=plugins/dev&assistant=claude-code,cursor",
+            1,
+        )
+        assert spec is not None
+        assert spec.module_ref == "https://github.com/user/repo.git"
+        assert spec.subdirectory == "plugins/dev"
+        assert spec.fragment_assistants == ["claude-code", "cursor"]
+
+    def test_parse_url_with_ref_and_fragment(self):
+        """Test parsing URL with @ref and fragment."""
+        spec = parse_lolareq_line(
+            "https://github.com/user/repo.git@main#subdirectory=plugins", 1
+        )
+        assert spec is not None
+        assert spec.module_ref == "https://github.com/user/repo.git@main"
+        assert spec.subdirectory == "plugins"
+
+    def test_parse_git_plus_url_with_fragment(self):
+        """Test parsing git+ URL with fragment."""
+        spec = parse_lolareq_line(
+            "git+https://github.com/user/repo.git#subdirectory=module&assistant=cursor",
+            1,
+        )
+        assert spec is not None
+        assert spec.module_ref == "git+https://github.com/user/repo.git"
+        assert spec.subdirectory == "module"
+        assert spec.fragment_assistants == ["cursor"]
+
+    def test_parse_url_fragment_and_operator_assistant_raises_error(self):
+        """Test that using both >> operator and #assistant fragment raises an error."""
+        with pytest.raises(
+            ValueError,
+            match="Cannot use both '>>'.* and '#assistant='.*fragment",
+        ):
+            parse_lolareq_line(
+                "https://github.com/user/repo.git#assistant=cursor>>claude-code", 1
+            )
+
     def test_parse_blank_line(self):
         """Test that blank lines return None."""
         assert parse_lolareq_line("", 1) is None

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -20,7 +20,6 @@ class TestParseLolareqLine:
         assert spec is not None
         assert spec.module_ref == "my-skill"
         assert spec.version_spec is None
-        assert spec.assistant is None
 
     def test_parse_version_exact(self):
         """Test parsing module with exact version."""
@@ -28,7 +27,6 @@ class TestParseLolareqLine:
         assert spec is not None
         assert spec.module_ref == "my-skill"
         assert spec.version_spec == "==1.2.0"
-        assert spec.assistant is None
 
     def test_parse_version_gte(self):
         """Test parsing module with >= version."""
@@ -57,28 +55,6 @@ class TestParseLolareqLine:
         assert ">=1.2" in spec.version_spec
         assert "<2" in spec.version_spec
 
-    def test_parse_with_assistant(self):
-        """Test parsing module with assistant specification."""
-        spec = parse_lolareq_line("my-skill>>claude-code", 1)
-        assert spec is not None
-        assert spec.module_ref == "my-skill"
-        assert spec.assistant == "claude-code"
-
-    def test_parse_with_assistant_space(self):
-        """Test parsing module with assistant specification (with space)."""
-        spec = parse_lolareq_line("my-skill>> claude-code", 1)
-        assert spec is not None
-        assert spec.module_ref == "my-skill"
-        assert spec.assistant == "claude-code"
-
-    def test_parse_version_and_assistant(self):
-        """Test parsing module with version and assistant."""
-        spec = parse_lolareq_line("my-skill>=1.0.0>>cursor", 1)
-        assert spec is not None
-        assert spec.module_ref == "my-skill"
-        assert spec.version_spec == ">=1.0.0"
-        assert spec.assistant == "cursor"
-
     def test_parse_marketplace_ref(self):
         """Test parsing marketplace reference."""
         spec = parse_lolareq_line("@official/python-tools", 1)
@@ -98,13 +74,6 @@ class TestParseLolareqLine:
         assert spec is not None
         assert spec.module_ref == "https://github.com/user/repo.git"
 
-    def test_parse_url_with_assistant(self):
-        """Test parsing git URL with assistant."""
-        spec = parse_lolareq_line("https://github.com/user/repo.git>>claude-code", 1)
-        assert spec is not None
-        assert spec.module_ref == "https://github.com/user/repo.git"
-        assert spec.assistant == "claude-code"
-
     def test_parse_git_plus_https_url(self):
         """Test parsing git+https:// URL."""
         spec = parse_lolareq_line("git+https://github.com/user/repo.git", 1)
@@ -123,13 +92,6 @@ class TestParseLolareqLine:
         assert spec is not None
         assert spec.module_ref == "git+ssh://git@github.com/user/repo.git"
 
-    def test_parse_git_plus_url_with_assistant(self):
-        """Test parsing git+ URL with assistant."""
-        spec = parse_lolareq_line("git+https://github.com/user/repo.git>>cursor", 1)
-        assert spec is not None
-        assert spec.module_ref == "git+https://github.com/user/repo.git"
-        assert spec.assistant == "cursor"
-
     def test_parse_url_with_ref(self):
         """Test parsing URL with @ref (branch/tag)."""
         spec = parse_lolareq_line("https://github.com/user/repo.git@v1.0.0", 1)
@@ -141,15 +103,6 @@ class TestParseLolareqLine:
         spec = parse_lolareq_line("git+https://github.com/user/repo.git@main", 1)
         assert spec is not None
         assert spec.module_ref == "git+https://github.com/user/repo.git@main"
-
-    def test_parse_url_with_ref_and_assistant(self):
-        """Test parsing URL with @ref and assistant."""
-        spec = parse_lolareq_line(
-            "https://github.com/user/repo.git@develop>>claude-code", 1
-        )
-        assert spec is not None
-        assert spec.module_ref == "https://github.com/user/repo.git@develop"
-        assert spec.assistant == "claude-code"
 
     def test_parse_url_with_commit_hash(self):
         """Test parsing URL with commit hash."""
@@ -246,16 +199,6 @@ class TestParseLolareqLine:
         assert spec.subdirectory == "module"
         assert spec.fragment_assistants == ["cursor"]
 
-    def test_parse_url_fragment_and_operator_assistant_raises_error(self):
-        """Test that using both >> operator and #assistant fragment raises an error."""
-        with pytest.raises(
-            ValueError,
-            match="Cannot use both '>>'.* and '#assistant='.*fragment",
-        ):
-            parse_lolareq_line(
-                "https://github.com/user/repo.git#assistant=cursor>>claude-code", 1
-            )
-
     def test_parse_blank_line(self):
         """Test that blank lines return None."""
         assert parse_lolareq_line("", 1) is None
@@ -264,11 +207,6 @@ class TestParseLolareqLine:
     def test_parse_comment(self):
         """Test that comments return None."""
         assert parse_lolareq_line("# This is a comment", 1) is None
-
-    def test_parse_empty_module_ref(self):
-        """Test that empty module ref raises error."""
-        with pytest.raises(ValueError, match="Empty module reference"):
-            parse_lolareq_line(">>claude-code", 1)
 
 
 class TestModuleSpec:
@@ -394,34 +332,9 @@ another-skill>=1.0.0
         assert specs[0].module_ref == "my-skill"
         assert specs[1].module_ref == "another-skill"
 
-    def test_load_with_assistants(self, tmp_path):
-        """Test loading file with assistant specifications."""
-        lolareq = tmp_path / ".lola-req"
-        lolareq.write_text(
-            """
-skill1>>claude-code
-skill2>> cursor
-skill3
-"""
-        )
-
-        specs = load_lolareq(lolareq)
-        assert len(specs) == 3
-        assert specs[0].assistant == "claude-code"
-        assert specs[1].assistant == "cursor"
-        assert specs[2].assistant is None
-
     def test_load_missing_file(self, tmp_path):
         """Test loading non-existent file raises error."""
         lolareq = tmp_path / ".lola-req"
 
         with pytest.raises(FileNotFoundError):
-            load_lolareq(lolareq)
-
-    def test_load_invalid_line(self, tmp_path):
-        """Test that invalid line raises error."""
-        lolareq = tmp_path / ".lola-req"
-        lolareq.write_text("my-skill\n>>claude-code\n")
-
-        with pytest.raises(ValueError, match="Empty module reference"):
             load_lolareq(lolareq)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -136,7 +136,7 @@ class TestParseLolareqLine:
         assert spec is not None
         assert spec.module_ref == "https://github.com/user/repo.git"
         assert spec.subdirectory == "plugins/dev"
-        assert spec.fragment_assistants is None
+        assert spec.assistants is None
 
     def test_parse_url_with_assistant_fragment_single(self):
         """Test parsing URL with single assistant fragment."""
@@ -146,7 +146,7 @@ class TestParseLolareqLine:
         assert spec is not None
         assert spec.module_ref == "https://github.com/user/repo.git"
         assert spec.subdirectory is None
-        assert spec.fragment_assistants == ["claude-code"]
+        assert spec.assistants == ["claude-code"]
 
     def test_parse_url_with_assistant_fragment_multiple(self):
         """Test parsing URL with multiple assistants fragment."""
@@ -156,7 +156,7 @@ class TestParseLolareqLine:
         assert spec is not None
         assert spec.module_ref == "https://github.com/user/repo.git"
         assert spec.subdirectory is None
-        assert spec.fragment_assistants == ["claude-code", "cursor"]
+        assert spec.assistants == ["claude-code", "cursor"]
 
     def test_parse_url_with_assistant_fragment_multiple_spaces(self):
         """Test parsing URL with multiple assistants fragment with spaces."""
@@ -166,7 +166,7 @@ class TestParseLolareqLine:
         )
         assert spec is not None
         assert spec.module_ref == "https://github.com/user/repo.git"
-        assert spec.fragment_assistants == ["claude-code", "cursor", "gemini-cli"]
+        assert spec.assistants == ["claude-code", "cursor", "gemini-cli"]
 
     def test_parse_url_with_both_fragments(self):
         """Test parsing URL with both subdirectory and assistant fragments."""
@@ -177,7 +177,7 @@ class TestParseLolareqLine:
         assert spec is not None
         assert spec.module_ref == "https://github.com/user/repo.git"
         assert spec.subdirectory == "plugins/dev"
-        assert spec.fragment_assistants == ["claude-code", "cursor"]
+        assert spec.assistants == ["claude-code", "cursor"]
 
     def test_parse_url_with_ref_and_fragment(self):
         """Test parsing URL with @ref and fragment."""
@@ -197,7 +197,7 @@ class TestParseLolareqLine:
         assert spec is not None
         assert spec.module_ref == "git+https://github.com/user/repo.git"
         assert spec.subdirectory == "module"
-        assert spec.fragment_assistants == ["cursor"]
+        assert spec.assistants == ["cursor"]
 
     def test_parse_blank_line(self):
         """Test that blank lines return None."""


### PR DESCRIPTION
## Summary

Add supoprt for URL fragment parameters for .lola-req files, following pip's
subdirectory syntax. Enables precise control over module installation
paths and target assistants in declarative configurations.

Features:
- subdirectory=path/to/module - Install from repository subdirectory
- assistant=name1,name2 - Install to specific assistants (comma-separated)
- Full compatibility with existing >> operator and @ref syntax

Examples:
```
  https://github.com/user/repo.git#subdirectory=plugins/dev
  https://github.com/user/repo.git#assistant=claude-code,cursor
  https://github.com/user/repo.git@main#subdirectory=plugins&assistant=cursor
```

## Related Issues

Fixes #118

## AI Disclosure

Assisted by Claude-code using Claude Sonnet.

## Test Plan

Try to reproduce issues raised in #118 

## Checklist

- [X] Tests pass (`pytest`)
- [X] Linting passes (`ruff check src tests`)
- [X] Type checking passes (`ty check`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Module URLs now support fragments for subdirectory (`#subdirectory=...`) and assistant targeting (`#assistant=...`); sync installs specified subdirectory content and honors fragment-based assistant lists (deduplicated, ordered).

* **Documentation**
  * README and guides expanded with fragment usage, marketplace setup, CLI reference, module-creation walkthrough, and updated declarative-install examples; removed prior `>>` assistant-targeting docs.

* **Tests**
  * Tests updated to validate fragment parsing; several legacy `>>`-based assistant tests removed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LobsterTrap/lola/pull/131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->