### PR TITLE
ci: skip publish and deploy workflows on forks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: github.repository == 'lobstertrap/lola'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   deploy:
-    if: github.repository == 'lobstertrap/lola'
+    if: github.repository == 'LobsterTrap/lola'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   build:
-    if: github.repository == 'lobstertrap/lola'
+    if: github.repository == 'LobsterTrap/lola'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ permissions: {}
 
 jobs:
   build:
+    if: github.repository == 'lobstertrap/lola'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

When pushing changes to a fork both docs/deploy and publish actions are executed, but they shouldn't as these should be done only from the lobstertrap/lola repo.

## Test Plan

Create a branch and push changes to your own fork.

## AI Disclosure

Assisted by Claude Opus 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD workflows updated: Pages deployment and publish builds are now gated so they only run for the main repository, reducing accidental executions on forks.
  * No user-facing functionality changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->