### PR TITLE
docs: add OpenSSF badge and Matrix channel badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 Lola is a universal AI Package Manager. If an agent's skills were an RPM, Lola is the DNF for it. Write your [skills and context modules](https://lobstertrap.org/lola/concepts/skills-and-modules/) once as portable packages, then install them to any AI assistant or agent with a single command.
 
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13138/badge)](https://www.bestpractices.dev/projects/13138)
+[![Matrix](https://img.shields.io/matrix/%23lola-ai%3Amatrix.org?server_fqdn=matrix.org&label=Matrix&logo=matrix&color=blue)](https://matrix.to/#/#lola-ai:matrix.org)
+
 [![asciicast](https://asciinema.org/a/1035360.svg)](https://asciinema.org/a/1035360)
 
 ## Supported AI Assistants

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 **Write Agent Skills and Contexts once, use everywhere.**
 
-Lola is a universal AI Package Manager. If an agent's skills were an RPM, Lola is the DNF for it. Write your [skills and context modules](https://lobstertrap.org/lola/concepts/skills-and-modules/) once as portable packages, then install them to any AI assistant or agent with a single command.
-
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13138/badge)](https://www.bestpractices.dev/projects/13138)
-[![Matrix](https://img.shields.io/matrix/%23lola-ai%3Amatrix.org?server_fqdn=matrix.org&label=Matrix&logo=matrix&color=blue)](https://matrix.to/#/#lola-ai:matrix.org)
+[![Matrix](https://img.shields.io/badge/chat-Matrix-blue?logo=matrix)](https://matrix.to/#/#lola-ai:matrix.org)
+
+Lola is a universal AI Package Manager. If an agent's skills were an RPM, Lola is the DNF for it. Write your [skills and context modules](https://lobstertrap.org/lola/concepts/skills-and-modules/) once as portable packages, then install them to any AI assistant or agent with a single command.
 
 [![asciicast](https://asciinema.org/a/1035360.svg)](https://asciinema.org/a/1035360)
 


### PR DESCRIPTION
## Summary

- Adds the **OpenSSF Best Practices** passing badge to README.md
- Adds the **Matrix** channel badge linking to `#lola-ai:matrix.org`

## Details

Both badges appear at the top of the README for immediate visibility:

- OpenSSF badge: https://www.bestpractices.dev/projects/13138
- Matrix badge: links to https://matrix.to/#/#lola-ai:matrix.org

Part of the AAIF readiness work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added OpenSSF Best Practices and Matrix status badges to the project README.
  * Badges link to their respective project pages to surface security best-practices compliance and community matrix information for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->