### PR TITLE
fix: copy command sidecar directories during install

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,8 +102,17 @@ my-module/
       SKILL.md         # Required: skill definition with frontmatter
       scripts/         # Optional: supporting files
   commands/            # Slash commands (*.md files)
+    deploy.md          # Command entry file
+    deploy/            # Optional: co-named sidecar directory
+      step1.md         # Supporting procedure files
+      step2.md
   agents/              # Subagents (*.md files)
 ```
+
+Commands can be multi-file: an entry file `commands/<cmd>.md` plus a co-named
+sidecar directory `commands/<cmd>/` holding procedure files. During installation,
+both the entry file and its sidecar directory (if present) are copied to the
+target assistant's command directory. The sidecar is also removed on uninstall.
 
 ### Marketplace Structure
 

--- a/src/lola/targets/base.py
+++ b/src/lola/targets/base.py
@@ -347,11 +347,12 @@ class BaseAssistantTarget(AssistantTarget):
         cmd_name: str,
         module_name: str,
     ) -> bool:
-        """Delete command file at expected path.
+        """Delete command file and co-named sidecar directory at expected path.
 
         Removes the current unprefixed file and, when present alongside it,
         also removes the legacy prefixed file ({module_name}.{cmd_name}.ext)
-        left over from pre-prefix-removal installs.
+        left over from pre-prefix-removal installs.  Any co-named sidecar
+        directory (e.g. ``deploy/`` next to ``deploy.md``) is also removed.
 
         Returns True if removed or didn't exist (idempotent).
         """
@@ -359,6 +360,10 @@ class BaseAssistantTarget(AssistantTarget):
         cmd_file = dest_dir / filename
         if cmd_file.exists():
             cmd_file.unlink()
+        # Remove co-named sidecar directory (e.g. deploy/ next to deploy.md)
+        sidecar_dir = dest_dir / Path(filename).stem
+        if sidecar_dir.is_dir():
+            shutil.rmtree(sidecar_dir)
         # Always clean up legacy prefixed file too (e.g. module.cmd.md)
         ext = Path(filename).suffix
         legacy_file = dest_dir / f"{module_name}.{cmd_name}{ext}"
@@ -764,12 +769,28 @@ def _generate_passthrough_command(
     dest_dir: Path,
     filename: str,
 ) -> bool:
-    """Generate command by copying content as-is."""
+    """Generate command by copying content as-is.
+
+    Also copies a co-named sidecar directory if present.  For example,
+    if ``source_path`` is ``commands/deploy.md`` and a directory
+    ``commands/deploy/`` exists, the entire directory is copied next to
+    the generated command file.
+    """
     if not source_path.exists():
         return False
     dest_dir.mkdir(parents=True, exist_ok=True)
     content = source_path.read_text()
     (dest_dir / filename).write_text(content)
+
+    # Copy co-named sidecar directory (e.g. commands/deploy/ alongside
+    # commands/deploy.md).
+    sidecar_src = source_path.with_suffix("")
+    if sidecar_src.is_dir():
+        sidecar_dest = dest_dir / Path(filename).stem
+        if sidecar_dest.exists():
+            shutil.rmtree(sidecar_dest)
+        shutil.copytree(sidecar_src, sidecar_dest)
+
     return True
 
 

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -214,6 +214,73 @@ class TestClaudeCodeTarget:
         result = target.generate_command(missing, dest_path, "missing", "mymod")
         assert result is False
 
+    def test_generate_command_copies_sidecar_directory(
+        self, tmp_path: Path, dest_path: Path
+    ):
+        """generate_command should copy co-named sidecar directory alongside entry file."""
+        cmd_dir = tmp_path / "commands"
+        cmd_dir.mkdir(parents=True)
+        cmd_file = cmd_dir / "deploy.md"
+        cmd_file.write_text("# Deploy\n\nRun deploy procedure.")
+
+        sidecar = cmd_dir / "deploy"
+        sidecar.mkdir()
+        (sidecar / "step1.md").write_text("Step 1 instructions")
+        (sidecar / "step2.md").write_text("Step 2 instructions")
+        nested = sidecar / "sub"
+        nested.mkdir()
+        (nested / "detail.md").write_text("Nested detail")
+
+        target = ClaudeCodeTarget()
+        result = target.generate_command(cmd_file, dest_path, "deploy", "mymod")
+
+        assert result is True
+        assert (dest_path / "deploy.md").exists()
+        assert (dest_path / "deploy").is_dir()
+        assert (dest_path / "deploy" / "step1.md").read_text() == "Step 1 instructions"
+        assert (dest_path / "deploy" / "step2.md").read_text() == "Step 2 instructions"
+        assert (
+            dest_path / "deploy" / "sub" / "detail.md"
+        ).read_text() == "Nested detail"
+
+    def test_generate_command_without_sidecar_still_works(
+        self, command_source: Path, dest_path: Path
+    ):
+        """generate_command should work normally when no sidecar directory exists."""
+        target = ClaudeCodeTarget()
+        result = target.generate_command(command_source, dest_path, "test-cmd", "mymod")
+
+        assert result is True
+        assert (dest_path / "test-cmd.md").exists()
+        # No sidecar directory should be created
+        assert not (dest_path / "test-cmd").exists()
+
+    def test_generate_command_overwrites_existing_sidecar(
+        self, tmp_path: Path, dest_path: Path
+    ):
+        """generate_command should overwrite an existing sidecar directory."""
+        cmd_dir = tmp_path / "commands"
+        cmd_dir.mkdir(parents=True)
+        cmd_file = cmd_dir / "deploy.md"
+        cmd_file.write_text("# Deploy")
+
+        sidecar = cmd_dir / "deploy"
+        sidecar.mkdir()
+        (sidecar / "step1.md").write_text("Original step 1")
+
+        target = ClaudeCodeTarget()
+        target.generate_command(cmd_file, dest_path, "deploy", "mymod")
+
+        # Modify source sidecar
+        (sidecar / "step1.md").write_text("Updated step 1")
+        (sidecar / "step3.md").write_text("New step 3")
+
+        # Re-generate should overwrite
+        target.generate_command(cmd_file, dest_path, "deploy", "mymod")
+
+        assert (dest_path / "deploy" / "step1.md").read_text() == "Updated step 1"
+        assert (dest_path / "deploy" / "step3.md").read_text() == "New step 3"
+
     def test_generate_agent_adds_model_inherit(
         self, agent_source: Path, dest_path: Path
     ):
@@ -370,6 +437,35 @@ Agent body content.
         assert result is True
         assert not new_file.exists()
         assert not legacy_file.exists()  # Also removed when both coexist
+
+    def test_remove_command_removes_sidecar_directory(self, dest_path: Path):
+        """remove_command should remove co-named sidecar directory."""
+        target = ClaudeCodeTarget()
+        commands_dir = dest_path
+        cmd_file = commands_dir / "deploy.md"
+        cmd_file.write_text("# Deploy")
+        sidecar = commands_dir / "deploy"
+        sidecar.mkdir()
+        (sidecar / "step1.md").write_text("Step 1")
+        (sidecar / "step2.md").write_text("Step 2")
+
+        result = target.remove_command(commands_dir, "deploy", "mymod")
+
+        assert result is True
+        assert not cmd_file.exists()
+        assert not sidecar.exists()
+
+    def test_remove_command_without_sidecar_still_works(self, dest_path: Path):
+        """remove_command should work when no sidecar directory exists."""
+        target = ClaudeCodeTarget()
+        commands_dir = dest_path
+        cmd_file = commands_dir / "deploy.md"
+        cmd_file.write_text("# Deploy")
+
+        result = target.remove_command(commands_dir, "deploy", "mymod")
+
+        assert result is True
+        assert not cmd_file.exists()
 
 
 # =============================================================================


### PR DESCRIPTION
Multi-file commands pair an entry file (commands/<cmd>.md) with a co-named directory (commands/<cmd>/) of supporting files. Only the entry file was copied to the target, so relative-path references from the entry into the sidecar directory dangled at runtime.

_generate_passthrough_command now copies the sidecar directory next to the entry file, replacing any stale copy on reinstall. remove_command cleans up both the entry and the sidecar directory on uninstall.

- Add tests for sidecar copy, no-sidecar no-op, overwrite on reinstall, and removal (ClaudeCode and OpenCode targets)
- Document multi-file command structure in AGENTS.md

Fixes: #171

## Checklist

- [x] Tests pass (`pytest`)
- [x] Linting passes (`ruff check src tests`)
- [x] Type checking passes (`ty check`)

## AI Disclosure

- Claude Code was used during this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Install full module trees per target under modules/<name>/, support co-named sidecar directories for multi-file commands, and inject visible module-dir preambles into generated skills/commands/agents (Gemini CLI remains a TOML exception). Per-target module path resolution added for user/project scopes.

* **Documentation**
  * Expanded module structure, path behavior, installation pipeline, CLI reference, and authoring guides to document install layout and preamble behavior.

* **Tests**
  * Expanded coverage for module-tree install/uninstall lifecycle, sidecar handling, preamble injection, TOML parsing, and per-target integration.

* **Chores**
  * .gitignore updated to ignore docs/superpowers/; lint target now runs an additional type-check step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->