### PR TITLE
fix: correct mcp.json to mcps.json in docs

### DIFF
--- a/docs/concepts/skills-and-modules.md
+++ b/docs/concepts/skills-and-modules.md
@@ -25,7 +25,7 @@ my-project/
   module/                   # AI Module Directory
     AGENTS.md               # AI Main Spec
     commands/               # Assistant Commands
-    mcp.json                # MCP Settings
+    mcps.json               # MCP Settings
     my-skill-A/             # Skill following agentskills.io
       SKILL.md
       scripts/

--- a/docs/guides/creating-modules.md
+++ b/docs/guides/creating-modules.md
@@ -1,6 +1,6 @@
 # Creating Modules
 
-Lola modules can be a single [Agent Skill](https://agentskills.io/specification) or a full [AI Context Module](../concepts/skills-and-modules.md). An Agent Skill is a standalone `SKILL.md` with optional supporting files. An AI Context Module is a superset - it wraps one or more skills alongside `AGENTS.md`, `commands/`, and `mcp.json` inside a `module/` directory.
+Lola modules can be a single [Agent Skill](https://agentskills.io/specification) or a full [AI Context Module](../concepts/skills-and-modules.md). An Agent Skill is a standalone `SKILL.md` with optional supporting files. An AI Context Module is a superset - it wraps one or more skills alongside `AGENTS.md`, `commands/`, and `mcps.json` inside a `module/` directory.
 
 ## Initialize an AI Context Module
 


### PR DESCRIPTION
## Summary
- Two doc pages (`docs/concepts/skills-and-modules.md` and `docs/guides/creating-modules.md`) incorrectly referenced `mcp.json` instead of the canonical `mcps.json`
- The source code, config constant (`MCPS_FILE`), tests, and example modules all use `mcps.json` (plural)

## Test plan
- [x] Verified all source code references use `mcps.json`
- [x] Confirmed docs now match the canonical filename

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected MCP configuration filename references in AI Context Module documentation and the Creating Modules guide for consistency with current naming conventions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LobsterTrap/lola/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->