### PR TITLE
docs: add E2E BDD testing design for cross-language and cross-OS exec…

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,11 @@
+.venv/
+.git/
+__pycache__/
+*.egg-info/
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+build/
+dist/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,28 @@
+name: E2E
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  behave:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Run E2E tests
+        run: make e2e

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,3 +63,10 @@ repos:
         language: system
         types: [python]
         pass_filenames: false
+
+      - id: behave
+        name: behave
+        entry: bash -c 'cd e2e/features && uv run behave --no-capture --tags="~@wip"'
+        language: system
+        types_or: [python, gherkin]
+        pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ help: ## - print the help and usage
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 include mk/dev.mk
+include mk/e2e.mk
 include mk/mkdocs.mk
 include mk/adr.mk
 include mk/go.mk

--- a/docs/dev-guide/design/e2e-bdd.md
+++ b/docs/dev-guide/design/e2e-bdd.md
@@ -452,13 +452,13 @@ There is intentional overlap at the integration boundary — both test `lola ins
 ```makefile
 # mk/dev.mk additions
 e2e:  ## Run E2E BDD tests
-	cd e2e/python && behave --format progress --no-capture ../features
+	cd e2e/features && uv run behave --format progress --no-capture
 
 e2e-wip:  ## Run only @wip tagged E2E scenarios
-	cd e2e/python && behave --tags="@wip" --format progress ../features
+	cd e2e/features && uv run behave --tags="@wip" --format progress
 
 e2e-smoke:  ## Run smoke E2E tests (pre-commit)
-	cd e2e/python && behave --tags="@smoke" --format progress ../features
+	cd e2e/features && uv run behave --tags="@smoke" --format progress
 ```
 
 ## Cross-OS Containerized Execution
@@ -588,10 +588,10 @@ CMD ["go"]
 # e2e/containers/scripts/run-tests.sh
 set -euo pipefail
 
-LANG="${1:-python}"
+TEST_LANG="${1:-python}"
 TAGS="${E2E_TAGS:-~@wip}"
 
-case "$LANG" in
+case "$TEST_LANG" in
     python)
         cd e2e
         exec behave --tags="$TAGS" --no-capture --format progress
@@ -601,7 +601,7 @@ case "$LANG" in
         exec go test -v -run TestFeatures -tags="$TAGS" ./...
         ;;
     *)
-        echo "Unknown language: $LANG" >&2
+        echo "Unknown language: $TEST_LANG" >&2
         exit 1
         ;;
 esac
@@ -772,7 +772,7 @@ When Go is added, each row doubles (`lang: [python, go]`), but the feature files
 
 ```bash
 # Run locally without containers (fastest feedback loop)
-cd e2e/python && behave ../features
+cd e2e/features && uv run behave
 
 # Run in a rootless container (reproduces CI)
 make e2e-container
@@ -793,13 +793,13 @@ E2E_LANG ?= python
 E2E_TAGS ?= ~@wip
 
 e2e:  ## Run E2E BDD tests locally
-	cd e2e/python && behave --tags="$(E2E_TAGS)" --format progress --no-capture ../features
+	cd e2e/features && uv run behave --no-capture
 
 e2e-wip:  ## Run only @wip tagged E2E scenarios
-	cd e2e/python && behave --tags="@wip" --format progress ../features
+	cd e2e/features && uv run behave --tags="@wip" --no-capture
 
 e2e-smoke:  ## Run smoke E2E tests (pre-commit)
-	cd e2e/python && behave --tags="@smoke" --format progress ../features
+	cd e2e/features && uv run behave --tags="@smoke" --no-capture
 
 e2e-container-build:  ## Build E2E container images
 	podman build -t lola-e2e-base-$(DISTRO) -f e2e/containers/base/$(DISTRO).Containerfile .
@@ -812,10 +812,6 @@ e2e-container: e2e-container-build  ## Run E2E tests in a rootless container
 
 ## Dependencies
 
-```
-# e2e/python/requirements.txt (or managed via uv)
-behave>=1.2.6
-PyYAML>=6.0
-```
+`behave>=1.2.6` is included in the `dev` dependency group in `pyproject.toml`, installed via `uv sync --group dev`. No separate requirements file is needed.
 
-No other dependencies — the E2E tests use only stdlib (`subprocess`, `tempfile`, `pathlib`, `http.server`, `threading`, `re`) plus behave and PyYAML for marketplace fixture building.
+The E2E tests use only stdlib (`subprocess`, `tempfile`, `pathlib`, `http.server`, `threading`, `re`) plus behave and PyYAML (already a project dependency) for marketplace fixture building.

