### PR TITLE
fix: add --no-cone to sparse-checkout for marketplace git clone

### DIFF
--- a/src/lola/models.py
+++ b/src/lola/models.py
@@ -600,12 +600,15 @@ class Marketplace:
                     checkout_path = cls._pick_marketplace_yaml(repo_dir, name)
 
                 # Sparse checkout: fetch only the file we need
+                # Use --no-cone because cone mode only supports directories,
+                # but marketplace YAML files are individual files at repo root.
                 sparse_cmd = [
                     "git",
                     "-C",
                     str(repo_dir),
                     "sparse-checkout",
                     "set",
+                    "--no-cone",
                     checkout_path,
                 ]
                 result = subprocess.run(  # nosec B603 B607

--- a/tests/test_marketplace_model.py
+++ b/tests/test_marketplace_model.py
@@ -218,7 +218,7 @@ class TestMarketplaceFromGitUrl:
         Handles three commands:
         1. git clone --filter=blob:none --sparse ... → creates repo dir
         2. git ls-tree --name-only HEAD → returns filename list
-        3. git sparse-checkout set <path> → writes the YAML file to disk
+        3. git sparse-checkout set --no-cone <path> → writes the YAML file to disk
         """
 
         def side_effect(cmd, **kwargs):
@@ -239,7 +239,11 @@ class TestMarketplaceFromGitUrl:
                 # git -C <dir> ls-tree --name-only HEAD
                 result.stdout = filename + "\n"
             elif "sparse-checkout" in cmd:
-                # git -C <dir> sparse-checkout set <path>
+                # git -C <dir> sparse-checkout set --no-cone <path>
+                # Verify --no-cone is passed (cone mode rejects file paths)
+                assert "--no-cone" in cmd, (
+                    "sparse-checkout must use --no-cone for individual file paths"
+                )
                 repo_dir = cmd[2]  # -C <dir>
                 checkout_path = cmd[-1]
                 target = Path(repo_dir) / checkout_path


### PR DESCRIPTION
## Summary

Add `--no-cone` to `git sparse-checkout set` in `Marketplace.from_url()` so file paths are accepted

Update test mock to assert `--no-cone` is present in the sparse-checkout command

## Related Issues

Fixes #167, introduced in #146

## Test Plan

 - [x] `pytest tests/test_marketplace_model.py` — all 37 tests pass
 - [x] Manual test: `lola market add` from a `git+ssh:// URL` succeeds

## Checklist

- [x] Tests pass (`pytest`)
- [x] Linting passes (`ruff check src tests`)
- [x] Type checking passes (`ty check`)

## AI Disclosure

AI-assisted with GitHub Copilot (VS Code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved sparse-checkout behavior when fetching marketplace data to better select individual files.
* **Tests**
  * Updated tests to verify the adjusted sparse-checkout behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LobsterTrap/lola/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->