### PR TITLE
docs: add Reporting Bugs section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -300,6 +300,21 @@ https://docs.github.com/en/authentication/connecting-to-github-with-ssh
   (https://opensource.guide/how-to-contribute/)**: General
   open-source contribution guidance
 
+## Reporting Bugs
+
+Found a bug? Open a [Bug Report](https://github.com/LobsterTrap/lola/issues/new?template=bug_report.yml)
+issue on GitHub. The template will guide you through providing the
+information we need (description, steps to reproduce, OS, versions,
+and any relevant logs).
+
+**Please write bug reports in English** — it is the project's working
+language and ensures the widest range of maintainers and contributors
+can respond.
+
+> [!NOTE]
+> For security vulnerabilities, do **not** open a public issue.
+> Follow the process in [SECURITY.md](SECURITY.md) instead.
+
 ## Questions?
 
 If you have questions about contributing, please open an issue on


### PR DESCRIPTION
## Summary

- Adds a **Reporting Bugs** section to `CONTRIBUTING.md` that links directly to the bug report issue template (`?template=bug_report.yml`)
- Explicitly states English as the project's working language for bug reports
- Redirects security issues to `SECURITY.md`

## Motivation

Satisfies two OpenSSF Best Practices badge criteria:
- `[report_process]` (MUST) — documented process for submitting bug reports
- `[english]` (SHOULD) — project accepts bug reports in English

Part of the AAIF readiness work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines with a new "Reporting Bugs" section providing instructions for submitting bug reports through GitHub templates, requiring English-language reports, and directing security vulnerabilities to the proper security disclosure process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->