--- a/docs/dev-guide/design/e2e-bdd.md
+++ b/docs/dev-guide/design/e2e-bdd.md
@@ -1,0 +1,821 @@
+# Design: E2E BDD Testing for Lola CLI
+
+**Created**: 2026-06-05
+**Status**: Draft
+
+## Goal
+
+Structure E2E tests using BDD (Behavior-Driven Development) for the Lola Python CLI. The Gherkin feature files must be reusable when the project is rewritten in Go.
+
+## Framework Choice
+
+| Language | Framework  | Rationale |
+|----------|------------|-----------|
+| Python   | **behave** | Closest structural analog to godog — `features/`, `steps/`, `environment.py` map 1:1 to godog's layout. |
+| Go       | **godog**  | Standard Go BDD framework, consumes the same `.feature` files unchanged. |
+
+Both use Gherkin feature files as the single source of truth. Feature files are 100% portable; only step definitions and helpers get rewritten.
+
+## Directory Layout
+
+```
+e2e/
+├── features/                      # Gherkin files, Python steps, and support
+│   ├── behave.ini                 # behave configuration
+│   ├── environment.py             # behave hooks (before_scenario, after_scenario)
+│   ├── steps/                     # Step definitions (behave discovers these)
+│   │   ├── cli_steps.py           # Given/When/Then for CLI invocations
+│   │   ├── filesystem_steps.py    # Given/Then for files and directories
+│   │   └── marketplace_steps.py   # Given for HTTP-served marketplaces
+│   ├── support/                   # Shared helpers
+│   │   ├── cli.py                 # subprocess wrapper for `lola`
+│   │   ├── fixtures.py            # Module/marketplace builders
+│   │   └── http_server.py         # Local HTTP server for marketplace URLs
+│   ├── mod/
+│   │   ├── add.feature
+│   │   ├── rm.feature
+│   │   ├── ls.feature
+│   │   ├── info.feature
+│   │   ├── init.feature
+│   │   ├── update.feature
+│   │   └── search.feature
+│   ├── install/
+│   │   ├── install.feature
+│   │   ├── uninstall.feature
+│   │   ├── update.feature
+│   │   ├── list.feature
+│   │   └── scope.feature
+│   ├── market/
+│   │   ├── add.feature
+│   │   ├── ls.feature
+│   │   ├── rm.feature
+│   │   ├── update.feature
+│   │   └── set.feature
+│   ├── sync.feature
+│   ├── completions.feature
+│   └── cli.feature
+│
+└── go/                            # Go step definitions (godog) — future
+    ├── e2e_test.go                # godog test runner + hooks
+    ├── cli_steps.go
+    ├── filesystem_steps.go
+    ├── marketplace_steps.go
+    └── support/
+        ├── cli.go
+        ├── fixtures.go
+        └── http_server.go
+```
+
+Steps, support modules, and `environment.py` live alongside the feature files under `e2e/features/`. Behave natively adds this directory to `sys.path`, so `from support.cli import ...` works without path manipulation. When Go is added, `e2e/go/` has its own step definitions and `godog.Options{Paths: []string{"../features"}}` points at the same `.feature` files.
+
+```ini
+# e2e/features/behave.ini
+[behave]
+paths = .
+```
+
+```go
+// go/e2e_test.go
+opts := godog.Options{Paths: []string{"../features"}}
+```
+
+## Core Design Principles
+
+### 1. Black-box CLI testing via subprocess
+
+Never import `lola` internals. Invoke the `lola` binary the way a user would. This makes tests valid regardless of implementation language.
+
+```python
+# python/support/cli.py
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+@dataclass
+class LolaResult:
+    exit_code: int
+    stdout: str
+    stderr: str
+
+class LolaCLI:
+    def __init__(self, lola_home: Path, work_dir: Path):
+        self.env = {**os.environ, "LOLA_HOME": str(lola_home)}
+        self.work_dir = work_dir
+
+    def run(self, *args: str) -> LolaResult:
+        result = subprocess.run(
+            ["lola", *args],
+            capture_output=True, text=True,
+            cwd=self.work_dir, env=self.env,
+        )
+        return LolaResult(result.returncode, result.stdout, result.stderr)
+```
+
+```go
+// go/support/cli.go
+type LolaResult struct {
+    ExitCode int
+    Stdout   string
+    Stderr   string
+}
+
+type LolaCLI struct {
+    LolaHome string
+    WorkDir  string
+}
+
+func (c *LolaCLI) Run(args ...string) LolaResult {
+    cmd := exec.Command("lola", args...)
+    cmd.Dir = c.WorkDir
+    cmd.Env = append(os.Environ(), "LOLA_HOME="+c.LolaHome)
+    var stdout, stderr bytes.Buffer
+    cmd.Stdout = &stdout
+    cmd.Stderr = &stderr
+    err := cmd.Run()
+    exitCode := 0
+    if err != nil {
+        var exitErr *exec.ExitError
+        if errors.As(err, &exitErr) {
+            exitCode = exitErr.ExitCode()
+        }
+    }
+    return LolaResult{exitCode, stdout.String(), stderr.String()}
+}
+```
+
+### 2. Scenario isolation
+
+Every scenario gets a fresh temp directory with its own `LOLA_HOME` and project directory. No scenario can leak state to another.
+
+```python
+# python/environment.py
+import shutil
+import tempfile
+from pathlib import Path
+from support.cli import LolaCLI
+
+def before_scenario(context, scenario):
+    context.tmp_dir = Path(tempfile.mkdtemp(prefix="lola-e2e-"))
+    context.lola_home = context.tmp_dir / ".lola"
+    context.project_dir = context.tmp_dir / "project"
+    context.project_dir.mkdir(parents=True)
+    context.cli = LolaCLI(context.lola_home, context.project_dir)
+    context.modules = {}
+    context.http_servers = []
+    context.last_result = None
+
+def after_scenario(context, scenario):
+    for server in getattr(context, "http_servers", []):
+        server.stop()
+    shutil.rmtree(context.tmp_dir, ignore_errors=True)
+```
+
+### 3. Thin step definitions, fat helpers
+
+Steps delegate to helper functions immediately. This keeps steps readable and helpers testable/reusable. Steps should never contain more than 3-4 lines of glue logic.
+
+### 4. Consistent step vocabulary
+
+A small, reusable set of step patterns covers most scenarios. New features should compose from these before inventing new steps.
+
+## Step Pattern Catalog
+
+These patterns form the shared vocabulary across all features.
+
+### CLI Execution
+
+```gherkin
+When I run lola "{command}"
+When I run lola "{command}" in "{directory}"
+```
+
+### Exit Code & Output Assertions
+
+```gherkin
+Then the exit code should be {code:d}
+Then the output should contain "{text}"
+Then the output should not contain "{text}"
+Then the output should match /{pattern}/
+Then the error output should contain "{text}"
+```
+
+### Filesystem Preconditions (Given)
+
+```gherkin
+Given a module "{name}" with a skill "{skill_name}"
+Given a module "{name}" with skills, commands, and agents
+Given a module "{name}" at "{path}"
+Given assistant directories for "{assistant}"
+Given a project directory
+Given the module "{name}" is registered
+Given the module "{name}" is installed to "{assistant}"
+Given the module "{name}" is installed to "{assistant}" with scope "{scope}"
+```
+
+### Filesystem Assertions (Then)
+
+```gherkin
+Then the file "{path}" should exist
+Then the file "{path}" should not exist
+Then the directory "{path}" should exist
+Then the directory "{path}" should not exist
+Then the file "{path}" should contain "{text}"
+Then the file "{path}" should have frontmatter key "{key}" with value "{value}"
+```
+
+### Marketplace Preconditions
+
+```gherkin
+Given a marketplace "{name}" serving modules:
+  | module     | version | repository                       |
+  | git-module | 1.0.0   | https://github.com/user/repo.git |
+Given the marketplace "{name}" is disabled
+Given a local HTTP server serving "{file}" at "{url_path}"
+```
+
+### Path Interpolation
+
+Feature files use placeholders like `{lola_home}`, `{project}`, `{module_path}`. Step definitions resolve these from the scenario context:
+
+```python
+def resolve_path(context, text):
+    replacements = {
+        "{lola_home}": str(context.lola_home),
+        "{project}": str(context.project_dir),
+        "{home}": str(Path.home()),
+        "{tmp}": str(context.tmp_dir),
+    }
+    for name, path in context.modules.items():
+        replacements[f"{{{name}_path}}"] = str(path)
+        replacements["{module_path}"] = str(path)
+    for k, v in replacements.items():
+        text = text.replace(k, v)
+    return text
+```
+
+## Example Feature Files
+
+### `features/mod/add.feature`
+
+```gherkin
+Feature: Module registration
+  As a user, I want to register modules from various sources
+  so that I can install them to my AI assistants.
+
+  Background:
+    Given a project directory
+
+  Scenario: Add a module from a local folder
+    Given a module "my-module" with skills, commands, and agents
+    When I run lola "mod add {module_path}"
+    Then the exit code should be 0
+    And the output should contain "my-module"
+    And the directory "{lola_home}/modules/my-module" should exist
+
+  Scenario: Add a module that already exists
+    Given a module "my-module" with a skill "example"
+    And the module "my-module" is registered
+    When I run lola "mod add {module_path}"
+    Then the exit code should be 1
+    And the output should contain "already"
+
+  Scenario: Remove a registered module
+    Given the module "my-module" is registered
+    When I run lola "mod rm my-module"
+    Then the exit code should be 0
+    And the directory "{lola_home}/modules/my-module" should not exist
+
+  Scenario: List registered modules
+    Given the module "my-module" is registered
+    When I run lola "mod ls"
+    Then the exit code should be 0
+    And the output should contain "my-module"
+```
+
+### `features/install/install.feature`
+
+```gherkin
+Feature: Module installation
+  As a user, I want to install modules to AI assistants
+  so that skills, commands, and agents are available in my workflow.
+
+  Background:
+    Given a project directory
+    And the module "git-module" is registered
+    And assistant directories for "claude-code"
+
+  Scenario: Install a module to Claude Code
+    When I run lola "install git-module -a claude-code"
+    Then the exit code should be 0
+    And the directory "{project}/.claude/skills" should exist
+    And the output should contain "Installed"
+
+  Scenario: Install with user scope
+    When I run lola "install git-module -a claude-code --scope user"
+    Then the exit code should be 0
+    And the directory "{home}/.claude/skills" should exist
+
+  Scenario: Uninstall a previously installed module
+    Given the module "git-module" is installed to "claude-code"
+    When I run lola "uninstall git-module -a claude-code"
+    Then the exit code should be 0
+    And the directory "{project}/.claude/skills/git-cheatsheet" should not exist
+
+  Scenario: Install a module not in registry but available in marketplace
+    Given a marketplace "community" serving modules:
+      | module     | version | repository                       |
+      | new-module | 1.0.0   | https://github.com/user/repo.git |
+    When I run lola "install new-module -a claude-code"
+    Then the exit code should be 0
+    And the output should contain "new-module"
+```
+
+### `features/market/add.feature`
+
+```gherkin
+Feature: Marketplace management
+  As a user, I want to register marketplaces
+  so I can discover and install modules from curated catalogs.
+
+  Scenario: Add a marketplace
+    Given a local HTTP server serving a marketplace catalog at "/catalog.yml"
+    When I run lola "market add community {server_url}/catalog.yml"
+    Then the exit code should be 0
+    And the file "{lola_home}/market/community.yml" should exist
+    And the file "{lola_home}/market/cache/community.yml" should exist
+
+  Scenario: List marketplaces
+    Given a marketplace "community" serving modules:
+      | module    | version |
+      | my-module | 1.0.0   |
+    When I run lola "market ls"
+    Then the exit code should be 0
+    And the output should contain "community"
+
+  Scenario: Disable a marketplace excludes it from search
+    Given a marketplace "community" serving modules:
+      | module    | version |
+      | my-module | 1.0.0   |
+    When I run lola "market set community --disable"
+    Then the exit code should be 0
+    When I run lola "mod search my-module"
+    Then the output should not contain "my-module"
+```
+
+## Marketplace HTTP Testing
+
+For features that need to download marketplace catalogs, use a local HTTP server:
+
+```python
+# python/support/http_server.py
+import threading
+from functools import partial
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from pathlib import Path
+
+class LocalHTTPServer:
+    def __init__(self, directory: Path):
+        self.directory = directory
+        handler = partial(SimpleHTTPRequestHandler, directory=str(directory))
+        self.server = HTTPServer(("127.0.0.1", 0), handler)
+        self.port = self.server.server_address[1]
+        self.url = f"http://127.0.0.1:{self.port}"
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    def start(self):
+        self.thread.start()
+
+    def stop(self):
+        self.server.shutdown()
+```
+
+```go
+// go equivalent uses net/http/httptest
+server := httptest.NewServer(http.FileServer(http.Dir(directory)))
+defer server.Close()
+```
+
+## Tagging Strategy
+
+```gherkin
+@slow              # Tests that take >5s (HTTP, git clone)
+@marketplace       # Needs HTTP server
+@wip               # Work in progress — excluded from CI
+@smoke             # Fast subset for pre-commit
+@claude-code       # Assistant-specific scenarios
+@cursor
+@gemini
+@opencode
+```
+
+Run subsets:
+
+```bash
+behave --tags="@smoke"              # Pre-commit fast check
+behave --tags="~@slow"              # Skip slow tests
+behave --tags="@marketplace"        # Only marketplace tests
+behave --tags="~@wip"               # CI default
+```
+
+## Portability Matrix
+
+| Artifact | Portable? | Go Migration |
+|----------|-----------|--------------|
+| `features/**/*.feature` | **Yes** | Move unchanged |
+| Step patterns (cucumber expressions) | **Yes** | Same expressions in godog |
+| Step definition bodies | No | Rewrite in Go, same logic |
+| `LolaCLI` helper | No | Rewrite using `os/exec`, same interface |
+| Filesystem helpers | No | Rewrite using `os`/`filepath`, same interface |
+| `environment.py` hooks | No | Map to `ScenarioContext.Before`/`After` |
+| `LocalHTTPServer` | No | Replace with `net/http/httptest` |
+| `behave.ini` | No | Replace with `godog.Options{}` |
+
+The Go rewrite touches only step definitions and support code. Feature files and step patterns carry over unchanged.
+
+## Relationship to Existing Tests
+
+The existing pytest unit tests in `tests/` remain as-is. They test internal functions, data models, parsers, and target generators at the code level. The BDD E2E tests complement them by testing the CLI from the outside:
+
+| Concern | pytest (unit/integration) | BDD E2E |
+|---------|--------------------------|---------|
+| Scope | Internal functions, classes | CLI binary as subprocess |
+| Isolation | Mocked paths, patched imports | Real filesystem, env vars |
+| Speed | Fast (no subprocess overhead) | Slower (process spawn per step) |
+| Portability | Python-only | Feature files portable to Go |
+| Purpose | Correctness of internals | User-visible behavior |
+
+There is intentional overlap at the integration boundary — both test `lola install`, for example — but from different angles. The BDD tests are the ones that survive the Go rewrite.
+
+## Makefile Integration
+
+```makefile
+# mk/dev.mk additions
+e2e:  ## Run E2E BDD tests
+	cd e2e/python && behave --format progress --no-capture ../features
+
+e2e-wip:  ## Run only @wip tagged E2E scenarios
+	cd e2e/python && behave --tags="@wip" --format progress ../features
+
+e2e-smoke:  ## Run smoke E2E tests (pre-commit)
+	cd e2e/python && behave --tags="@smoke" --format progress ../features
+```
+
+## Cross-OS Containerized Execution
+
+### Problem
+
+Lola must work on Linux, macOS, and Windows. E2E tests should verify behavior on all three operating systems, run without root privileges, and use the same feature files and step definitions regardless of the host or implementation language (Python or Go).
+
+### Container Runtime: Podman (Rootless)
+
+Podman runs rootless by default — no daemon, no root, no `sudo`. It is the primary runtime for containerized E2E execution. Docker-compatible Containerfiles work unchanged.
+
+```bash
+podman build -t lola-e2e-python -f e2e/containers/python.Containerfile .
+podman run --rm lola-e2e-python
+```
+
+### Multi-OS Strategy
+
+OCI containers are Linux-only. True macOS and Windows testing requires native execution on those platforms. The strategy splits into two layers:
+
+| Layer | Linux | macOS | Windows |
+|-------|-------|-------|---------|
+| **Container** | Rootless Podman — primary path | Podman Machine (Linux VM) — validates container workflow | WSL2 + Podman — validates container workflow |
+| **Native** | CI runner (also covered by container) | CI runner (macOS host) | CI runner (Windows host) |
+
+- **Linux variants** (Fedora, Debian, Alpine): fully covered by containers with different base images.
+- **macOS/Windows native behavior** (path separators, case sensitivity, home directory layout): covered by CI runners on real hosts.
+- **Container workflow validation on macOS/Windows**: developers on those platforms use Podman Machine / WSL2 to run the Linux container tests locally.
+
+### Directory Layout (Additions)
+
+```
+e2e/
+├── features/                          # (unchanged — shared Gherkin files)
+├── python/                            # (unchanged — behave steps)
+├── go/                                # (unchanged — godog steps, future)
+│
+└── containers/
+    ├── python.Containerfile           # Python + behave image
+    ├── go.Containerfile               # Go + godog image (future)
+    ├── base/
+    │   ├── fedora.Containerfile       # Fedora base (default)
+    │   ├── debian.Containerfile       # Debian base
+    │   └── alpine.Containerfile       # Alpine base
+    └── scripts/
+        ├── run-tests.sh               # Entrypoint: run behave or godog
+        └── install-lola.sh            # Build & install lola from source
+
+.github/
+└── workflows/
+    └── e2e.yml                        # GitHub Actions CI matrix
+```
+
+### Containerfiles
+
+#### Base Image (Fedora)
+
+```dockerfile
+# e2e/containers/base/fedora.Containerfile
+FROM registry.fedoraproject.org/fedora:42
+
+RUN dnf install -y --setopt=install_weak_deps=False \
+    git curl ca-certificates \
+    && dnf clean all
+
+RUN useradd --create-home --shell /bin/bash tester
+USER tester
+WORKDIR /home/tester
+```
+
+#### Python Test Image
+
+```dockerfile
+# e2e/containers/python.Containerfile
+ARG BASE=fedora
+FROM localhost/lola-e2e-base-${BASE}:latest AS base
+
+USER root
+RUN dnf install -y --setopt=install_weak_deps=False \
+    python3 python3-pip python3-devel \
+    && dnf clean all
+USER tester
+
+COPY --chown=tester:tester . /home/tester/lola
+WORKDIR /home/tester/lola
+
+RUN python3 -m venv .venv \
+    && .venv/bin/pip install --no-cache-dir . \
+    && .venv/bin/pip install --no-cache-dir behave pyyaml
+
+ENV PATH="/home/tester/lola/.venv/bin:${PATH}"
+
+ENTRYPOINT ["e2e/containers/scripts/run-tests.sh"]
+CMD ["python"]
+```
+
+Note: The `RUN` package-install commands are Fedora-specific. The Debian and Alpine Containerfiles use `apt-get` and `apk` respectively but produce the same final environment. The `BASE` build arg selects which base image to layer on.
+
+#### Go Test Image (Future)
+
+```dockerfile
+# e2e/containers/go.Containerfile
+ARG BASE=fedora
+FROM localhost/lola-e2e-base-${BASE}:latest AS base
+
+USER root
+RUN dnf install -y --setopt=install_weak_deps=False golang \
+    && dnf clean all
+USER tester
+
+ENV PATH="/home/tester/go/bin:${PATH}"
+
+COPY --chown=tester:tester . /home/tester/lola
+WORKDIR /home/tester/lola
+
+RUN cd e2e/go && go mod download
+
+ENTRYPOINT ["e2e/containers/scripts/run-tests.sh"]
+CMD ["go"]
+```
+
+#### Test Entrypoint
+
+```bash
+#!/usr/bin/env bash
+# e2e/containers/scripts/run-tests.sh
+set -euo pipefail
+
+LANG="${1:-python}"
+TAGS="${E2E_TAGS:-~@wip}"
+
+case "$LANG" in
+    python)
+        cd e2e
+        exec behave --tags="$TAGS" --no-capture --format progress
+        ;;
+    go)
+        cd e2e/go
+        exec go test -v -run TestFeatures -tags="$TAGS" ./...
+        ;;
+    *)
+        echo "Unknown language: $LANG" >&2
+        exit 1
+        ;;
+esac
+```
+
+### Build & Run Commands
+
+```bash
+# Build base image (once)
+podman build -t lola-e2e-base-fedora -f e2e/containers/base/fedora.Containerfile .
+
+# Build and run Python E2E tests
+podman build -t lola-e2e-python \
+    --build-arg BASE=fedora \
+    -f e2e/containers/python.Containerfile .
+podman run --rm lola-e2e-python
+
+# Run with tag filter
+podman run --rm -e E2E_TAGS="@smoke" lola-e2e-python
+
+# Run on Debian base
+podman build -t lola-e2e-base-debian -f e2e/containers/base/debian.Containerfile .
+podman build -t lola-e2e-python-debian \
+    --build-arg BASE=debian \
+    -f e2e/containers/python.Containerfile .
+podman run --rm lola-e2e-python-debian
+```
+
+### Cross-OS Considerations in Feature Files
+
+Feature files must remain OS-agnostic. Step definitions handle platform differences internally.
+
+#### Path Separators
+
+Feature files always use forward slashes. Step definitions normalize to the host OS:
+
+```python
+# python/support/cli.py
+def resolve_path(context, text):
+    resolved = _interpolate_placeholders(context, text)
+    return str(Path(resolved))  # normalizes separators per OS
+```
+
+```go
+// go/support/cli.go
+func resolvePath(ctx *scenarioContext, text string) string {
+    resolved := interpolatePlaceholders(ctx, text)
+    return filepath.FromSlash(resolved)
+}
+```
+
+#### Home Directory
+
+`{home}` resolves differently per OS (`/home/tester` in containers, `/Users/x` on macOS, `C:\Users\x` on Windows). Step definitions handle this via the environment:
+
+```python
+def home_dir():
+    return Path.home()
+```
+
+```go
+func homeDir() string {
+    home, _ := os.UserHomeDir()
+    return home
+}
+```
+
+#### Filesystem Case Sensitivity
+
+macOS (HFS+/APFS default) and Windows (NTFS) are case-insensitive. Linux (ext4) is case-sensitive. Feature files should use consistent casing and avoid relying on case-insensitive lookups. Step assertions compare paths case-sensitively everywhere — if a test passes on Linux, it will pass on macOS/Windows. The reverse is what catches bugs.
+
+#### Newlines
+
+Lola writes text files. Step definitions that assert file content should normalize `\r\n` to `\n` before comparison so Windows output doesn't break assertions written for Unix:
+
+```python
+def read_normalized(path: Path) -> str:
+    return path.read_text().replace("\r\n", "\n")
+```
+
+### CI Pipeline (GitHub Actions)
+
+The CI matrix covers three dimensions: OS, implementation language, and Linux distribution (for containers).
+
+```yaml
+# .github/workflows/e2e.yml
+name: E2E BDD Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  e2e-container:
+    name: "E2E / ${{ matrix.lang }} / ${{ matrix.distro }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        lang: [python]          # add 'go' when ready
+        distro: [fedora, debian, alpine]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build base image
+        run: |
+          podman build -t lola-e2e-base-${{ matrix.distro }} \
+            -f e2e/containers/base/${{ matrix.distro }}.Containerfile .
+
+      - name: Build test image
+        run: |
+          podman build -t lola-e2e-${{ matrix.lang }}-${{ matrix.distro }} \
+            --build-arg BASE=${{ matrix.distro }} \
+            -f e2e/containers/${{ matrix.lang }}.Containerfile .
+
+      - name: Run E2E tests
+        run: |
+          podman run --rm \
+            lola-e2e-${{ matrix.lang }}-${{ matrix.distro }} \
+            ${{ matrix.lang }}
+
+  e2e-native:
+    name: "E2E / ${{ matrix.lang }} / ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        lang: [python]          # add 'go' when ready
+        os: [macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        if: matrix.lang == 'python'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install lola and test dependencies
+        shell: bash
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate || . .venv/Scripts/activate
+          pip install . behave pyyaml
+
+      - name: Run E2E tests
+        shell: bash
+        run: |
+          source .venv/bin/activate || . .venv/Scripts/activate
+          cd e2e
+          behave --tags="~@wip" --no-capture --format progress
+```
+
+### CI Matrix Summary
+
+| Job | Runner | Method | What It Validates |
+|-----|--------|--------|-------------------|
+| `e2e-container` / fedora | `ubuntu-latest` | Rootless Podman | Fedora baseline (default) |
+| `e2e-container` / debian | `ubuntu-latest` | Rootless Podman | Debian/dpkg-based compatibility |
+| `e2e-container` / alpine | `ubuntu-latest` | Rootless Podman | Musl libc, minimal environment |
+| `e2e-native` / macOS | `macos-latest` | Direct execution | Case-insensitive FS, macOS paths |
+| `e2e-native` / Windows | `windows-latest` | Direct execution | NTFS, backslash paths, `%USERPROFILE%` |
+
+When Go is added, each row doubles (`lang: [python, go]`), but the feature files stay identical — only the runner language changes.
+
+### Local Developer Workflow
+
+```bash
+# Run locally without containers (fastest feedback loop)
+cd e2e/python && behave ../features
+
+# Run in a rootless container (reproduces CI)
+make e2e-container
+
+# Run on a specific distro
+make e2e-container DISTRO=debian
+
+# Run only smoke tests in container
+make e2e-container E2E_TAGS=@smoke
+```
+
+### Makefile Integration (Updated)
+
+```makefile
+# mk/dev.mk additions
+DISTRO ?= fedora
+E2E_LANG ?= python
+E2E_TAGS ?= ~@wip
+
+e2e:  ## Run E2E BDD tests locally
+	cd e2e/python && behave --tags="$(E2E_TAGS)" --format progress --no-capture ../features
+
+e2e-wip:  ## Run only @wip tagged E2E scenarios
+	cd e2e/python && behave --tags="@wip" --format progress ../features
+
+e2e-smoke:  ## Run smoke E2E tests (pre-commit)
+	cd e2e/python && behave --tags="@smoke" --format progress ../features
+
+e2e-container-build:  ## Build E2E container images
+	podman build -t lola-e2e-base-$(DISTRO) -f e2e/containers/base/$(DISTRO).Containerfile .
+	podman build -t lola-e2e-$(E2E_LANG)-$(DISTRO) --build-arg BASE=$(DISTRO) \
+		-f e2e/containers/$(E2E_LANG).Containerfile .
+
+e2e-container: e2e-container-build  ## Run E2E tests in a rootless container
+	podman run --rm -e E2E_TAGS="$(E2E_TAGS)" lola-e2e-$(E2E_LANG)-$(DISTRO) $(E2E_LANG)
+```
+
+## Dependencies
+
+```
+# e2e/python/requirements.txt (or managed via uv)
+behave>=1.2.6
+PyYAML>=6.0
+```
+
+No other dependencies — the E2E tests use only stdlib (`subprocess`, `tempfile`, `pathlib`, `http.server`, `threading`, `re`) plus behave and PyYAML for marketplace fixture building.

