### PR TITLE
docs: add GOVERNANCE.md with roles and release cadence

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -5,25 +5,17 @@ contributors may hold, how decisions are made, and how to participate in the pro
 
 ## Roles
 
-### Lead
-
-The project Lead sets the overall direction of Lola, has the final tie-break on
-decisions where consensus cannot be reached, and holds Core Maintainer rights.
-
-| Name | GitHub |
-|------|--------|
-| Igor Brandao | [@mrbrandao](https://github.com/mrbrandao) |
-
 ### Core Maintainer
 
 Core Maintainers have full merge rights across the project, participate in all
 governance decisions, and are responsible for nominating new Maintainers and Core
-Maintainers.
+Maintainers. When consensus cannot be reached, the Founding Architect holds the
+tiebreak vote.
 
-| Name | GitHub |
-|------|--------|
-| Igor Brandao | [@mrbrandao](https://github.com/mrbrandao) |
-| Katie Mulliken | [@SecKatie](https://github.com/SecKatie) |
+| Name | Role |
+|------|------|
+| [@mrbrandao](https://github.com/mrbrandao) via [Matrix](https://matrix.to/#/@mrbrandao:matrix.org) | Founding Architect |
+| [@SecKatie](https://github.com/SecKatie) via [Matrix](https://matrix.to/#/@katie:glitches.chat) | Co-Architect |
 
 ### Maintainer
 
@@ -44,26 +36,27 @@ Maintainers over time.
 The project has a lightweight contributor ladder:
 
 ```text
-Contributor → Maintainer → Core Maintainer → Lead
+Contributor → Maintainer → Core Maintainer
 ```
 
 Advancement is invitation-based — a Core Maintainer nominates a candidate based on
 sustained, quality contributions over time. There is no hard commit count; what matters
 is the quality and consistency of contributions and alignment with the project's goals.
 
-Nominations are approved by lazy consensus among Core Maintainers (see
-[Decision-Making](#decision-making)).
+Nominations are approved by [lazy consensus](https://community.apache.org/committers/lazyConsensus.html)
+among Core Maintainers (see [Decision-Making](#decision-making)).
 
 ## Decision-Making
 
 Day-to-day decisions (PR merges, bug fixes, documentation, dependency updates) use
-**lazy consensus**: a Maintainer or Core Maintainer approves the change, and if no
-objection is raised within 48 hours, the change lands.
+**[lazy consensus](https://community.apache.org/committers/lazyConsensus.html)**:
+a Maintainer or Core Maintainer approves the change, and if no objection is raised
+within 2 business days, the change lands.
 
 Significant decisions (architectural changes, breaking changes, new major features,
 adding or removing Maintainers or Core Maintainers) are discussed openly in GitHub
-Issues or Discussions. If consensus cannot be reached, the Lead has the final
-tie-break.
+Issues or Discussions. If consensus cannot be reached, the Founding Architect holds
+the final tiebreak vote.
 
 ## Pull Requests
 
@@ -82,14 +75,16 @@ may be cut at any time when a critical fix is needed.
 This project follows the
 [Contributor Covenant Code of Conduct v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
 Violations may be reported to the Core Maintainers via a GitHub Discussion marked
-private, or by contacting the Lead directly.
+private, or by contacting a Core Maintainer directly:
+[@mrbrandao](https://github.com/mrbrandao) via [Matrix](https://matrix.to/#/@mrbrandao:matrix.org)
+or [@SecKatie](https://github.com/SecKatie) via [Matrix](https://matrix.to/#/@katie:glitches.chat).
 
 ## Communication
 
 Project discussions happen openly in
 [GitHub Issues](https://github.com/LobsterTrap/lola/issues) and
 [GitHub Discussions](https://github.com/LobsterTrap/lola/discussions).
-A community channel is planned and will be linked here once available.
+Join us on Matrix: [#lola-ai:matrix.org](https://matrix.to/#/#lola-ai:matrix.org)
 
 ## Amendments
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,97 @@
+# Governance
+
+This document defines the governance of the Lola project. It describes the roles
+contributors may hold, how decisions are made, and how to participate in the project.
+
+## Roles
+
+### Lead
+
+The project Lead sets the overall direction of Lola, has the final tie-break on
+decisions where consensus cannot be reached, and holds Core Maintainer rights.
+
+| Name | GitHub |
+|------|--------|
+| Igor Brandao | [@mrbrandao](https://github.com/mrbrandao) |
+
+### Core Maintainer
+
+Core Maintainers have full merge rights across the project, participate in all
+governance decisions, and are responsible for nominating new Maintainers and Core
+Maintainers.
+
+| Name | GitHub |
+|------|--------|
+| Igor Brandao | [@mrbrandao](https://github.com/mrbrandao) |
+| Katie Mulliken | [@SecKatie](https://github.com/SecKatie) |
+
+### Maintainer
+
+Maintainers are active contributors who have been nominated by a Core Maintainer and
+approved by the existing Core Maintainers. Maintainers have merge rights and assist
+in reviewing and landing contributions.
+
+There are currently no designated Maintainers beyond the Core Maintainers listed above.
+
+### Contributor
+
+A Contributor is anyone who has had a pull request merged into the project. Contributors
+are the starting point on the contributor ladder and are eligible to be nominated as
+Maintainers over time.
+
+## Contributor Ladder
+
+The project has a lightweight contributor ladder:
+
+```text
+Contributor → Maintainer → Core Maintainer → Lead
+```
+
+Advancement is invitation-based — a Core Maintainer nominates a candidate based on
+sustained, quality contributions over time. There is no hard commit count; what matters
+is the quality and consistency of contributions and alignment with the project's goals.
+
+Nominations are approved by lazy consensus among Core Maintainers (see
+[Decision-Making](#decision-making)).
+
+## Decision-Making
+
+Day-to-day decisions (PR merges, bug fixes, documentation, dependency updates) use
+**lazy consensus**: a Maintainer or Core Maintainer approves the change, and if no
+objection is raised within 48 hours, the change lands.
+
+Significant decisions (architectural changes, breaking changes, new major features,
+adding or removing Maintainers or Core Maintainers) are discussed openly in GitHub
+Issues or Discussions. If consensus cannot be reached, the Lead has the final
+tie-break.
+
+## Pull Requests
+
+- Every PR requires at least one approval from a Maintainer or Core Maintainer.
+- Authors may not approve or merge their own PRs.
+- Trivial changes (typos, broken links, formatting) may be merged by any Maintainer
+  after a short window with no objections.
+
+## Releases
+
+Lola targets a monthly release on the **last Wednesday of each month**. Patch releases
+may be cut at any time when a critical fix is needed.
+
+## Code of Conduct
+
+This project follows the
+[Contributor Covenant Code of Conduct v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+Violations may be reported to the Core Maintainers via a GitHub Discussion marked
+private, or by contacting the Lead directly.
+
+## Communication
+
+Project discussions happen openly in
+[GitHub Issues](https://github.com/LobsterTrap/lola/issues) and
+[GitHub Discussions](https://github.com/LobsterTrap/lola/discussions).
+A community channel is planned and will be linked here once available.
+
+## Amendments
+
+Changes to this document require a pull request approved by all current Core
+Maintainers.

--- a/README.md
+++ b/README.md
@@ -424,6 +424,10 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 
 Lola is governed by its maintainers. See [GOVERNANCE.md](GOVERNANCE.md) for the project's roles, decision-making process, and release cadence.
 
+## Community
+
+Join the community on Matrix: [#lola-ai:matrix.org](https://matrix.to/#/#lola-ai:matrix.org)
+
 ## License
 
 [GPL-2.0-or-later](https://spdx.org/licenses/GPL-2.0-or-later.html)

--- a/README.md
+++ b/README.md
@@ -420,6 +420,10 @@ This project follows the [Contributor Covenant Code of Conduct v2.1](CODE_OF_CON
 
 Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
+## Governance
+
+Lola is governed by its maintainers. See [GOVERNANCE.md](GOVERNANCE.md) for the project's roles, decision-making process, and release cadence.
+
 ## License
 
 [GPL-2.0-or-later](https://spdx.org/licenses/GPL-2.0-or-later.html)

--- a/docs/dev-guide/contributing.md
+++ b/docs/dev-guide/contributing.md
@@ -2,7 +2,7 @@
 
 We welcome contributions to Lola! For the full contributing guide, see [CONTRIBUTING.md](https://github.com/LobsterTrap/lola/blob/main/CONTRIBUTING.md).
 
-For project roles, decision-making process, and release cadence, see [GOVERNANCE.md](https://github.com/LobsterTrap/lola/blob/main/GOVERNANCE.md).
+For project roles, decision-making process, and release cadence, see [GOVERNANCE.md](../../GOVERNANCE.md).
 
 ## Quick Start
 

--- a/docs/dev-guide/contributing.md
+++ b/docs/dev-guide/contributing.md
@@ -2,6 +2,8 @@
 
 We welcome contributions to Lola! For the full contributing guide, see [CONTRIBUTING.md](https://github.com/LobsterTrap/lola/blob/main/CONTRIBUTING.md).
 
+For project roles, decision-making process, and release cadence, see [GOVERNANCE.md](https://github.com/LobsterTrap/lola/blob/main/GOVERNANCE.md).
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## Summary

- Add `GOVERNANCE.md` defining project roles (Lead, Core Maintainer, Maintainer, Contributor), contributor ladder, decision-making process, release cadence (monthly, last Wednesday), and communication channels
- Link `GOVERNANCE.md` from `README.md` and `docs/dev-guide/contributing.md`

## Related Issues

Part of AAIF readiness work.

## Test Plan

- [ ] GOVERNANCE.md is present at repo root
- [ ] README.md links to GOVERNANCE.md
- [ ] docs/dev-guide/contributing.md links to GOVERNANCE.md

## Checklist

- [x] Tests pass (`pytest`)
- [x] Linting passes (`ruff check src tests`)
- [x] Type checking passes (`ty check`)

## AI Disclosure

AI-assisted with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added governance documentation detailing contributor roles and invitation ladder, decision-making via lazy consensus with a 2-business-day objection window and tie-break process, PR approval rules (no self-merge, required maintainer approval, short no-objection path for trivial changes), monthly releases plus ad-hoc patches, Code of Conduct reporting, communication channels, and amendment rules
  * Updated README and contributor guide to reference the governance docs and community channels (Matrix invite)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LobsterTrap/lola/pull/150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->