### PR TITLE
feat: add -a/--assistant flag to lola sync

### DIFF
--- a/src/lola/cli/sync.py
+++ b/src/lola/cli/sync.py
@@ -79,7 +79,20 @@ def _fetch_from_marketplace_quiet(
 )
 @click.option("--dry-run", is_flag=True, help="Show what would be installed")
 @click.option("-v", "--verbose", is_flag=True, help="Show detailed output")
-def sync_cmd(project_path: str, config_file: str, dry_run: bool, verbose: bool):
+@click.option(
+    "-a",
+    "--assistant",
+    type=click.Choice(list(TARGETS.keys())),
+    multiple=True,
+    help="AI assistant(s) to sync for (repeatable, default: all detected assistants)",
+)
+def sync_cmd(
+    project_path: str,
+    config_file: str,
+    dry_run: bool,
+    verbose: bool,
+    assistant: tuple[str, ...],
+):
     """Sync modules from configuration file."""
     project = Path(project_path).resolve()
 
@@ -121,7 +134,7 @@ def sync_cmd(project_path: str, config_file: str, dry_run: bool, verbose: bool):
     # Process each spec
     for spec in specs:
         try:
-            result = sync_module_spec(spec, project, dry_run, verbose)
+            result = sync_module_spec(spec, project, dry_run, verbose, assistant)
             if result == "installed":
                 installed.append(spec.raw_line)
             elif result == "skipped":
@@ -140,7 +153,11 @@ def sync_cmd(project_path: str, config_file: str, dry_run: bool, verbose: bool):
 
 
 def sync_module_spec(
-    spec: ModuleSpec, project_path: Path, dry_run: bool, verbose: bool
+    spec: ModuleSpec,
+    project_path: Path,
+    dry_run: bool,
+    verbose: bool,
+    cli_assistants: tuple[str, ...] = (),
 ) -> str:
     """
     Sync a single module spec.
@@ -168,14 +185,16 @@ def sync_module_spec(
     ]
 
     # Determine target assistants
-    # Priority: assistants > all assistants
-    if spec.assistants:
+    # Priority: CLI flag > URL fragment > all assistants
+    if cli_assistants:
+        target_assistants = list(dict.fromkeys(cli_assistants))
+    elif spec.assistants:
         # Deduplicate while preserving order
         unique_assistants = list(dict.fromkeys(spec.assistants))
         # Validate all assistants from fragment
         for asst in unique_assistants:
             if asst not in TARGETS:
-                raise ValueError(f"Unknown assistant in URL fragment: {asst}")
+                raise ValueError(f"Unknown assistant in fragment: {asst}")
         target_assistants = unique_assistants
     else:
         target_assistants = list(TARGETS.keys())

--- a/src/lola/sync.py
+++ b/src/lola/sync.py
@@ -120,27 +120,23 @@ def parse_lolareq_line(line: str, line_num: int) -> Optional[ModuleSpec]:
     subdirectory = None
     assistants = None
 
-    # Check if this looks like a URL (has :// or starts with git@)
-    if "://" in module_part or module_part.startswith("git@"):
-        # Parse URL fragment
-        if "#" in module_part:
-            url_part, fragment = module_part.rsplit("#", 1)
-            module_part = url_part
+    # Parse fragment (#key=value) from both URLs and plain module names
+    if "#" in module_part:
+        url_part, fragment = module_part.rsplit("#", 1)
+        module_part = url_part
 
-            # Parse fragment as query string parameters
-            fragment_params = parse_qs(fragment)
+        # Parse fragment as query string parameters
+        fragment_params = parse_qs(fragment)
 
-            # Extract subdirectory
-            if "subdirectory" in fragment_params:
-                subdirectory = fragment_params["subdirectory"][0]
+        # Extract subdirectory (only meaningful for URLs)
+        if "subdirectory" in fragment_params:
+            subdirectory = fragment_params["subdirectory"][0]
 
-            # Extract assistant(s) - comma-separated list
-            if "assistant" in fragment_params:
-                assistant_value = fragment_params["assistant"][0]
-                # Split on comma and strip whitespace
-                assistants = [
-                    a.strip() for a in assistant_value.split(",") if a.strip()
-                ]
+        # Extract assistant(s) - comma-separated list
+        if "assistant" in fragment_params:
+            assistant_value = fragment_params["assistant"][0]
+            # Split on comma and strip whitespace
+            assistants = [a.strip() for a in assistant_value.split(",") if a.strip()]
 
     # Extract version spec from module_ref
     module_ref = module_part

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -199,6 +199,102 @@ sample-module
         # Sample-module might still be processed (depending on order)
 
 
+class TestSyncWithAssistantFlag:
+    """Tests for sync command with -a/--assistant flag."""
+
+    def test_sync_with_assistant_flag(self, cli_runner, mock_sync_environment):
+        """Test sync with -a flag installs only to specified assistant."""
+        project = mock_sync_environment["project"]
+        lolareq = project / ".lola-req"
+        lolareq.write_text("sample-module\n")
+
+        result = cli_runner.invoke(sync_cmd, [str(project), "-a", "claude-code"])
+
+        assert result.exit_code == 0
+        assert "sample-module" in result.output
+        assert "claude-code" in result.output
+
+    def test_sync_with_assistant_long_flag(self, cli_runner, mock_sync_environment):
+        """Test sync with --assistant flag."""
+        project = mock_sync_environment["project"]
+        lolareq = project / ".lola-req"
+        lolareq.write_text("sample-module\n")
+
+        result = cli_runner.invoke(
+            sync_cmd, [str(project), "--assistant", "claude-code"]
+        )
+
+        assert result.exit_code == 0
+        assert "claude-code" in result.output
+
+    def test_sync_assistant_flag_only_installs_specified(
+        self, cli_runner, mock_sync_environment
+    ):
+        """Test that -a flag restricts to only the specified assistant."""
+        project = mock_sync_environment["project"]
+        lolareq = project / ".lola-req"
+        lolareq.write_text("sample-module\n")
+
+        result = cli_runner.invoke(sync_cmd, [str(project), "-a", "cursor"])
+
+        assert result.exit_code == 0
+        assert "cursor" in result.output
+        assert "claude-code" not in result.output
+
+    def test_sync_module_name_with_assistant_fragment(
+        self, cli_runner, mock_sync_environment
+    ):
+        """Test that #assistant= fragment works on plain module names."""
+        project = mock_sync_environment["project"]
+        lolareq = project / ".lola-req"
+        lolareq.write_text("sample-module#assistant=claude-code\n")
+
+        result = cli_runner.invoke(sync_cmd, [str(project)])
+
+        assert result.exit_code == 0
+        assert "claude-code" in result.output
+
+    def test_sync_invalid_assistant(self, cli_runner, mock_sync_environment):
+        """Test sync with invalid assistant name."""
+        project = mock_sync_environment["project"]
+        lolareq = project / ".lola-req"
+        lolareq.write_text("sample-module\n")
+
+        result = cli_runner.invoke(sync_cmd, [str(project), "-a", "invalid-assistant"])
+
+        assert result.exit_code != 0
+
+    def test_sync_multiple_assistant_flags(self, cli_runner, mock_sync_environment):
+        """Test sync with multiple -a flags installs to all specified assistants."""
+        project = mock_sync_environment["project"]
+        lolareq = project / ".lola-req"
+        lolareq.write_text("sample-module\n")
+
+        result = cli_runner.invoke(
+            sync_cmd, [str(project), "-a", "cursor", "-a", "claude-code"]
+        )
+
+        assert result.exit_code == 0
+        assert "cursor" in result.output
+        assert "claude-code" in result.output
+
+    def test_sync_without_assistant_installs_all(
+        self, cli_runner, mock_sync_environment
+    ):
+        """Test sync without -a flag installs to all assistants."""
+        project = mock_sync_environment["project"]
+        lolareq = project / ".lola-req"
+        lolareq.write_text("sample-module\n")
+
+        result = cli_runner.invoke(sync_cmd, [str(project)])
+
+        assert result.exit_code == 0
+        assert "sample-module" in result.output
+        # Without -a, output should include multiple target assistants
+        assert "claude-code" in result.output
+        assert "cursor" in result.output
+
+
 class TestSyncWithVersions:
     """Tests for sync command with version constraints."""
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -199,6 +199,28 @@ class TestParseLolareqLine:
         assert spec.subdirectory == "module"
         assert spec.assistants == ["cursor"]
 
