### PR TITLE
docs: add SECURITY.md with disclosure policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,10 @@ Commands are automatically converted to each assistant's format:
 
 This project follows the [Contributor Covenant Code of Conduct v2.1](CODE_OF_CONDUCT.md).
 
+## Security
+
+For reporting vulnerabilities, see [SECURITY.md](SECURITY.md).
+
 ## Contributing
 
 Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,59 @@
+# Security Policy
+
+## Supported Versions
+
+Lola is currently pre-1.0. Security fixes are applied to the **latest release only**.
+We encourage all users to keep Lola up to date.
+
+| Version | Supported |
+|---------|-----------|
+| Latest  | Yes |
+| Older releases | No |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+To report a vulnerability, use GitHub's private vulnerability reporting:
+[Report a vulnerability](https://github.com/LobsterTrap/lola/security/advisories/new)
+
+Alternatively, you can contact the maintainers directly via
+[GitHub Discussions](https://github.com/LobsterTrap/lola/discussions) with a
+private message to a Core Maintainer.
+
+Please include the following in your report:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce the issue
+- Any suggested mitigations or patches, if available
+
+## Disclosure Policy
+
+We follow a coordinated disclosure process:
+
+1. **Acknowledge** — We will acknowledge receipt of your report within **5 business days**.
+2. **Investigate** — We will investigate and keep you informed of our progress.
+3. **Fix** — We aim to release a fix within **30 days** of confirmation. Complex
+   vulnerabilities may take longer; we will communicate any delays.
+4. **Disclose** — We will coordinate the public disclosure date with you. We ask that
+   you do not disclose the vulnerability publicly until a fix is available.
+
+We are committed to recognizing reporters who responsibly disclose vulnerabilities.
+
+## Security Best Practices
+
+- Always install Lola from the official PyPI package (`pip install lola-ai`) or the
+  official GitHub releases.
+- Verify release checksums when downloading binaries directly.
+- Review any skills or modules before installing them, as they may contain executable
+  scripts that run on your system.
+- Keep Lola updated to the latest release to receive security patches.
+
+## Scope
+
+Security issues in Lola's own code are in scope. The following are generally out of
+scope:
+
+- Vulnerabilities in third-party skills or modules distributed via the marketplace
+- Issues in the AI assistants Lola installs to (Claude Code, Cursor, etc.)
+- Social engineering attacks

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,9 +17,8 @@ We encourage all users to keep Lola up to date.
 To report a vulnerability, use GitHub's private vulnerability reporting:
 [Report a vulnerability](https://github.com/LobsterTrap/lola/security/advisories/new)
 
-Alternatively, you can contact the maintainers directly via
-[GitHub Discussions](https://github.com/LobsterTrap/lola/discussions) with a
-private message to a Core Maintainer.
+Do not use public GitHub issues or discussions for vulnerability details as they
+are visible to everyone.
 
 Please include the following in your report:
 

--- a/docs/dev-guide/contributing.md
+++ b/docs/dev-guide/contributing.md
@@ -3,6 +3,7 @@
 We welcome contributions to Lola! For the full contributing guide, see [CONTRIBUTING.md](https://github.com/LobsterTrap/lola/blob/main/CONTRIBUTING.md).
 
 For project roles, decision-making process, and release cadence, see [GOVERNANCE.md](../../GOVERNANCE.md).
+For security vulnerabilities, see [SECURITY.md](../../docs/SECURITY.md).
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

- Add `SECURITY.md` with supported versions, vulnerability reporting process (GitHub private advisories), coordinated disclosure policy, security best practices, and scope definition
- Link `SECURITY.md` from `README.md` (before Contributing section to avoid conflicts with governance PR) and `docs/dev-guide/contributing.md`

## Related Issues

Part of AAIF readiness work. Required for OpenSSF Best Practices Badge application.

## Test Plan

- [ ] SECURITY.md is present at repo root
- [ ] README.md links to SECURITY.md
- [ ] docs/dev-guide/contributing.md links to SECURITY.md
- [ ] GitHub private vulnerability reporting URL is valid

## Checklist

- [x] Tests pass (`pytest`)
- [x] Linting passes (`ruff check src tests`)
- [x] Type checking passes (`ty check`)

## AI Disclosure

AI-assisted with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive security policy covering supported versions, private vulnerability reporting channels, required report contents, coordinated disclosure timeline, and user-facing security best practices.
  * Updated project README and contributing guide to point to the new security policy and reporting guidelines for handling vulnerabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LobsterTrap/lola/pull/151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->