--- a/e2e/containers/base/fedora.Containerfile
+++ b/e2e/containers/base/fedora.Containerfile
@@ -1,0 +1,9 @@
+FROM registry.fedoraproject.org/fedora:latest
+
+RUN dnf install -y --setopt=install_weak_deps=False \
+    git curl ca-certificates \
+    && dnf clean all
+
+RUN useradd --create-home --shell /bin/bash tester
+USER tester
+WORKDIR /home/tester

--- a/e2e/containers/python.Containerfile
+++ b/e2e/containers/python.Containerfile
@@ -1,0 +1,17 @@
+ARG BASE=fedora
+FROM localhost/lola-e2e-base-${BASE}:latest
+
+USER root
+RUN dnf install -y --setopt=install_weak_deps=False \
+    python3 python3-pip \
+    && dnf clean all
+
+RUN pip install --no-cache-dir \
+    click rich pygments pyyaml python-frontmatter inquirerpy packaging \
+    behave uv
+
+USER tester
+ENV PATH="/home/tester/.local/bin:${PATH}"
+WORKDIR /home/tester/lola
+
+ENTRYPOINT ["e2e/containers/scripts/run-tests.sh"]

--- a/e2e/containers/scripts/run-tests.sh
+++ b/e2e/containers/scripts/run-tests.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(realpath "$(dirname "$0")")"
+REPO_DIR="$(realpath "${SCRIPT_DIR}/../../..")"
+
+TEST_LANG="${1:-python}"
+TAGS="${E2E_TAGS:-~@wip}"
+
+cat <<EOF
+
+---------------------
+  Running BDD tests
+---------------------
+
+EOF
+
+case "$TEST_LANG" in
+    python)
+        # run from e2e directory
+        pip install --no-deps -e "${REPO_DIR}" >/dev/null 2>/dev/null
+        cd "${REPO_DIR}/e2e"
+        exec behave --tags="$TAGS" --no-capture --format progress
+        ;;
+    go)
+        # run from e2e/go directory
+        cd "${REPO_DIR}/e2e/go"
+        exec godog --tags="$TAGS" ../features
+        ;;
+    *)
+        echo "Unknown language: $TEST_LANG" >&2
+        exit 1
+        ;;
+esac

