### PR TITLE
feat: add -s short form for --scope on install and uninstall

### DIFF
--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -745,6 +745,7 @@ def _format_update_summary(result: UpdateResult) -> str:
     "Pass a name like 'work' to target ~/.openclaw/workspace-work.",
 )
 @click.option(
+    "-s",
     "--scope",
     type=click.Choice(["project", "user"]),
     default="project",
@@ -981,6 +982,7 @@ def install_cmd(
     "-f", "--force", is_flag=True, help="Force uninstall without confirmation"
 )
 @click.option(
+    "-s",
     "--scope",
     type=click.Choice(["project", "user"]),
     default=None,

--- a/tests/test_cli_install_scope.py
+++ b/tests/test_cli_install_scope.py
@@ -5,6 +5,14 @@ from click.testing import CliRunner
 from lola.cli.install import install_cmd
 
 
+def test_install_scope_short_form():
+    """-s is a short alias for --scope."""
+    runner = CliRunner()
+    result = runner.invoke(install_cmd, ["--help"])
+    assert result.exit_code == 0
+    assert "-s, --scope" in result.output
+
+
 def test_install_user_scope_with_explicit_path_fails():
     """User scope with explicit project path should fail."""
     runner = CliRunner()

--- a/tests/test_cli_mod.py
+++ b/tests/test_cli_mod.py
@@ -99,6 +99,22 @@ class TestModAdd:
         assert result.exit_code == 1
         assert "path separators" in result.output.lower()
 
+    def test_add_next_steps_hint(self, cli_runner, sample_module, tmp_path):
+        """The post-add hint references install's -a and -s flags."""
+        modules_dir = tmp_path / ".lola" / "modules"
+        modules_dir.mkdir(parents=True)
+
+        with (
+            patch("lola.cli.mod.MODULES_DIR", modules_dir),
+            patch("lola.cli.mod.ensure_lola_dirs"),
+        ):
+            result = cli_runner.invoke(mod, ["add", str(sample_module)])
+
+        assert result.exit_code == 0
+        assert "Next steps:" in result.output
+        assert "-a <assistant>" in result.output
+        assert "-s <scope>" in result.output
+
 
 class TestModList:
     """Tests for mod ls command."""

--- a/tests/test_uninstall_scope.py
+++ b/tests/test_uninstall_scope.py
@@ -13,11 +13,11 @@ class TestUninstallScopeFilter:
     """Test --scope filter for uninstall command."""
 
     def test_scope_option_exists(self):
-        """Verify --scope option is registered on uninstall_cmd."""
+        """Verify --scope (with -s short form) is registered on uninstall_cmd."""
         runner = CliRunner()
         result = runner.invoke(uninstall_cmd, ["--help"])
         assert result.exit_code == 0
-        assert "--scope" in result.output
+        assert "-s, --scope" in result.output
 
     def test_uninstall_filters_by_scope_user(self, mock_lola_home, tmp_path):
         """Uninstall with --scope user should only remove user-scoped installations."""


### PR DESCRIPTION
## Summary

The post-add 'Next steps' hint suggested `lola install <mod> -a <assistant> -s <scope>`, but `-s` was not a valid option. Add `-s` as the short form for `--scope` on both install and uninstall so the hint is correct and the flag is consistent with other paired short/long options in the CLI.

## Related Issues

Fixes: #129

## Checklist

- [x] Tests pass (`pytest`)
- [x] Linting passes (`ruff check src tests`)
- [x] Type checking passes (`ty check`)

## AI Disclosure

Ai assisted using Claude Opus 4.7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now use `-s` as a short alias for `--scope` in the install and uninstall commands.

* **Tests**
  * Added test coverage for the short scope option alias.
  * Added test coverage for next steps guidance in the mod add command.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LobsterTrap/lola/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->