### PR TITLE
feat: Go CLI skeleton — version command and lola mod stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,30 @@ plan/
 
 # asdf
 .tool-versions
+
+### Go ###
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace files
+go.work
+
+### Custom ###
+# Build output
+bin/
+
+### SuperPowers ###
+docs/superpowers/

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ plan/
 .env*
 *.log
 *.tmp
+
+# asdf
+.tool-versions

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,4 @@ help: ## - print the help and usage
 include mk/dev.mk
 include mk/mkdocs.mk
 include mk/adr.mk
+include mk/go.mk

--- a/cmd/mod.go
+++ b/cmd/mod.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/LobsterTrap/lola/internal/modules"
+)
+
+var modCmd = &cobra.Command{
+	Use:   "mod",
+	Short: "Manage lola modules",
+}
+
+var modAddCmd = &cobra.Command{
+	Use:   "add <source>",
+	Short: "Add a module from a source",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := modules.Add(args[0]); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	},
+}
+
+var modRmCmd = &cobra.Command{
+	Use:   "rm <name>",
+	Short: "Remove a registered module",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := modules.Remove(args[0]); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	},
+}
+
+var modLsCmd = &cobra.Command{
+	Use:   "ls",
+	Short: "List registered modules",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := modules.List(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	},
+}
+
+var modInfoCmd = &cobra.Command{
+	Use:   "info [name]",
+	Short: "Show detailed info for a module",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		name := ""
+		if len(args) > 0 {
+			name = args[0]
+		}
+		if err := modules.Info(name); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	},
+}
+
+var modUpdateCmd = &cobra.Command{
+	Use:   "update [name]",
+	Short: "Update a module from its source",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		name := ""
+		if len(args) > 0 {
+			name = args[0]
+		}
+		if err := modules.Update(name); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	},
+}
+
+var modInitCmd = &cobra.Command{
+	Use:   "init <name>",
+	Short: "Scaffold a new module",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := modules.Init(args[0]); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	modCmd.AddCommand(modAddCmd, modRmCmd, modLsCmd, modInfoCmd, modUpdateCmd, modInitCmd)
+	rootCmd.AddCommand(modCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,6 +30,7 @@ to quickly create a Cobra application.`,
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	InitVersionFlags(rootCmd)
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,10 +1,6 @@
 package cmd
 
-import (
-	"os"
-
-	"github.com/spf13/cobra"
-)
+import "github.com/spf13/cobra"
 
 var rootCmd = &cobra.Command{
 	Use:   "lola",
@@ -21,11 +17,8 @@ Quick start:
   lola install [module] -a [assistant]     Install skills`,
 }
 
-func Execute() {
-	err := rootCmd.Execute()
-	if err != nil {
-		os.Exit(1)
-	}
+func Execute() error {
+	return rootCmd.Execute()
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,3 @@
-/*
-Copyright © 2026 NAME HERE <EMAIL ADDRESS>
-
-*/
 package cmd
 
 import (
@@ -10,27 +6,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
-
-
-// rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "lola",
-	Short: "A brief description of your application",
-	Long: `A longer description that spans multiple lines and likely contains
-examples and usage of using your application. For example:
+	Short: "AI Context Package Manager",
+	Long: `lola - Universal AI Context Package Manager
 
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	// Run: func(cmd *cobra.Command, args []string) { },
+Lola is a universal AI Context Package Manager, for skills, plugins,
+profiles or Context Modules. Lola strives for AI sovereignty without
+vendor lock-in. Write your AI Skills once, run anywhere.
+
+Quick start:
+  lola mod add [git-url|folder|zip|tar]    Add a module
+  lola mod ls                               List modules
+  lola install [module] -a [assistant]     Install skills`,
 }
 
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	InitVersionFlags(rootCmd)
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)
@@ -38,15 +29,5 @@ func Execute() {
 }
 
 func init() {
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-
-	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.lola.yaml)")
-
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	rootCmd.Version = currentVersion()
 }
-
-

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,51 @@
+/*
+Copyright © 2026 NAME HERE <EMAIL ADDRESS>
+
+*/
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "lola",
+	Short: "A brief description of your application",
+	Long: `A longer description that spans multiple lines and likely contains
+examples and usage of using your application. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	// Uncomment the following line if your bare application
+	// has an action associated with it:
+	// Run: func(cmd *cobra.Command, args []string) { },
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func init() {
+	// Here you will define your flags and configuration settings.
+	// Cobra supports persistent flags, which, if defined here,
+	// will be global for your application.
+
+	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.lola.yaml)")
+
+	// Cobra also supports local flags, which will only run
+	// when this action is called directly.
+	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,40 @@
+/*
+Copyright © 2026 NAME HERE <EMAIL ADDRESS>
+
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("version called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// versionCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// versionCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -60,7 +60,7 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print lola version and platform info",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("lola version %s %s/%s\n", currentVersion(), runtime.GOOS, runtime.GOARCH)
+		fmt.Printf("lola version %s %s/%s\n", cmd.Root().Version, runtime.GOOS, runtime.GOARCH)
 	},
 }
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -64,14 +64,7 @@ var versionCmd = &cobra.Command{
 	},
 }
 
-// InitVersionFlags configures the root command with version information.
-// Sets the version string and template for --version / -v output to be script-friendly.
-// Must be called from Execute() before rootCmd.Execute().
-func InitVersionFlags(cmd *cobra.Command) {
-	cmd.Version = currentVersion()
-	cmd.SetVersionTemplate("{{.Version}}\n")
-}
-
 func init() {
 	rootCmd.AddCommand(versionCmd)
+	rootCmd.SetVersionTemplate("{{.Version}}\n")
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,40 +1,77 @@
-/*
-Copyright © 2026 NAME HERE <EMAIL ADDRESS>
-
-*/
 package cmd
 
 import (
 	"fmt"
+	"runtime"
+	"runtime/debug"
 
 	"github.com/spf13/cobra"
 )
 
-// versionCmd represents the version command
+// version is injected at build time:
+// -ldflags "-X github.com/LobsterTrap/lola/cmd.version=v1.2.0"
+var version string
+
+// resolveVersion determines the version string based on available version sources
+// in order of priority: build-time injection, go install module version, git commit hash, or default dev version.
+//
+// Parameters:
+//   - version: version injected at build time via ldflags
+//   - moduleVersion: version from debug.ReadBuildInfo().Main.Version
+//   - vcsRevision: git commit hash from debug.ReadBuildInfo().Settings
+//
+// Returns the resolved version string following the fallback chain:
+// 1. If version is set (build-time injection) → return it
+// 2. If moduleVersion is set and not "(devel)" → return it
+// 3. If vcsRevision is set → return "0.0.0-dev+" with first 7 chars of commit hash
+// 4. Default → return "0.0.0-dev"
+func resolveVersion(version, moduleVersion, vcsRevision string) string {
+	switch {
+	case version != "":
+		return version
+	case moduleVersion != "" && moduleVersion != "(devel)":
+		return moduleVersion
+	case vcsRevision != "":
+		return "0.0.0-dev+" + vcsRevision[:min(7, len(vcsRevision))]
+	default:
+		return "0.0.0-dev"
+	}
+}
+
+// currentVersion queries runtime build info and returns the resolved version.
+// It extracts moduleVersion and vcsRevision from debug.ReadBuildInfo() and passes
+// them to resolveVersion along with the build-time injected version variable.
+func currentVersion() string {
+	var moduleVersion, vcsRevision string
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		moduleVersion = bi.Main.Version
+		for _, s := range bi.Settings {
+			if s.Key == "vcs.revision" {
+				vcsRevision = s.Value
+				break
+			}
+		}
+	}
+	return resolveVersion(version, moduleVersion, vcsRevision)
+}
+
+// versionCmd represents the version command.
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "Print lola version and platform info",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("version called")
+		fmt.Printf("lola version %s %s/%s\n", currentVersion(), runtime.GOOS, runtime.GOARCH)
 	},
+}
+
+// InitVersionFlags configures the root command with version information.
+// Sets the version string and template for --version / -v output to be script-friendly.
+// Must be called from Execute() before rootCmd.Execute().
+func InitVersionFlags(cmd *cobra.Command) {
+	cmd.Version = currentVersion()
+	cmd.SetVersionTemplate("{{.Version}}\n")
 }
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// versionCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// versionCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,27 @@
+package cmd
+
+import "testing"
+
+func TestResolveVersion(t *testing.T) {
+	tt := []struct {
+		name          string
+		version       string
+		moduleVersion string
+		vcsRevision   string
+		want          string
+	}{
+		{"release build",     "v1.2.0", "(devel)", "a3f9b12abc", "v1.2.0"},
+		{"go install",        "",       "v1.2.0",  "",           "v1.2.0"},
+		{"dev with commit",   "",       "(devel)", "a3f9b12abc", "0.0.0-dev+a3f9b12"},
+		{"dev short hash",    "",       "(devel)", "abc",        "0.0.0-dev+abc"},
+		{"dev no vcs",        "",       "(devel)", "",           "0.0.0-dev"},
+		{"no context at all", "",       "",        "",           "0.0.0-dev"},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveVersion(tc.version, tc.moduleVersion, tc.vcsRevision); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -14,6 +14,7 @@ func TestResolveVersion(t *testing.T) {
 		{"go install",        "",       "v1.2.0",  "",           "v1.2.0"},
 		{"dev with commit",   "",       "(devel)", "a3f9b12abc", "0.0.0-dev+a3f9b12"},
 		{"dev short hash",    "",       "(devel)", "abc",        "0.0.0-dev+abc"},
+		{"dev exact 7 hash",  "",       "(devel)", "a3f9b12",    "0.0.0-dev+a3f9b12"},
 		{"dev no vcs",        "",       "(devel)", "",           "0.0.0-dev"},
 		{"no context at all", "",       "",        "",           "0.0.0-dev"},
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/LobsterTrap/lola
+
+go 1.26.3
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/cobra v1.10.2 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/modules/add.go
+++ b/internal/modules/add.go
@@ -1,0 +1,5 @@
+package modules
+
+func Add(source string) error {
+	return ErrNotImplemented
+}

--- a/internal/modules/add.go
+++ b/internal/modules/add.go
@@ -1,5 +1,6 @@
 package modules
 
+// Add registers a new module from the given source (git URL, local path, zip, tar, or OCI reference).
 func Add(source string) error {
 	return ErrNotImplemented
 }

--- a/internal/modules/errors.go
+++ b/internal/modules/errors.go
@@ -1,0 +1,5 @@
+package modules
+
+import "errors"
+
+var ErrNotImplemented = errors.New("not yet implemented")

--- a/internal/modules/errors.go
+++ b/internal/modules/errors.go
@@ -1,5 +1,9 @@
+// Package modules implements Lola's module management domain logic.
 package modules
 
 import "errors"
 
+// ErrNotImplemented is returned by stub functions that have not yet been implemented.
+// It serves as the template for domain-specific errors (e.g. ErrModuleNotFound) that
+// will be added to this file as each function is implemented.
 var ErrNotImplemented = errors.New("not yet implemented")

--- a/internal/modules/info.go
+++ b/internal/modules/info.go
@@ -1,5 +1,7 @@
 package modules
 
+// Info returns detailed information about the named module.
+// TODO: return (*Module, error) once the Module type is defined in pkg/models.
 func Info(name string) error {
 	return ErrNotImplemented
 }

--- a/internal/modules/info.go
+++ b/internal/modules/info.go
@@ -1,0 +1,5 @@
+package modules
+
+func Info(name string) error {
+	return ErrNotImplemented
+}

--- a/internal/modules/init.go
+++ b/internal/modules/init.go
@@ -1,5 +1,6 @@
 package modules
 
+// Init scaffolds a new module directory structure with the given name.
 func Init(name string) error {
 	return ErrNotImplemented
 }

--- a/internal/modules/init.go
+++ b/internal/modules/init.go
@@ -1,0 +1,5 @@
+package modules
+
+func Init(name string) error {
+	return ErrNotImplemented
+}

--- a/internal/modules/ls.go
+++ b/internal/modules/ls.go
@@ -1,5 +1,7 @@
 package modules
 
+// List returns all modules registered in LOLA_HOME.
+// TODO: return ([]Module, error) once the Module type is defined in pkg/models.
 func List() error {
 	return ErrNotImplemented
 }

--- a/internal/modules/ls.go
+++ b/internal/modules/ls.go
@@ -1,0 +1,5 @@
+package modules
+
+func List() error {
+	return ErrNotImplemented
+}

--- a/internal/modules/rm.go
+++ b/internal/modules/rm.go
@@ -1,0 +1,5 @@
+package modules
+
+func Remove(name string) error {
+	return ErrNotImplemented
+}

--- a/internal/modules/rm.go
+++ b/internal/modules/rm.go
@@ -1,5 +1,6 @@
 package modules
 
+// Remove unregisters the module with the given name from LOLA_HOME.
 func Remove(name string) error {
 	return ErrNotImplemented
 }

--- a/internal/modules/update.go
+++ b/internal/modules/update.go
@@ -1,0 +1,5 @@
+package modules
+
+func Update(name string) error {
+	return ErrNotImplemented
+}

--- a/internal/modules/update.go
+++ b/internal/modules/update.go
@@ -1,5 +1,7 @@
 package modules
 
+// Update re-fetches the module with the given name from its original source.
+// If name is empty, all registered modules are updated.
 func Update(name string) error {
 	return ErrNotImplemented
 }

--- a/main.go
+++ b/main.go
@@ -1,11 +1,16 @@
-/*
-Copyright © 2026 NAME HERE <EMAIL ADDRESS>
+// Copyright © 2026 LobsterTrap Contributors
+// SPDX-License-Identifier: Apache-2.0
 
-*/
 package main
 
-import "github.com/LobsterTrap/lola/cmd"
+import (
+	"os"
+
+	"github.com/LobsterTrap/lola/cmd"
+)
 
 func main() {
-	cmd.Execute()
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -1,0 +1,11 @@
+/*
+Copyright © 2026 NAME HERE <EMAIL ADDRESS>
+
+*/
+package main
+
+import "github.com/LobsterTrap/lola/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/mk/go.mk
+++ b/mk/go.mk
@@ -1,0 +1,16 @@
+# Go build targets
+# VERSION is set only when HEAD is exactly on a tag; empty string otherwise,
+# which causes resolveVersion to fall through to VCS stamping.
+VERSION := $(shell git describe --tags --exact-match 2>/dev/null || echo "")
+LDFLAGS := -X github.com/LobsterTrap/lola/cmd.version=$(VERSION)
+
+.PHONY: go-build go-test go-vet
+
+go-build: ## - build lola binary (version from tag if on one, else from VCS)
+	go build -ldflags "$(LDFLAGS)" -o bin/lola .
+
+go-test: ## - run Go test suite
+	go test ./...
+
+go-vet: ## - run go vet static analysis
+	go vet ./...


### PR DESCRIPTION
## Summary

Bootstraps the Lola Go CLI with the initial project structure, version
command, and `lola mod` skeleton. This is the first PR in the Go port
series (`go-port-00`), establishing the foundation for all subsequent
command implementations.

- Bootstrap Go CLI with Cobra (`main.go`, `cmd/root.go`)
- `lola version` / `lola --version` / `lola -v` with dynamic version
  resolution (ldflags → `go install` module version → VCS commit hash →
  `0.0.0-dev` fallback)
- `lola mod` command group with 6 no-op subcommands: `add`, `rm`, `ls`,
  `info`, `update`, `init`
- `internal/modules/` domain package with stub functions and per-package
  error sentinel (`ErrNotImplemented`)
- `mk/go.mk` with `go-build`, `go-test`, `go-vet` Makefile targets
- `.gitignore` updated with Go and SuperPowers sections

## Test plan

- [x] `lola --version` / `lola -v` prints version string (e.g. `0.0.0-dev+279d87c`)
- [x] `lola version` prints `lola version 0.0.0-dev+279d87c linux/amd64`
- [x] `lola mod --help` lists all 6 subcommands, no `search`
- [x] Each `lola mod <sub>` prints `not yet implemented` to stderr, exits 1
- [x] Arg validation rejects wrong arg count before hitting stubs
- [x] `make go-test` passes
- [x] `make go-vet` clean

## Related issues

Closes #182 — Go project skeleton
Part of the Go migration (ADR: go-migration)

## AI Disclosure

AI-assisted with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `mod` subcommands (add, rm, ls, info, update, init) for module management (currently scaffolded and returns “not yet implemented”).
  * Added a `version` command with resolved version details and `GOOS/GOARCH`.
* **Bug Fixes**
  * Improved CLI execution flow to return errors from the root command and exit with a non-zero status.
* **Chores**
  * Added Go module setup, Makefile Go build targets, and expanded local ignore rules.
* **Tests**
  * Added unit tests for version resolution across common release and development scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->