### PR TITLE
Fix hatch-vcs failing on non-version git tags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ lola = "lola.__main__:main"
 
 [tool.hatch.version]
 source = "vcs"
-raw-options = { local_scheme = "no-local-version" }
+raw-options = { local_scheme = "no-local-version", git_describe_command = "git describe --dirty --tags --long --match v[0-9]*" }
 
 [tool.hatch.build.hooks.vcs]
 version-file = "src/lola/_version.py"


### PR DESCRIPTION
Add git_describe_command to raw-options so git-describe only matches tags starting with 'v' followed by a digit. The default glob '*[0-9]*' matched checkpoint tags (e.g. riotbox-checkpoint/20260528-190957), causing tag_to_version() to return None and trigger an assertion error during editable installs.

Fixes: #165

## Checklist

- [x] Tests pass (`pytest`)
- [x] Linting passes (`ruff check src tests`)
- [x] Type checking passes (`ty check`)

## AI Disclosure

- AI-assisted with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build/versioning configuration to produce more descriptive, tag-aware version strings for releases.
  * No runtime behavior, APIs, or public interfaces were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->