--- a/e2e/features/behave.ini
+++ b/e2e/features/behave.ini
@@ -1,0 +1,5 @@
+[behave]
+paths = .
+format = progress
+default_tags = ~@wip
+show_timings = true

--- a/e2e/features/cli.feature
+++ b/e2e/features/cli.feature
@@ -27,3 +27,10 @@ Feature: Top-level CLI behavior
     When I run lola with no arguments
     Then the exit code should be 2
     And the output should contain "AI Skills Package Manager"
+
+  Scenario: No arguments lists available subcommands
+    When I run lola with no arguments
+    Then the exit code should be 2
+    And the output should contain "mod"
+    And the output should contain "install"
+    And the output should contain "market"

--- a/e2e/features/cli.feature
+++ b/e2e/features/cli.feature
@@ -34,3 +34,10 @@ Feature: Top-level CLI behavior
     And the output should contain "mod"
     And the output should contain "install"
     And the output should contain "market"
+
+  Scenario: Show subcommand help
+    When I run lola "mod --help"
+    Then the exit code should be 0
+    And the output should contain "add"
+    And the output should contain "ls"
+    And the output should contain "rm"

--- a/e2e/features/cli.feature
+++ b/e2e/features/cli.feature
@@ -12,3 +12,13 @@ Feature: Top-level CLI behavior
       | flag      |
       | --version |
       | -v        |
+
+  Scenario Outline: Show help with flag
+    When I run lola "<flag>"
+    Then the exit code should be 0
+    And the output should contain "AI Skills Package Manager"
+
+    Examples:
+      | flag   |
+      | --help |
+      | -h     |

--- a/e2e/features/cli.feature
+++ b/e2e/features/cli.feature
@@ -46,3 +46,8 @@ Feature: Top-level CLI behavior
     When I run lola "nonexistent"
     Then the exit code should be 2
     And the output should contain "No such command"
+
+  Scenario: Reject unknown option
+    When I run lola "--bogus"
+    Then the exit code should be 2
+    And the output should contain "No such option"

--- a/e2e/features/cli.feature
+++ b/e2e/features/cli.feature
@@ -22,3 +22,8 @@ Feature: Top-level CLI behavior
       | flag   |
       | --help |
       | -h     |
+
+  Scenario: Show help when invoked without arguments
+    When I run lola with no arguments
+    Then the exit code should be 2
+    And the output should contain "AI Skills Package Manager"

--- a/e2e/features/cli.feature
+++ b/e2e/features/cli.feature
@@ -1,0 +1,14 @@
+@smoke
+Feature: Top-level CLI behavior
+  As a user, I want basic CLI commands to work
+  so that I can verify my lola installation.
+
+  Scenario Outline: Show version
+    When I run lola "<flag>"
+    Then the exit code should be 0
+    And the output should match /lola \d+\.\d+/
+
+    Examples:
+      | flag      |
+      | --version |
+      | -v        |

--- a/e2e/features/cli.feature
+++ b/e2e/features/cli.feature
@@ -41,3 +41,8 @@ Feature: Top-level CLI behavior
     And the output should contain "add"
     And the output should contain "ls"
     And the output should contain "rm"
+
+  Scenario: Reject unknown subcommand
+    When I run lola "nonexistent"
+    Then the exit code should be 2
+    And the output should contain "No such command"

--- a/e2e/features/completions.feature
+++ b/e2e/features/completions.feature
@@ -1,0 +1,8 @@
+Feature: Shell completions
+  As a user, I want to generate shell completion scripts
+  so that I can enable tab completion for lola commands.
+
+  Scenario: Generate bash completion script
+    When I run lola "completions bash"
+    Then the exit code should be 0
+    And the output should contain "complete"

--- a/e2e/features/completions.feature
+++ b/e2e/features/completions.feature
@@ -6,3 +6,8 @@ Feature: Shell completions
     When I run lola "completions bash"
     Then the exit code should be 0
     And the output should contain "complete"
+
+  Scenario: Reject invalid shell name
+    When I run lola "completions invalid"
+    Then the exit code should be 2
+    And the output should contain "Invalid value"

--- a/e2e/features/environment.py
+++ b/e2e/features/environment.py
@@ -1,0 +1,33 @@
+"""Behave environment hooks for E2E scenario isolation."""
+
+import shutil
+import tempfile
+from pathlib import Path
+
+from support.cli import LolaCLI
+
+
+def before_scenario(context, scenario):
+    """Set up an isolated temp environment for each scenario."""
+    # Isolated temp directory per scenario — no state leaks between scenarios
+    context.tmp_dir = Path(tempfile.mkdtemp(prefix="lola-e2e-"))
+    # LOLA_HOME override — subprocess reads this env var instead of ~/.lola
+    context.lola_home = context.tmp_dir / ".lola"
+    # Working directory for CLI invocations (simulates a user's project)
+    context.project_dir = context.tmp_dir / "project"
+    context.project_dir.mkdir(parents=True)
+    # CLI wrapper that runs `lola` as a subprocess with LOLA_HOME set
+    context.cli = LolaCLI(context.lola_home, context.project_dir)
+    # Registry of module source paths created by Given steps, keyed by name
+    context.modules = {}
+    # HTTP servers started by marketplace steps, stopped in after_scenario
+    context.http_servers = []
+    # Most recent LolaResult from a "When I run lola" step
+    context.last_result = None
+
+
+def after_scenario(context, scenario):
+    """Stop any HTTP servers and remove the scenario's temp directory."""
+    for server in getattr(context, "http_servers", []):
+        server.stop()
+    shutil.rmtree(context.tmp_dir, ignore_errors=True)

--- a/e2e/features/install/install.feature
+++ b/e2e/features/install/install.feature
@@ -9,3 +9,8 @@ Feature: Module installation
     Then the exit code should be 0
     And the output should contain "claude-code"
     And the directory "{project}/.claude/skills/skill1" should exist
+
+  Scenario: Install a module that is not registered
+    When I run lola "install nonexistent -a claude-code"
+    Then the exit code should be 1
+    And the output should contain "not found"

--- a/e2e/features/install/install.feature
+++ b/e2e/features/install/install.feature
@@ -1,0 +1,11 @@
+Feature: Module installation
+  As a user, I want to install modules to AI assistants
+  so that skills, commands, and agents are available in my workflow.
+
+  Scenario: Install a module to Claude Code
+    Given a module "my-module" with skills, commands, and agents
+    And the module "my-module" is registered
+    When I run lola "install my-module -a claude-code"
+    Then the exit code should be 0
+    And the output should contain "claude-code"
+    And the directory "{project}/.claude/skills/skill1" should exist

--- a/e2e/features/install/list.feature
+++ b/e2e/features/install/list.feature
@@ -1,0 +1,8 @@
+Feature: List installed modules
+  As a user, I want to list all installed modules
+  so that I can see what is currently active.
+
+  Scenario: List installed modules when none are installed
+    When I run lola "list"
+    Then the exit code should be 0
+    And the output should contain "No modules installed"

--- a/e2e/features/install/list.feature
+++ b/e2e/features/install/list.feature
@@ -6,3 +6,11 @@ Feature: List installed modules
     When I run lola "list"
     Then the exit code should be 0
     And the output should contain "No modules installed"
+
+  Scenario: List installed modules with an active installation
+    Given a module "my-module" with skills, commands, and agents
+    And the module "my-module" is installed to "claude-code"
+    When I run lola "list"
+    Then the exit code should be 0
+    And the output should contain "my-module"
+    And the output should contain "claude-code"

--- a/e2e/features/install/scope.feature
+++ b/e2e/features/install/scope.feature
@@ -1,0 +1,10 @@
+Feature: Installation scopes
+  As a user, I want to install modules at different scopes
+  so that I can choose between project-local and user-wide installations.
+
+  Scenario: Install with project scope by default
+    Given a module "my-module" with skills, commands, and agents
+    And the module "my-module" is registered
+    When I run lola "install my-module -a claude-code"
+    Then the exit code should be 0
+    And the directory "{project}/.claude/skills/skill1" should exist

