### PR TITLE
build: add make targets for install, uninstall, test, lint, clean, distclean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,6 @@ help: ## - print the help and usage
 		sed 's/^[^:]*://' | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+include mk/dev.mk
 include mk/mkdocs.mk
 include mk/adr.mk

--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -1,0 +1,63 @@
+# Development workflow targets
+# install, uninstall, test, lint — all driven through uv against the local .venv.
+
+# Pin uv to the project-local virtualenv. This overrides any global
+# UV_PROJECT_ENVIRONMENT a developer may have set, guaranteeing every
+# `uv sync` / `uv run` here targets ./.venv.
+export UV_PROJECT_ENVIRONMENT := $(CURDIR)/.venv
+
+# Necessary for operating systems with old pythons
+export UV_MANAGED_PYTHON := 1
+
+.PHONY: install uninstall test lint clean distclean run
+
+install: ## - install project + dev dependencies into local .venv (creates/updates .venv as needed)
+	@echo "Syncing dev environment into $(UV_PROJECT_ENVIRONMENT)..."
+	@uv sync --group dev
+	@uv tool install --force --editable .
+
+uninstall: ## - remove the lola-ai package from the local .venv (dev deps remain)
+	@echo "Uninstalling lola-ai from $(UV_PROJECT_ENVIRONMENT)...";
+	@uv pip uninstall lola-ai || echo "Nothing to uninstall";
+
+test: ## - run the pytest suite
+	@echo "Running tests..."
+	@uv run pytest
+
+run: ## - run the installed lola CLI; pass args via ARGS="..." (e.g., make run ARGS="mod ls")
+	@uv run lola $(ARGS)
+
+lint: ## - run ruff (check + format check) and mypy on src
+	@echo "Running ruff check..."
+	@uv run ruff check src tests
+	@echo "Running ruff format check..."
+	@uv run ruff format --check src tests
+	@echo "Running mypy..."
+	@uv run mypy src
+
+# Subtrees clean must never descend into: virtualenv, lola state, git internals.
+# -prune (not -not -path) is required to skip the subtree entirely — otherwise
+# find still descends and hits permission errors inside .lola/modules/.
+CLEAN_PRUNE := \( -path './.venv' -o -path './.lola' -o -path './.git' \) -prune
+
+clean: ## - remove build artifacts, caches, coverage, and Python bytecode (leaves .venv intact)
+	@echo "Cleaning build artifacts..."
+	@rm -rf build/ dist/
+	@find . $(CLEAN_PRUNE) -o -type d -name '*.egg-info' -exec rm -rf {} +
+	@echo "Cleaning lint, type-check, and test caches..."
+	@rm -rf .pytest_cache/ .ruff_cache/ .mypy_cache/
+	@echo "Cleaning coverage artifacts..."
+	@rm -rf .coverage htmlcov/
+	@echo "Cleaning test output..."
+	@rm -rf .test-output/
+	@echo "Cleaning Python bytecode..."
+	@find . $(CLEAN_PRUNE) -o -type d -name __pycache__ -exec rm -rf {} +
+	@find . $(CLEAN_PRUNE) -o -type f -name '*.pyc' -exec rm -f {} +
+	@echo "Done."
+
+distclean: clean docs-clean ## - deep clean: also removes .venv and generated _version.py (slow to rebuild)
+	@echo "Removing virtual environment at $(UV_PROJECT_ENVIRONMENT)..."
+	@rm -rf "$(UV_PROJECT_ENVIRONMENT)"
+	@echo "Removing hatch-vcs generated _version.py..."
+	@rm -f src/lola/_version.py
+	@echo "Done. Run 'make install' to rebuild the environment."


### PR DESCRIPTION
## Summary

Adds the following usual `make` targets:

- install: uv sync --group dev (creates or updates .venv)
- uninstall: removes lola-ai package; graceful no-op when no .venv
- test: uv run pytest (auto-syncs venv if missing)
- lint: ruff check + format check + mypy
- clean: prunes caches, build artifacts, bytecode; preserves .venv, .lola, and .git via find -prune to avoid descending into restricted subtrees
- distclean: cascades clean + docs-clean, then removes .venv and the hatch-vcs _version.py

## Related Issues

Fixes: #130 

## Checklist

- [x] Tests pass (`pytest`)
- [x] Linting passes (`ruff check src tests`)
- [x] Type checking passes (`ty check`)

## AI Disclosure


AI Use - Claude Opus 4.7 (1M context)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added developer-oriented commands to streamline the local development workflow: create/sync the project virtual environment and dependencies, run/uninstall the CLI, execute tests, and perform lint/format/type checks.
  * Added cleanup targets to remove build artifacts, caches, coverage outputs, bytecode, and an optional command to fully remove the local virtual environment and derived files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LobsterTrap/lola/pull/138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->