### PR TITLE
docs: fix module taxonomy — two types not three

### DIFF
--- a/docs/concepts/skills-and-modules.md
+++ b/docs/concepts/skills-and-modules.md
@@ -20,7 +20,7 @@ my-skill/
 
 **Skill Pack** — multiple related skills grouped together:
 
-```
+```text
 my-skills/
   skills/
     skill-a/

--- a/docs/concepts/skills-and-modules.md
+++ b/docs/concepts/skills-and-modules.md
@@ -6,12 +6,27 @@ Lola distributes two types of AI context packages: **Agent Skills** and **AI Con
 
 An Agent Skill is a standalone context file following the [AgentSkills.io](https://agentskills.io/specification) standard. It is the fundamental unit of AI context - a markdown file (`SKILL.md`) with optional supporting assets that can be loaded by an agent on demand for In-Context Learning (ICL).
 
+Agent Skills come in two forms:
+
+**Standalone** — a single focused skill:
+
 ```
 my-skill/
   SKILL.md              # Required: skill definition
   scripts/              # Optional: executable scripts
   reference/            # Optional: documentation
   assets/               # Optional: other supporting files
+```
+
+**Skill Pack** — multiple related skills grouped together:
+
+```
+my-skills/
+  skills/
+    skill-a/
+      SKILL.md
+    skill-b/
+      SKILL.md
 ```
 
 A skill injects context into the LLM's runtime memory, guiding it to return more precise results. It translates your workflows and knowledge into transferable instructions an agent can execute.
@@ -46,10 +61,10 @@ AI Context Modules also solve the problem where a developer wants to integrate t
 
 | | Agent Skill | AI Context Module |
 |---|---|---|
-| **Use case** | Single focused capability | Complete agent context |
-| **Contents** | SKILL.md + optional assets | Multiple skills + AGENTS.md + commands + MCP |
+| **Use case** | Single focused capability (standalone or skill pack) | Complete agent context |
+| **Contents** | SKILL.md + optional assets; or `skills/` directory with multiple skills | Multiple skills + AGENTS.md + commands + MCP |
 | **Standard** | [AgentSkills.io](https://agentskills.io/specification) | Lola extension of the standard |
-| **Example** | A code review skill | A full DevSecOps module with review, security, and compliance skills |
+| **Example** | A code review skill, or a pack of review + lint + test skills | A full DevSecOps module with review, security, and compliance skills |
 | **Init** | Manual or future `lola skill init` | `lola mod init` |
 
 See [Installing Modules](../guides/modules.md) for more details.

--- a/docs/guides/modules.md
+++ b/docs/guides/modules.md
@@ -52,7 +52,7 @@ Agent Skills come in two forms:
 
 **Standalone** — a single skill following the [agentskills.io](https://agentskills.io/specification) standard:
 
-```
+```text
 my-skill/
   SKILL.md           # Required
   scripts/           # Optional
@@ -60,7 +60,7 @@ my-skill/
 
 **Skill Pack** — multiple related skills grouped together:
 
-```
+```text
 my-skills/
   skills/
     skill-a/

--- a/docs/guides/modules.md
+++ b/docs/guides/modules.md
@@ -44,11 +44,13 @@ lola mod rm my-skills
 
 ## Module Structure
 
-Lola supports three module patterns:
+Lola supports two module types. See [Skills and Context Modules](../concepts/skills-and-modules.md) for full definitions.
 
-### Single Skill
+### Agent Skills
 
-Follows the [agentskills.io](https://agentskills.io/specification) standard:
+Agent Skills come in two forms:
+
+**Standalone** — a single skill following the [agentskills.io](https://agentskills.io/specification) standard:
 
 ```
 my-skill/
@@ -56,18 +58,18 @@ my-skill/
   scripts/           # Optional
 ```
 
-### Skill Bundle
-
-Multiple related skills packaged together:
+**Skill Pack** — multiple related skills grouped together:
 
 ```
-my-bundle/
+my-skills/
   skills/
-    skill-a/SKILL.md
-    skill-b/SKILL.md
+    skill-a/
+      SKILL.md
+    skill-b/
+      SKILL.md
 ```
 
-### AI Context Module (recommended)
+### AI Context Module (recommended for complete contexts)
 
 Complete module with instructions, skills, commands, and agents:
 


### PR DESCRIPTION
## Summary

- Expand `skills-and-modules.md` to show both Agent Skill variants (standalone and skill pack)
- Collapse `modules.md` module structure from three patterns to two, aligned with concepts page
- Add cross-reference from guides to concepts page as source of truth

## Related Issues

Fixes #143

## Test Plan

- [x] Both pages describe exactly two types: Agent Skills and AI Context Modules
- [x] Agent Skills section clearly shows standalone and skill pack layouts
- [x] `modules.md` links to `skills-and-modules.md` for type definitions

## Checklist

- [x] Tests pass (`pytest`)
- [x] Linting passes (`ruff check src tests`)
- [x] Type checking passes (`ty check`)

## AI Disclosure

AI-assisted with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that Agent Skills can be configured as either standalone skills or grouped into Skill Packs, with guidance on when to use each form.
  * Added example directory layouts to illustrate Skill Pack organization.
  * Revised module patterns docs to describe the two supported module types and to position the AI Context Module as the full-context option.
  * Minor formatting and table clarifications for readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LobsterTrap/lola/pull/144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->