--- a/e2e/features/install/uninstall.feature
+++ b/e2e/features/install/uninstall.feature
@@ -1,0 +1,11 @@
+Feature: Module uninstallation
+  As a user, I want to uninstall modules from AI assistants
+  so that I can remove skills I no longer need.
+
+  Scenario: Uninstall a previously installed module
+    Given a module "my-module" with skills, commands, and agents
+    And the module "my-module" is installed to "claude-code"
+    When I run lola "uninstall my-module -a claude-code"
+    Then the exit code should be 0
+    And the output should contain "Uninstalled"
+    And the directory "{project}/.claude/skills/skill1" should not exist

--- a/e2e/features/install/update.feature
+++ b/e2e/features/install/update.feature
@@ -6,3 +6,10 @@ Feature: Installation update
     When I run lola "update"
     Then the exit code should be 0
     And the output should contain "No installations to update"
+
+  Scenario: Update an installed module
+    Given a module "my-module" with skills, commands, and agents
+    And the module "my-module" is installed to "claude-code"
+    When I run lola "update my-module"
+    Then the exit code should be 0
+    And the output should contain "Update complete"

--- a/e2e/features/install/update.feature
+++ b/e2e/features/install/update.feature
@@ -1,0 +1,8 @@
+Feature: Installation update
+  As a user, I want to regenerate assistant files from source modules
+  so that changes to modules are reflected in my assistants.
+
+  Scenario: Update when no modules are installed
+    When I run lola "update"
+    Then the exit code should be 0
+    And the output should contain "No installations to update"

--- a/e2e/features/market/add.feature
+++ b/e2e/features/market/add.feature
@@ -1,0 +1,14 @@
+@marketplace
+Feature: Marketplace registration
+  As a user, I want to register marketplaces
+  so I can discover and install modules from curated catalogs.
+
+  Scenario: Add a marketplace
+    Given a marketplace catalog served at "/catalog.yml" with modules
+      | module     | version |
+      | my-module  | 1.0.0   |
+    When I run lola "market add community {server_url}/catalog.yml"
+    Then the exit code should be 0
+    And the output should contain "Added marketplace"
+    And the file "{lola_home}/market/community.yml" should exist
+    And the file "{lola_home}/market/cache/community.yml" should exist

--- a/e2e/features/market/ls.feature
+++ b/e2e/features/market/ls.feature
@@ -1,0 +1,13 @@
+@marketplace
+Feature: List marketplaces
+  As a user, I want to list registered marketplaces
+  so that I can see which module catalogs are available.
+
+  Scenario: List marketplaces
+    Given a marketplace catalog served at "/catalog.yml" with modules
+      | module    | version |
+      | my-module | 1.0.0   |
+    When I run lola "market add community {server_url}/catalog.yml"
+    And I run lola "market ls"
+    Then the exit code should be 0
+    And the output should contain "community"

--- a/e2e/features/market/rm.feature
+++ b/e2e/features/market/rm.feature
@@ -11,3 +11,8 @@ Feature: Marketplace removal
     And I run lola "market rm community"
     Then the exit code should be 0
     And the output should contain "Removed"
+
+  Scenario: Remove a marketplace that does not exist
+    When I run lola "market rm nonexistent"
+    Then the exit code should be 0
+    And the output should contain "not found"

--- a/e2e/features/market/rm.feature
+++ b/e2e/features/market/rm.feature
@@ -1,0 +1,13 @@
+@marketplace
+Feature: Marketplace removal
+  As a user, I want to remove marketplaces
+  so that I can clean up catalogs I no longer need.
+
+  Scenario: Remove a marketplace
+    Given a marketplace catalog served at "/catalog.yml" with modules
+      | module    | version |
+      | my-module | 1.0.0   |
+    When I run lola "market add community {server_url}/catalog.yml"
+    And I run lola "market rm community"
+    Then the exit code should be 0
+    And the output should contain "Removed"

--- a/e2e/features/market/set.feature
+++ b/e2e/features/market/set.feature
@@ -1,0 +1,13 @@
+@marketplace
+Feature: Marketplace enable/disable
+  As a user, I want to enable or disable marketplaces
+  so that I can control which catalogs are searched.
+
+  Scenario: Disable a marketplace
+    Given a marketplace catalog served at "/catalog.yml" with modules
+      | module    | version |
+      | my-module | 1.0.0   |
+    When I run lola "market add community {server_url}/catalog.yml"
+    And I run lola "market set community --disable"
+    Then the exit code should be 0
+    And the output should contain "disabled"

--- a/e2e/features/market/set.feature
+++ b/e2e/features/market/set.feature
@@ -11,3 +11,13 @@ Feature: Marketplace enable/disable
     And I run lola "market set community --disable"
     Then the exit code should be 0
     And the output should contain "disabled"
+
+  Scenario: Enable a disabled marketplace
+    Given a marketplace catalog served at "/catalog.yml" with modules
+      | module    | version |
+      | my-module | 1.0.0   |
+    When I run lola "market add community {server_url}/catalog.yml"
+    And I run lola "market set community --disable"
+    And I run lola "market set community --enable"
+    Then the exit code should be 0
+    And the output should contain "enabled"

--- a/e2e/features/market/update.feature
+++ b/e2e/features/market/update.feature
@@ -1,0 +1,13 @@
+@marketplace
+Feature: Marketplace update
+  As a user, I want to update marketplace catalogs
+  so that I can discover newly published modules.
+
+  Scenario: Update a marketplace
+    Given a marketplace catalog served at "/catalog.yml" with modules
+      | module    | version |
+      | my-module | 1.0.0   |
+    When I run lola "market add community {server_url}/catalog.yml"
+    And I run lola "market update community"
+    Then the exit code should be 0
+    And the output should contain "Updated"

--- a/e2e/features/mod/add.feature
+++ b/e2e/features/mod/add.feature
@@ -1,0 +1,10 @@
+Feature: Module registration
+  As a user, I want to register modules from various sources
+  so that I can install them to my AI assistants.
+
+  Scenario: Add a module from a local folder
+    Given a module "my-module" with skills, commands, and agents
+    When I run lola "mod add {module_path}"
+    Then the exit code should be 0
+    And the output should contain "Added my-module"
+    And the directory "{lola_home}/modules/my-module" should exist

--- a/e2e/features/mod/add.feature
+++ b/e2e/features/mod/add.feature
@@ -8,3 +8,9 @@ Feature: Module registration
     Then the exit code should be 0
     And the output should contain "Added my-module"
     And the directory "{lola_home}/modules/my-module" should exist
+
+  Scenario: Add a module that already exists
+    Given a module "my-module" with skills, commands, and agents
+    And the module "my-module" is registered
+    When I run lola "mod add {module_path}"
+    Then the output should contain "already exists"

--- a/e2e/features/mod/info.feature
+++ b/e2e/features/mod/info.feature
@@ -11,3 +11,8 @@ Feature: Module information
     And the output should contain "skill1"
     And the output should contain "cmd1"
     And the output should contain "agent1"
+
+  Scenario: Show info for a module that does not exist
+    When I run lola "mod info nonexistent"
+    Then the exit code should be 1
+    And the output should contain "not found"

--- a/e2e/features/mod/info.feature
+++ b/e2e/features/mod/info.feature
@@ -1,0 +1,13 @@
+Feature: Module information
+  As a user, I want to view detailed information about a module
+  so that I can understand its contents before installing.
+
+  Scenario: Show info for a registered module
+    Given a module "my-module" with skills, commands, and agents
+    And the module "my-module" is registered
+    When I run lola "mod info my-module"
+    Then the exit code should be 0
+    And the output should contain "my-module"
+    And the output should contain "skill1"
+    And the output should contain "cmd1"
+    And the output should contain "agent1"

--- a/e2e/features/mod/init.feature
+++ b/e2e/features/mod/init.feature
@@ -1,0 +1,9 @@
+Feature: Module initialization
+  As a module author, I want to scaffold a new module
+  so that I have a complete template to customize.
+
+  Scenario: Initialize a new module
+    When I run lola "mod init test-module"
+    Then the exit code should be 0
+    And the output should contain "Initialized module test-module"
+    And the directory "{project}/test-module" should exist

--- a/e2e/features/mod/init.feature
+++ b/e2e/features/mod/init.feature
@@ -7,3 +7,9 @@ Feature: Module initialization
     Then the exit code should be 0
     And the output should contain "Initialized module test-module"
     And the directory "{project}/test-module" should exist
+
+  Scenario: Initialize a module when directory already exists
+    When I run lola "mod init test-module"
+    And I run lola "mod init test-module"
+    Then the exit code should be 1
+    And the output should contain "already exists"

--- a/e2e/features/mod/ls.feature
+++ b/e2e/features/mod/ls.feature
@@ -7,3 +7,13 @@ Feature: List registered modules
     When I run lola "mod ls"
     Then the exit code should be 0
     And the output should contain "No modules found"
+
+  Scenario: List modules with a registered module
+    Given a module "my-module" with skills, commands, and agents
+    And the module "my-module" is registered
+    When I run lola "mod ls"
+    Then the exit code should be 0
+    And the output should contain "my-module"
+    And the output should contain "1 skill"
+    And the output should contain "1 command"
+    And the output should contain "1 agent"

--- a/e2e/features/mod/ls.feature
+++ b/e2e/features/mod/ls.feature
@@ -1,0 +1,9 @@
+@smoke
+Feature: List registered modules
+  As a user, I want to list modules in the lola registry
+  so that I can see what modules are available for installation.
+
+  Scenario: List modules when none are registered
+    When I run lola "mod ls"
+    Then the exit code should be 0
+    And the output should contain "No modules found"

--- a/e2e/features/mod/rm.feature
+++ b/e2e/features/mod/rm.feature
@@ -9,3 +9,8 @@ Feature: Module removal
     Then the exit code should be 0
     And the output should contain "Removed my-module"
     And the directory "{lola_home}/modules/my-module" should not exist
+
+  Scenario: Remove a module that does not exist
+    When I run lola "mod rm nonexistent --force"
+    Then the exit code should be 1
+    And the output should contain "not found"

--- a/e2e/features/mod/rm.feature
+++ b/e2e/features/mod/rm.feature
@@ -1,0 +1,11 @@
+Feature: Module removal
+  As a user, I want to remove modules from the lola registry
+  so that I can clean up modules I no longer need.
+
+  Scenario: Remove a registered module
+    Given a module "my-module" with skills, commands, and agents
+    And the module "my-module" is registered
+    When I run lola "mod rm my-module --force"
+    Then the exit code should be 0
+    And the output should contain "Removed my-module"
+    And the directory "{lola_home}/modules/my-module" should not exist

