### PR TITLE
fix: show "No ADRs found" fallback in adr-list

### DIFF
--- a/mk/adr.mk
+++ b/mk/adr.mk
@@ -21,8 +21,12 @@ adr-new: ## - Create new ADR: make adr-new TOPIC-NAME
 	@cd $(ADR_DIR) && adr new $(filter-out $@,$(MAKECMDGOALS))
 
 adr-list: ## - List all ADRs
-	@cd $(ADR_DIR) 2>/dev/null && ls -1 *.md | grep -E '^[0-9]' | sort || \
-		echo "No ADRs found. Create one with: make adr-new TOPIC-NAME"
+	@found=$$(ls -1 $(ADR_DIR)/*.md 2>/dev/null | xargs -n1 basename 2>/dev/null | grep -E '^[0-9]' | sort); \
+	if [ -n "$$found" ]; then \
+		echo "$$found"; \
+	else \
+		echo "No ADRs found. Create one with: make adr-new TOPIC-NAME"; \
+	fi
 
 adr-help: ## - Show ADR usage and examples
 	@echo "Lola ADR (Architecture Decision Records) Management"

--- a/mk/adr.mk
+++ b/mk/adr.mk
@@ -21,7 +21,7 @@ adr-new: ## - Create new ADR: make adr-new TOPIC-NAME
 	@cd $(ADR_DIR) && adr new $(filter-out $@,$(MAKECMDGOALS))
 
 adr-list: ## - List all ADRs
-	@found=$$(ls -1 $(ADR_DIR)/*.md 2>/dev/null | xargs -n1 basename 2>/dev/null | grep -E '^[0-9]' | sort); \
+	@found=$$(cd "$(ADR_DIR)" 2>/dev/null && ls -1 *.md 2>/dev/null | grep -E '^[0-9]' | sort); \
 	if [ -n "$$found" ]; then \
 		echo "$$found"; \
 	else \


### PR DESCRIPTION
## Summary

- `make adr-list` was silent when `docs/adr/` contained no numbered ADRs (only `README.md` and `template.md`). Neither the list nor the "No ADRs found" fallback printed.
- Root cause: the recipe relied on `ls | grep | sort` pipeline exit codes. When `grep` matched nothing it exited 1, but `sort` of empty input exits 0, so the pipeline succeeded and the `||` fallback never fired. (Shell precedence also tied the `||` to the whole pipeline rather than to the `cd`.)
- Fix: capture the filtered list into a variable and branch on whether it's empty.

Fixes #135

## Test plan

- [x] `make adr-list` with only `README.md` + `template.md` present → prints "No ADRs found…"
- [x] `make adr-list` with numbered ADRs present → prints sorted list
- [x] `make adr-list` with `docs/adr/` missing → prints "No ADRs found…"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced error handling and user feedback when listing Architecture Decision Records, now gracefully handles missing or empty ADR directories with helpful guidance for creating new records.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LobsterTrap/lola/pull/136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->