+    def test_parse_module_name_with_assistant_fragment(self):
+        """Test parsing plain module name with #assistant= fragment."""
+        spec = parse_lolareq_line("my-skill#assistant=claude-code", 1)
+        assert spec is not None
+        assert spec.module_ref == "my-skill"
+        assert spec.assistants == ["claude-code"]
+
+    def test_parse_module_name_with_multiple_assistant_fragment(self):
+        """Test parsing plain module name with multiple assistants."""
+        spec = parse_lolareq_line("my-skill#assistant=claude-code,cursor", 1)
+        assert spec is not None
+        assert spec.module_ref == "my-skill"
+        assert spec.assistants == ["claude-code", "cursor"]
+
+    def test_parse_module_name_with_version_and_assistant_fragment(self):
+        """Test parsing module name with version spec and assistant fragment."""
+        spec = parse_lolareq_line("my-skill>=1.0.0#assistant=claude-code", 1)
+        assert spec is not None
+        assert spec.module_ref == "my-skill"
+        assert spec.version_spec == ">=1.0.0"
+        assert spec.assistants == ["claude-code"]
+
     def test_parse_blank_line(self):
         """Test that blank lines return None."""
         assert parse_lolareq_line("", 1) is None


### PR DESCRIPTION
## Summary

- Add `-a/--assistant` CLI flag to `lola sync` so users can target a specific assistant without installing to all detected assistants
- Extend `#assistant=` fragment parsing to work on plain module names in `.lola-req`, not just URLs
- Priority order for assistant selection: CLI flag > URL fragment > all assistants

Closes #147

## How to try it

```bash
# Install from the branch
uv tool install git+https://github.com/zjhuntin/lola.git@feature/sync-assistant-flag

# CLI flag — sync only to claude-code
lola sync -a claude-code

# Or use fragments on plain module names in .lola-req
echo "my-module#assistant=claude-code" > .lola-req
lola sync

# Run tests
uv sync --group dev
uv run pytest tests/test_cli_sync.py tests/test_sync.py -v
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a repeatable --assistant / -a option to restrict sync to one or more specified assistants; CLI selections take precedence over assistants declared on module lines.
  * Module entries now accept `#assistant`=... (and other fragment keys) on plain names as well as URLs to declare target assistants.

* **Tests**
  * Added tests covering assistant-flag behavior, fragment parsing, multiple assistants, invalid names, and default (no-flag) behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LobsterTrap/lola/pull/160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->