--- a/e2e/features/mod/search.feature
+++ b/e2e/features/mod/search.feature
@@ -1,0 +1,15 @@
+@marketplace
+Feature: Module search
+  As a user, I want to search for modules across marketplaces
+  so that I can discover available skills to install.
+
+  Scenario: Search for a module across marketplaces
+    Given a marketplace catalog served at "/catalog.yml" with modules
+      | module      | version |
+      | git-tools   | 1.0.0   |
+      | python-lint | 2.0.0   |
+    When I run lola "market add community {server_url}/catalog.yml"
+    And I run lola "mod search git"
+    Then the exit code should be 0
+    And the output should contain "git-tools"
+    And the output should not contain "python-lint"

--- a/e2e/features/mod/search.feature
+++ b/e2e/features/mod/search.feature
@@ -9,7 +9,7 @@ Feature: Module search
       | git-tools   | 1.0.0   |
       | python-lint | 2.0.0   |
     When I run lola "market add community {server_url}/catalog.yml"
-    And I run lola "mod search git"
+    And I run lola "search git"
     Then the exit code should be 0
     And the output should contain "git-tools"
     And the output should not contain "python-lint"

--- a/e2e/features/mod/update.feature
+++ b/e2e/features/mod/update.feature
@@ -6,3 +6,10 @@ Feature: Module update
     When I run lola "mod update"
     Then the exit code should be 0
     And the output should contain "No modules to update"
+
+  Scenario: Update a registered module from its source
+    Given a module "my-module" with skills, commands, and agents
+    When I run lola "mod add {module_path}"
+    And I run lola "mod update my-module"
+    Then the exit code should be 0
+    And the output should contain "my-module"

--- a/e2e/features/mod/update.feature
+++ b/e2e/features/mod/update.feature
@@ -1,0 +1,8 @@
+Feature: Module update
+  As a user, I want to update modules from their original sources
+  so that I can get the latest versions.
+
+  Scenario: Update when no modules are registered
+    When I run lola "mod update"
+    Then the exit code should be 0
+    And the output should contain "No modules to update"

--- a/e2e/features/steps/cli_steps.py
+++ b/e2e/features/steps/cli_steps.py
@@ -1,0 +1,37 @@
+"""Step definitions for CLI invocation and output assertions."""
+
+import shlex
+
+from behave import when, then
+
+from support.cli import resolve_path
+
+
+@when('I run lola "{command}"')
+def step_run_lola(context, command):
+    """Invoke lola as a subprocess with the given command string."""
+    command = resolve_path(context, command)
+    args = shlex.split(command)
+    context.last_result = context.cli.run(*args)
+
+
+@then("the exit code should be {code:d}")
+def step_exit_code(context, code):
+    """Assert the exit code of the last lola invocation."""
+    assert context.last_result.exit_code == code, (
+        f"Expected exit code {code}, got {context.last_result.exit_code}.\n"
+        f"stdout: {context.last_result.stdout}\n"
+        f"stderr: {context.last_result.stderr}"
+    )
+
+
+@then('the output should contain "{text}"')
+def step_output_contains(context, text):
+    """Assert that stdout or stderr contains the given text."""
+    text = resolve_path(context, text)
+    combined = context.last_result.stdout + context.last_result.stderr
+    assert text in combined, (
+        f'Expected output to contain "{text}".\n'
+        f"stdout: {context.last_result.stdout}\n"
+        f"stderr: {context.last_result.stderr}"
+    )

--- a/e2e/features/steps/cli_steps.py
+++ b/e2e/features/steps/cli_steps.py
@@ -55,3 +55,15 @@ def step_output_matches(context, pattern):
 def step_run_lola_no_args(context):
     """Invoke lola as a subprocess with no arguments."""
     context.last_result = context.cli.run()
+
+
+@then('the output should not contain "{text}"')
+def step_output_not_contains(context, text):
+    """Assert that neither stdout nor stderr contains the given text."""
+    text = resolve_path(context, text)
+    combined = context.last_result.stdout + context.last_result.stderr
+    assert text not in combined, (
+        f'Expected output NOT to contain "{text}".\n'
+        f"stdout: {context.last_result.stdout}\n"
+        f"stderr: {context.last_result.stderr}"
+    )

--- a/e2e/features/steps/cli_steps.py
+++ b/e2e/features/steps/cli_steps.py
@@ -35,3 +35,17 @@ def step_output_contains(context, text):
         f"stdout: {context.last_result.stdout}\n"
         f"stderr: {context.last_result.stderr}"
     )
+
+
+@then("the output should match /{pattern}/")
+def step_output_matches(context, pattern):
+    """Assert that the combined output matches a regex pattern."""
+    import re
+
+    pattern = resolve_path(context, pattern)
+    combined = context.last_result.stdout + context.last_result.stderr
+    assert re.search(pattern, combined), (
+        f"Expected output to match /{pattern}/.\n"
+        f"stdout: {context.last_result.stdout}\n"
+        f"stderr: {context.last_result.stderr}"
+    )

--- a/e2e/features/steps/cli_steps.py
+++ b/e2e/features/steps/cli_steps.py
@@ -49,3 +49,9 @@ def step_output_matches(context, pattern):
         f"stdout: {context.last_result.stdout}\n"
         f"stderr: {context.last_result.stderr}"
     )
+
+
+@when("I run lola with no arguments")
+def step_run_lola_no_args(context):
+    """Invoke lola as a subprocess with no arguments."""
+    context.last_result = context.cli.run()

--- a/e2e/features/steps/filesystem_steps.py
+++ b/e2e/features/steps/filesystem_steps.py
@@ -1,7 +1,10 @@
 """Step definitions for filesystem preconditions and assertions."""
 
-from behave import given
+from pathlib import Path
 
+from behave import given, then
+
+from support.cli import resolve_path
 from support.fixtures import (
     create_module_full,
     register_module,
@@ -25,3 +28,10 @@ def step_module_registered(context, name):
         f"Add a preceding 'Given a module \"{name}\" with ...' step."
     )
     register_module(context.lola_home, context.modules[name], name)
+
+
+@then('the directory "{path}" should exist')
+def step_dir_exists(context, path):
+    """Assert that a directory exists at the resolved path."""
+    resolved = resolve_path(context, path)
+    assert Path(resolved).is_dir(), f"Expected directory to exist: {resolved}"

--- a/e2e/features/steps/filesystem_steps.py
+++ b/e2e/features/steps/filesystem_steps.py
@@ -42,3 +42,18 @@ def step_dir_not_exists(context, path):
     """Assert that no directory exists at the resolved path."""
     resolved = resolve_path(context, path)
     assert not Path(resolved).is_dir(), f"Expected directory NOT to exist: {resolved}"
+
+
+@given('the module "{name}" is installed to "{assistant}"')
+def step_module_installed(context, name, assistant):
+    """Register a module and install it to an assistant via the CLI."""
+    assert name in context.modules, (
+        f'Module "{name}" not set up. '
+        f"Add a preceding 'Given a module \"{name}\" with ...' step."
+    )
+    register_module(context.lola_home, context.modules[name], name)
+    result = context.cli.run("install", name, "-a", assistant)
+    assert result.exit_code == 0, (
+        f"Failed to install {name} to {assistant}.\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )

--- a/e2e/features/steps/filesystem_steps.py
+++ b/e2e/features/steps/filesystem_steps.py
@@ -57,3 +57,10 @@ def step_module_installed(context, name, assistant):
         f"Failed to install {name} to {assistant}.\n"
         f"stdout: {result.stdout}\nstderr: {result.stderr}"
     )
+
+
+@then('the file "{path}" should exist')
+def step_file_exists(context, path):
+    """Assert that a file exists at the resolved path."""
+    resolved = resolve_path(context, path)
+    assert Path(resolved).is_file(), f"Expected file to exist: {resolved}"

--- a/e2e/features/steps/filesystem_steps.py
+++ b/e2e/features/steps/filesystem_steps.py
@@ -35,3 +35,10 @@ def step_dir_exists(context, path):
     """Assert that a directory exists at the resolved path."""
     resolved = resolve_path(context, path)
     assert Path(resolved).is_dir(), f"Expected directory to exist: {resolved}"
+
+
+@then('the directory "{path}" should not exist')
+def step_dir_not_exists(context, path):
+    """Assert that no directory exists at the resolved path."""
+    resolved = resolve_path(context, path)
+    assert not Path(resolved).is_dir(), f"Expected directory NOT to exist: {resolved}"

--- a/e2e/features/steps/filesystem_steps.py
+++ b/e2e/features/steps/filesystem_steps.py
@@ -1,0 +1,27 @@
+"""Step definitions for filesystem preconditions and assertions."""
+
+from behave import given
+
+from support.fixtures import (
+    create_module_full,
+    register_module,
+)
+
+
+@given('a module "{name}" with skills, commands, and agents')
+def step_module_full(context, name):
+    """Create a module source directory with one skill, command, and agent."""
+    source_dir = context.tmp_dir / "sources"
+    source_dir.mkdir(exist_ok=True)
+    module_path = create_module_full(source_dir, name)
+    context.modules[name] = module_path
+
+
+@given('the module "{name}" is registered')
+def step_module_registered(context, name):
+    """Copy a module into LOLA_HOME/modules/ to simulate `lola mod add`."""
+    assert name in context.modules, (
+        f'Module "{name}" not set up. '
+        f"Add a preceding 'Given a module \"{name}\" with ...' step."
+    )
+    register_module(context.lola_home, context.modules[name], name)

--- a/e2e/features/steps/marketplace_steps.py
+++ b/e2e/features/steps/marketplace_steps.py
@@ -1,0 +1,46 @@
+"""Step definitions for marketplace HTTP server and catalog preconditions."""
+
+import yaml
+
+from behave import given
+
+from support.http_server import LocalHTTPServer
+
+
+@given('a marketplace catalog served at "{url_path}" with modules')
+def step_marketplace_catalog_served(context, url_path):
+    """Start a local HTTP server serving a YAML marketplace catalog.
+
+    Reads module rows from the step's data table (columns: module, version,
+    repository). Sets context.server_url for {server_url} placeholder resolution.
+    """
+    serve_dir = context.tmp_dir / "http_serve"
+    serve_dir.mkdir(exist_ok=True)
+
+    modules = []
+    for row in context.table:
+        module_entry = {
+            "name": row["module"],
+            "description": f"{row['module']} description",
+            "version": row["version"],
+            "repository": row.get(
+                "repository", f"https://example.com/{row['module']}.git"
+            ),
+        }
+        modules.append(module_entry)
+
+    catalog = {
+        "name": "Test Marketplace",
+        "description": "E2E test marketplace",
+        "version": "1.0.0",
+        "modules": modules,
+    }
+
+    catalog_path = serve_dir / url_path.lstrip("/")
+    catalog_path.parent.mkdir(parents=True, exist_ok=True)
+    catalog_path.write_text(yaml.dump(catalog))
+
+    server = LocalHTTPServer(serve_dir)
+    server.start()
+    context.http_servers.append(server)
+    context.server_url = server.url

--- a/e2e/features/support/cli.py
+++ b/e2e/features/support/cli.py
@@ -1,0 +1,83 @@
+"""Subprocess wrapper for invoking the lola CLI in E2E tests."""
+
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+def _find_lola() -> str:
+    """Find the lola binary, preferring the active venv."""
+    venv_bin = Path(sys.executable).parent / "lola"
+    if venv_bin.exists():
+        return str(venv_bin)
+    found = shutil.which("lola")
+    if found:
+        return found
+    raise FileNotFoundError("lola binary not found. Install with: pip install -e .")
+
+
+_LOLA_BIN = _find_lola()
+
+
+@dataclass
+class LolaResult:
+    """Captured output from a lola CLI invocation."""
+
+    exit_code: int
+    stdout: str
+    stderr: str
+
+
+class LolaCLI:
+    """Subprocess wrapper that invokes `lola` with an isolated LOLA_HOME."""
+
+    def __init__(self, lola_home: Path, work_dir: Path):
+        """Initialize with the LOLA_HOME path and working directory."""
+        self.env = {**os.environ, "LOLA_HOME": str(lola_home)}
+        self.work_dir = work_dir
+
+    def run(self, *args: str, timeout: int = 30) -> LolaResult:
+        """Run `lola <args>` as a subprocess and return captured output."""
+        result = subprocess.run(
+            [_LOLA_BIN, *args],
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            cwd=self.work_dir,
+            env=self.env,
+            timeout=timeout,
+        )
+        return LolaResult(result.returncode, result.stdout, result.stderr)
+
+
+def resolve_path(context, text: str) -> str:
+    """Replace placeholders like {lola_home} and {project} with scenario paths.
+
+    Use {name_path} for a specific module. {module_path} is a shorthand that
+    resolves to the most recently added module — use only when the scenario
+    has a single module.
+    """
+    replacements = {
+        "{lola_home}": str(context.lola_home),
+        "{project}": str(context.project_dir),
+        "{home}": str(Path.home()),
+        "{tmp}": str(context.tmp_dir),
+    }
+    if hasattr(context, "server_url"):
+        replacements["{server_url}"] = context.server_url
+    for name, path in context.modules.items():
+        replacements[f"{{{name}_path}}"] = str(path)
+    if context.modules:
+        last_module = list(context.modules.values())[-1]
+        replacements["{module_path}"] = str(last_module)
+    for k, v in replacements.items():
+        text = text.replace(k, v)
+    return text
+
+
+def read_normalized(path: Path) -> str:
+    """Read a file and normalize line endings to Unix-style."""
+    return path.read_text().replace("\r\n", "\n")

--- a/e2e/features/support/fixtures.py
+++ b/e2e/features/support/fixtures.py
@@ -1,0 +1,61 @@
+"""Helpers for creating module and marketplace structures on disk."""
+
+import shutil
+from pathlib import Path
+
+
+def create_module_with_skill(base_dir: Path, name: str, skill_name: str) -> Path:
+    """Create a minimal module directory with a single skill.
+
+    Uses flat structure (no module/ subdir) so the directory name
+    becomes the module name when registered with `lola mod add`.
+    """
+    module_dir = base_dir / name
+    skill_dir = module_dir / "skills" / skill_name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\ndescription: {skill_name} skill\n---\n\n# {skill_name}\n\nA test skill.\n",
+        encoding="utf-8",
+    )
+    return module_dir
+
+
+def create_module_full(base_dir: Path, name: str) -> Path:
+    """Create a module directory with one skill, one command, and one agent.
+
+    Uses flat structure (no module/ subdir) so the directory name
+    becomes the module name when registered with `lola mod add`.
+    """
+    module_dir = base_dir / name
+
+    skill_dir = module_dir / "skills" / "skill1"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\ndescription: skill1 description\n---\n\n# Skill 1\n\nA test skill.\n",
+        encoding="utf-8",
+    )
+
+    cmd_dir = module_dir / "commands"
+    cmd_dir.mkdir(parents=True)
+    (cmd_dir / "cmd1.md").write_text(
+        "---\ndescription: cmd1 description\n---\n\n# Command 1\n\nA test command.\n",
+        encoding="utf-8",
+    )
+
+    agent_dir = module_dir / "agents"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "agent1.md").write_text(
+        "---\ndescription: agent1 description\n---\n\n# Agent 1\n\nA test agent.\n",
+        encoding="utf-8",
+    )
+
+    return module_dir
+
+
+def register_module(lola_home: Path, module_path: Path, name: str) -> Path:
+    """Copy a module source directory into LOLA_HOME/modules/ to simulate registration."""
+    modules_dir = lola_home / "modules"
+    modules_dir.mkdir(parents=True, exist_ok=True)
+    dest = modules_dir / name
+    shutil.copytree(module_path, dest)
+    return dest

--- a/e2e/features/support/http_server.py
+++ b/e2e/features/support/http_server.py
@@ -1,0 +1,29 @@
+"""Local HTTP server for serving marketplace catalogs during E2E tests."""
+
+import threading
+from functools import partial
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from pathlib import Path
+
+
+class LocalHTTPServer:
+    """Ephemeral HTTP server on localhost for serving marketplace catalogs in tests."""
+
+    def __init__(self, directory: Path):
+        """Bind to a random port and prepare to serve files from directory."""
+        self.directory = directory
+        handler = partial(SimpleHTTPRequestHandler, directory=str(directory))
+        self.server = HTTPServer(("127.0.0.1", 0), handler)
+        self.port = self.server.server_address[1]
+        self.url = f"http://127.0.0.1:{self.port}"
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    def start(self) -> None:
+        """Start serving in a daemon thread."""
+        self.thread.start()
+
+    def stop(self) -> None:
+        """Shut down the server and release the port."""
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join()

--- a/e2e/features/sync.feature
+++ b/e2e/features/sync.feature
@@ -1,0 +1,8 @@
+Feature: Module sync
+  As a user, I want to sync module installations from a config file
+  so that I can declaratively manage my module setup.
+
+  Scenario: Sync when config file does not exist
+    When I run lola "sync"
+    Then the exit code should be 1
+    And the output should contain "Config file not found"

--- a/mk/e2e.mk
+++ b/mk/e2e.mk
@@ -1,0 +1,38 @@
+# E2E BDD test targets
+# Run behavior tests via behave against the installed lola CLI.
+# Default format, tags, and feature paths are set in e2e/features/behave.ini.
+
+DISTRO ?= fedora
+E2E_LANG ?= python
+E2E_TAGS ?= ~@wip
+
+.PHONY: e2e e2e-wip e2e-smoke _ensure-podman-machine e2e-container-build e2e-container
+
+e2e: ## - run E2E BDD tests locally
+	@echo "Running E2E BDD tests..."
+	@cd e2e/features && uv run behave --no-capture
+
+e2e-wip: ## - run only @wip tagged E2E scenarios
+	@cd e2e/features && uv run behave --tags="@wip" --no-capture
+
+e2e-smoke: ## - run smoke E2E tests
+	@cd e2e/features && uv run behave --tags="@smoke" --no-capture
+
+_ensure-podman-machine:
+	@case "$$(uname -s)" in \
+		Darwin|MINGW*|MSYS*|CYGWIN*) \
+			state=$$(podman machine inspect --format '{{.State}}' 2>/dev/null) || true; \
+			if [ "$$state" != "running" ]; then \
+				echo "Starting podman machine..."; \
+				podman machine init 2>/dev/null || true; \
+				podman machine start; \
+			fi ;; \
+	esac
+
+e2e-container-build: _ensure-podman-machine ## - build E2E container images
+	podman build -t lola-e2e-base-$(DISTRO) -f e2e/containers/base/$(DISTRO).Containerfile .
+	podman build -t lola-e2e-$(E2E_LANG)-$(DISTRO) --build-arg BASE=$(DISTRO) \
+		-f e2e/containers/$(E2E_LANG).Containerfile .
+
+e2e-container: e2e-container-build ## - run E2E tests in a rootless container
+	podman run --rm -v "$(CURDIR):/home/tester/lola:Z" -e E2E_TAGS="$(E2E_TAGS)" lola-e2e-$(E2E_LANG)-$(DISTRO) $(E2E_LANG)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dev = [
     "types-pyyaml>=6.0.12.20250915",
     "filelock>=3.20.3",
     "virtualenv>=20.36.1",
+    "behave>=1.2.6",
 ]
 
 [project.optional-dependencies]
@@ -77,6 +78,11 @@ docs = [
     "mkdocs-awesome-pages-plugin>=2.9.0",
     "mkdocs-panzoom-plugin>=0.5.2",
 ]
+
+[[tool.ty.overrides]]
+include = ["e2e/features/steps/**"]
+[tool.ty.overrides.rules]
+call-non-callable = "ignore"  # behave's @given/@when/@then decorators
 
 [tool.ruff]
 extend-exclude = ["src/lola/_version.py"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,9 @@
 bandit==1.9.4 \
     --hash=sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628 \
     --hash=sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e
+behave==1.3.3 \
+    --hash=sha256:2b8f4b64ed2ea756a5a2a73e23defc1c4631e9e724c499e46661778453ebaf51 \
+    --hash=sha256:89bdb62af8fb9f147ce245736a5de69f025e5edfb66f1fbe16c5007493f842c0
 cfgv==3.5.0 \
     --hash=sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0 \
     --hash=sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132
@@ -12,11 +15,12 @@ click==8.4.1 \
     --hash=sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2 \
     --hash=sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96
     # via lola-ai
-colorama==0.4.6 ; sys_platform == 'win32' \
+colorama==0.4.6 \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
     # via
     #   bandit
+    #   behave
     #   click
     #   pytest
 coverage==7.13.4 \
@@ -83,6 +87,14 @@ coverage==7.13.4 \
     --hash=sha256:fb07dc5da7e849e2ad31a5d74e9bece81f30ecf5a42909d0a695f8bd1874d6af \
     --hash=sha256:fb26a934946a6afe0e326aebe0730cdff393a8bc0bbb65a2f41e30feddca399c
     # via pytest-cov
+cucumber-expressions==19.0.1 \
+    --hash=sha256:391edfdd750d0e12b97254e80470337f82315552a4d55404da363369dc84460d \
+    --hash=sha256:4b5283aed366a6fc37d02d6c42d58a9a2fdca1d17535aaace9b61daabc947cd4
+    # via behave
+cucumber-tag-expressions==9.1.0 \
+    --hash=sha256:cca145d677a942c1877e5a2cf13da8c6ec99260988877c817efd284d8455bb56 \
+    --hash=sha256:d960383d5885300ebcbcb14e41657946fde2a59d5c0f485eb291bc6a0e228acc
+    # via behave
 distlib==0.4.0 \
     --hash=sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16 \
     --hash=sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d
@@ -184,6 +196,16 @@ packaging==26.0 \
     # via
     #   lola-ai
     #   pytest
+parse==1.22.1 \
+    --hash=sha256:20f0925a46f06602485ac90d751764d0697fd8455aaa97489ba8953a4b66de32 \
+    --hash=sha256:d3a4740ec3da338e2b258b2d69741b731eadfddca59e24a14bc4ee5fce38c911
+    # via
+    #   behave
+    #   parse-type
+parse-type==0.6.6 \
+    --hash=sha256:3ca79bbe71e170dfccc8ec6c341edfd1c2a0fc1e5cfd18330f93af938de2348c \
+    --hash=sha256:513a3784104839770d690e04339a8b4d33439fcd5dd99f2e4580f9fc1097bfb2
+    # via behave
 pathspec==1.0.4 \
     --hash=sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645 \
     --hash=sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723
@@ -293,6 +315,12 @@ ruff==0.15.4 \
     --hash=sha256:c9fb74bab47139c1751f900f857fa503987253c3ef89129b24ed375e72873e85 \
     --hash=sha256:e9737c8161da79fd7cfec19f1e35620375bd8b2a50c3e77fa3d2c16f574105cc \
     --hash=sha256:f80c98765949c518142b3a50a5db89343aa90f2c2bf7799de9986498ae6176db
+six==1.17.0 \
+    --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
+    --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
+    # via
+    #   behave
+    #   parse-type
 stevedore==5.7.0 \
     --hash=sha256:31dd6fe6b3cbe921e21dcefabc9a5f1cf848cf538a1f27543721b8ca09948aa3 \
     --hash=sha256:fd25efbb32f1abb4c9e502f385f0018632baac11f9ee5d1b70f88cc5e22ad4ed

--- a/sbom.json
+++ b/sbom.json
@@ -9,7 +9,7 @@
       {
         "vendor": "Astral Software Inc.",
         "name": "uv",
-        "version": "0.10.9"
+        "version": "0.11.19"
       }
     ],
     "component": {
@@ -131,8 +131,7 @@
       ]
     },
     {
-      "ref": "colorama-3@0.4.6",
-      "dependsOn": []
+      "ref": "colorama-3@0.4.6"
     },
     {
       "ref": "inquirerpy-4@0.3.4",
@@ -160,16 +159,13 @@
       ]
     },
     {
-      "ref": "mdurl-6@0.1.2",
-      "dependsOn": []
+      "ref": "mdurl-6@0.1.2"
     },
     {
-      "ref": "packaging-7@26.0",
-      "dependsOn": []
+      "ref": "packaging-7@26.0"
     },
     {
-      "ref": "pfzy-8@0.3.4",
-      "dependsOn": []
+      "ref": "pfzy-8@0.3.4"
     },
     {
       "ref": "prompt-toolkit-9@3.0.52",
@@ -178,8 +174,7 @@
       ]
     },
     {
-      "ref": "pygments-10@2.20.0",
-      "dependsOn": []
+      "ref": "pygments-10@2.20.0"
     },
     {
       "ref": "python-frontmatter-11@1.1.0",
@@ -188,8 +183,7 @@
       ]
     },
     {
-      "ref": "pyyaml-12@6.0.3",
-      "dependsOn": []
+      "ref": "pyyaml-12@6.0.3"
     },
     {
       "ref": "rich-13@14.3.3",
@@ -199,8 +193,7 @@
       ]
     },
     {
-      "ref": "wcwidth-14@0.6.0",
-      "dependsOn": []
+      "ref": "wcwidth-14@0.6.0"
     }
   ]
 }

--- a/uv.lock
+++ b/uv.lock
@@ -54,6 +54,23 @@ wheels = [
 ]
 
 [[package]]
+name = "behave"
+version = "1.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+    { name = "cucumber-expressions" },
+    { name = "cucumber-tag-expressions" },
+    { name = "parse" },
+    { name = "parse-type" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/51/f37442fe648b3e35ecf69bee803fa6db3f74c5b46d6c882d0bc5654185a2/behave-1.3.3.tar.gz", hash = "sha256:2b8f4b64ed2ea756a5a2a73e23defc1c4631e9e724c499e46661778453ebaf51", size = 892639, upload-time = "2025-09-04T12:12:02.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/71/06f74ffed6d74525c5cd6677c97bd2df0b7649e47a249cf6a0c2038083b2/behave-1.3.3-py2.py3-none-any.whl", hash = "sha256:89bdb62af8fb9f147ce245736a5de69f025e5edfb66f1fbe16c5007493f842c0", size = 223594, upload-time = "2025-09-04T12:12:00.3Z" },
+]
+
+[[package]]
 name = "bracex"
 version = "2.6"
 source = { registry = "https://pypi.org/simple" }
@@ -225,6 +242,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/96/38086d58a181aac86d503dfa9c47eb20715a79c3e3acbdf786e92e5c09a8/coverage-7.13.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4c7d3cc01e7350f2f0f6f7036caaf5673fb56b6998889ccfe9e1c1fe75a9c932", size = 224148, upload-time = "2026-02-09T12:58:58.645Z" },
     { url = "https://files.pythonhosted.org/packages/ce/72/8d10abd3740a0beb98c305e0c3faf454366221c0f37a8bcf8f60020bb65a/coverage-7.13.4-cp314-cp314t-win_arm64.whl", hash = "sha256:23e3f687cf945070d1c90f85db66d11e3025665d8dafa831301a0e0038f3db9b", size = 222172, upload-time = "2026-02-09T12:59:00.396Z" },
     { url = "https://files.pythonhosted.org/packages/0d/4a/331fe2caf6799d591109bb9c08083080f6de90a823695d412a935622abb2/coverage-7.13.4-py3-none-any.whl", hash = "sha256:1af1641e57cf7ba1bd67d677c9abdbcd6cc2ab7da3bca7fa1e2b7e50e65f2ad0", size = 211242, upload-time = "2026-02-09T12:59:02.032Z" },
+]
+
+[[package]]
+name = "cucumber-expressions"
+version = "19.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/85/6e7f4ef1b673a45c716e5c9c8998918dd092530b7ab4c2203bdf1dbca2f9/cucumber_expressions-19.0.1.tar.gz", hash = "sha256:4b5283aed366a6fc37d02d6c42d58a9a2fdca1d17535aaace9b61daabc947cd4", size = 13743, upload-time = "2026-05-22T19:46:29.444Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/e4/1d68e3aa62b4cb8cee0b3b36170eb101adbfb36d59ec84848ec63cc02d5b/cucumber_expressions-19.0.1-py3-none-any.whl", hash = "sha256:391edfdd750d0e12b97254e80470337f82315552a4d55404da363369dc84460d", size = 20242, upload-time = "2026-05-22T19:46:30.151Z" },
+]
+
+[[package]]
+name = "cucumber-tag-expressions"
+version = "9.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/e0/de0b292a533846def28a4373a00c883ffa5ed986ca79f0284bd69a6297b8/cucumber_tag_expressions-9.1.0.tar.gz", hash = "sha256:d960383d5885300ebcbcb14e41657946fde2a59d5c0f485eb291bc6a0e228acc", size = 8437, upload-time = "2026-02-17T21:59:06.072Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/cf/8e8d034f7d55fceb2e4765bf9fab5da6d6a09204cd09de7bb5054f242cd0/cucumber_tag_expressions-9.1.0-py3-none-any.whl", hash = "sha256:cca145d677a942c1877e5a2cf13da8c6ec99260988877c817efd284d8455bb56", size = 9726, upload-time = "2026-02-17T21:59:04.755Z" },
 ]
 
 [[package]]
@@ -404,6 +439,7 @@ docs = [
 [package.dev-dependencies]
 dev = [
     { name = "bandit" },
+    { name = "behave" },
     { name = "filelock" },
     { name = "mypy" },
     { name = "pre-commit" },
@@ -436,6 +472,7 @@ provides-extras = ["docs"]
 [package.metadata.requires-dev]
 dev = [
     { name = "bandit", specifier = ">=1.9.4" },
+    { name = "behave", specifier = ">=1.2.6" },
     { name = "filelock", specifier = ">=3.20.3" },
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "pre-commit", specifier = ">=4.0.0" },
@@ -720,6 +757,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
+]
+
+[[package]]
+name = "parse"
+version = "1.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/f2/0b504486c2a5564798607d3860e48ed19c6443d5e9cc3ec61cc6b8b4ef58/parse-1.22.1.tar.gz", hash = "sha256:d3a4740ec3da338e2b258b2d69741b731eadfddca59e24a14bc4ee5fce38c911", size = 36970, upload-time = "2026-05-26T03:44:52.624Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/c5/7c16e99869e1f422629092cfd23e3b58e461988c3f9c36fd3624bb4142e6/parse-1.22.1-py2.py3-none-any.whl", hash = "sha256:20f0925a46f06602485ac90d751764d0697fd8455aaa97489ba8953a4b66de32", size = 20925, upload-time = "2026-05-26T03:44:51.156Z" },
+]
+
+[[package]]
+name = "parse-type"
+version = "0.6.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parse" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/ea/42ba6ce0abba04ab6e0b997dcb9b528a4661b62af1fe1b0d498120d5ea78/parse_type-0.6.6.tar.gz", hash = "sha256:513a3784104839770d690e04339a8b4d33439fcd5dd99f2e4580f9fc1097bfb2", size = 98012, upload-time = "2025-08-11T22:53:48.066Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/8d/eef3d8cdccc32abdd91b1286884c99b8c3a6d3b135affcc2a7a0f383bb32/parse_type-0.6.6-py2.py3-none-any.whl", hash = "sha256:3ca79bbe71e170dfccc8ec6c341edfd1c2a0fc1e5cfd18330f93af938de2348c", size = 27085, upload-time = "2025-08-11T22:53:46.396Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This is a draft proposal for having e2e testing using BDD/Gherkin.

The goal is to implement e2e testing with BDD for the Python CLI, and allow porting to Go to use the same testing framework.

The PR is a draft until we settle on how it should be implemented.

I'll add examples as de design is polished.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive E2E BDD test suite for many CLI scenarios and a pre-commit hook to run them.
  * Added containerized test runner images and an entrypoint to run tests inside containers.

* **Tests**
  * New Make targets for local and containerized E2E runs with tag filtering; Behave config, fixtures, step definitions, and test support utilities added.

* **Documentation**
  * Added a detailed E2E/BDD design guide.

* **Chores**
  * Updated ignore rules, dev dependencies, generated requirements, and SBOM metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->