### PR TITLE
fix(targets): translate agent frontmatter tools to target-native dialect

### DIFF
--- a/src/lola/targets/base.py
+++ b/src/lola/targets/base.py
@@ -49,6 +49,29 @@ _CLAUDE_TOOL_NAME_MAP: dict[str, str] = {
 }
 
 
+OPENCODE_ONLY_FIELDS = ("mode", "temperature")
+
+
+def _transform_claude_agent_frontmatter(front: dict) -> dict:
+    """Convert agent frontmatter fields to Claude/Cursor expected format.
+
+    Normalises tools from any input dialect to a comma-separated string and
+    strips fields that are foreign to Claude Code and Cursor (e.g. OpenCode's
+    ``mode`` and ``temperature``).
+    """
+    tools = front.get("tools")
+    if isinstance(tools, dict):
+        enabled = [k for k, v in tools.items() if v]
+        front["tools"] = ", ".join(_to_claude_tool_name(t) for t in enabled)
+    elif isinstance(tools, list):
+        front["tools"] = ", ".join(_to_claude_tool_name(str(t)) for t in tools if t)
+
+    for field in OPENCODE_ONLY_FIELDS:
+        front.pop(field, None)
+
+    return front
+
+
 def _to_claude_tool_name(name: str) -> str:
     """Map a lowercased tool name to its canonical Claude Code casing.
 

--- a/src/lola/targets/base.py
+++ b/src/lola/targets/base.py
@@ -26,6 +26,44 @@ import yaml
 import lola.frontmatter as fm
 
 
+_CLAUDE_TOOL_NAME_MAP: dict[str, str] = {
+    "lsp": "LSP",
+    "webfetch": "WebFetch",
+    "websearch": "WebSearch",
+    "notebookedit": "NotebookEdit",
+    "askuserquestion": "AskUserQuestion",
+    "enterplanmode": "EnterPlanMode",
+    "exitplanmode": "ExitPlanMode",
+    "enterworktree": "EnterWorktree",
+    "exitworktree": "ExitWorktree",
+    "taskcreate": "TaskCreate",
+    "taskget": "TaskGet",
+    "tasklist": "TaskList",
+    "taskupdate": "TaskUpdate",
+    "taskoutput": "TaskOutput",
+    "taskstop": "TaskStop",
+    "croncreate": "CronCreate",
+    "crondelete": "CronDelete",
+    "cronlist": "CronList",
+    "schedulewakeup": "ScheduleWakeup",
+}
+
+
+def _to_claude_tool_name(name: str) -> str:
+    """Map a lowercased tool name to its canonical Claude Code casing.
+
+    Multi-word tools like ``webfetch`` must become ``WebFetch``, not
+    ``Webfetch``.  Falls back to capitalising the first letter for
+    single-word tools not in the map.
+    """
+    lowered = name.strip().lower()
+    if lowered in _CLAUDE_TOOL_NAME_MAP:
+        return _CLAUDE_TOOL_NAME_MAP[lowered]
+    if lowered == "*":
+        return "*"
+    return lowered[0].upper() + lowered[1:] if lowered else lowered
+
+
 def _resolve_source_content(source: Path | str | list[str]) -> str | None:
     """Resolve source to string content. Returns None if Path doesn't exist.
 

--- a/src/lola/targets/base.py
+++ b/src/lola/targets/base.py
@@ -17,6 +17,7 @@ import json
 import re
 import shutil
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Optional
 
@@ -806,8 +807,15 @@ def _generate_agent_with_frontmatter(
     dest_dir: Path,
     filename: str,
     frontmatter_additions: dict,
+    frontmatter_transforms: Callable[[dict], dict] | None = None,
 ) -> bool:
-    """Generate agent file with additional frontmatter fields."""
+    """Generate agent file with additional frontmatter fields.
+
+    Args:
+        frontmatter_transforms: Optional callback applied after merging
+            frontmatter_additions. Receives the merged dict, returns the
+            final dict to write. Use for target-specific field conversions.
+    """
     if not source_path.exists():
         return False
     dest_dir.mkdir(parents=True, exist_ok=True)
@@ -815,6 +823,9 @@ def _generate_agent_with_frontmatter(
     content = source_path.read_text()
     frontmatter, body = fm.parse(content)
     frontmatter.update(frontmatter_additions)
+
+    if frontmatter_transforms is not None:
+        frontmatter = frontmatter_transforms(frontmatter)
 
     frontmatter_str = yaml.dump(
         frontmatter, default_flow_style=False, sort_keys=False

--- a/src/lola/targets/claude_code.py
+++ b/src/lola/targets/claude_code.py
@@ -12,32 +12,8 @@ from .base import (
     MCPSupportMixin,
     _generate_agent_with_frontmatter,
     _generate_passthrough_command,
-    _to_claude_tool_name,
+    _transform_claude_agent_frontmatter,
 )
-
-
-OPENCODE_ONLY_FIELDS = ("mode", "temperature")
-
-
-def _transform_agent_frontmatter(front: dict) -> dict:
-    """Convert agent frontmatter fields to Claude Code's expected format.
-
-    Normalises tools from any input dialect to a comma-separated string and
-    strips fields that are foreign to Claude Code (e.g. OpenCode's ``mode``).
-    """
-    tools = front.get("tools")
-    if isinstance(tools, dict):
-        enabled = [k for k, v in tools.items() if v]
-        front["tools"] = ", ".join(_to_claude_tool_name(t) for t in enabled)
-    elif isinstance(tools, list):
-        front["tools"] = ", ".join(
-            _to_claude_tool_name(str(t)) for t in tools if t
-        )
-
-    for field in OPENCODE_ONLY_FIELDS:
-        front.pop(field, None)
-
-    return front
 
 
 class ClaudeCodeTarget(MCPSupportMixin, ManagedInstructionsTarget, BaseAssistantTarget):
@@ -124,5 +100,5 @@ class ClaudeCodeTarget(MCPSupportMixin, ManagedInstructionsTarget, BaseAssistant
             dest_dir,
             filename,
             {"name": agent_full_name, "model": "inherit"},
-            frontmatter_transforms=_transform_agent_frontmatter,
+            frontmatter_transforms=_transform_claude_agent_frontmatter,
         )

--- a/src/lola/targets/claude_code.py
+++ b/src/lola/targets/claude_code.py
@@ -15,6 +15,34 @@ from .base import (
 )
 
 
+OPENCODE_ONLY_FIELDS = ("mode", "temperature")
+
+
+def _transform_agent_frontmatter(front: dict) -> dict:
+    """Convert agent frontmatter fields to Claude Code's expected format.
+
+    Normalises tools from any input dialect to a comma-separated string and
+    strips fields that are foreign to Claude Code (e.g. OpenCode's ``mode``).
+    """
+    tools = front.get("tools")
+    if isinstance(tools, dict):
+        enabled = [k for k, v in tools.items() if v]
+        front["tools"] = ", ".join(
+            t if t == "*" else t[0].upper() + t[1:] for t in enabled
+        )
+    elif isinstance(tools, list):
+        front["tools"] = ", ".join(
+            str(t) if str(t) == "*" else str(t)[0].upper() + str(t)[1:]
+            for t in tools
+            if t
+        )
+
+    for field in OPENCODE_ONLY_FIELDS:
+        front.pop(field, None)
+
+    return front
+
+
 class ClaudeCodeTarget(MCPSupportMixin, ManagedInstructionsTarget, BaseAssistantTarget):
     """Target for Claude Code assistant."""
 
@@ -93,11 +121,11 @@ class ClaudeCodeTarget(MCPSupportMixin, ManagedInstructionsTarget, BaseAssistant
         module_name: str,
     ) -> bool:
         filename = self.get_agent_filename(module_name, agent_name)
-        # Claude Code requires 'name' field in agent frontmatter
         agent_full_name = filename.removesuffix(".md")
         return _generate_agent_with_frontmatter(
             source_path,
             dest_dir,
             filename,
             {"name": agent_full_name, "model": "inherit"},
+            frontmatter_transforms=_transform_agent_frontmatter,
         )

--- a/src/lola/targets/claude_code.py
+++ b/src/lola/targets/claude_code.py
@@ -12,6 +12,7 @@ from .base import (
     MCPSupportMixin,
     _generate_agent_with_frontmatter,
     _generate_passthrough_command,
+    _to_claude_tool_name,
 )
 
 
@@ -27,14 +28,10 @@ def _transform_agent_frontmatter(front: dict) -> dict:
     tools = front.get("tools")
     if isinstance(tools, dict):
         enabled = [k for k, v in tools.items() if v]
-        front["tools"] = ", ".join(
-            t if t == "*" else t[0].upper() + t[1:] for t in enabled
-        )
+        front["tools"] = ", ".join(_to_claude_tool_name(t) for t in enabled)
     elif isinstance(tools, list):
         front["tools"] = ", ".join(
-            str(t) if str(t) == "*" else str(t)[0].upper() + str(t)[1:]
-            for t in tools
-            if t
+            _to_claude_tool_name(str(t)) for t in tools if t
         )
 
     for field in OPENCODE_ONLY_FIELDS:

--- a/src/lola/targets/cursor.py
+++ b/src/lola/targets/cursor.py
@@ -18,6 +18,7 @@ from .base import (
     BaseAssistantTarget,
     _generate_passthrough_command,
     _generate_agent_with_frontmatter,
+    _to_claude_tool_name,
 )
 
 
@@ -33,14 +34,10 @@ def _transform_agent_frontmatter(front: dict) -> dict:
     tools = front.get("tools")
     if isinstance(tools, dict):
         enabled = [k for k, v in tools.items() if v]
-        front["tools"] = ", ".join(
-            t if t == "*" else t[0].upper() + t[1:] for t in enabled
-        )
+        front["tools"] = ", ".join(_to_claude_tool_name(t) for t in enabled)
     elif isinstance(tools, list):
         front["tools"] = ", ".join(
-            str(t) if str(t) == "*" else str(t)[0].upper() + str(t)[1:]
-            for t in tools
-            if t
+            _to_claude_tool_name(str(t)) for t in tools if t
         )
 
     for field in OPENCODE_ONLY_FIELDS:

--- a/src/lola/targets/cursor.py
+++ b/src/lola/targets/cursor.py
@@ -18,32 +18,8 @@ from .base import (
     BaseAssistantTarget,
     _generate_passthrough_command,
     _generate_agent_with_frontmatter,
-    _to_claude_tool_name,
+    _transform_claude_agent_frontmatter,
 )
-
-
-OPENCODE_ONLY_FIELDS = ("mode", "temperature")
-
-
-def _transform_agent_frontmatter(front: dict) -> dict:
-    """Convert agent frontmatter fields to Cursor's expected format.
-
-    Same rules as Claude Code: tools as a comma-separated string, foreign
-    fields (``mode``, ``temperature``) stripped.
-    """
-    tools = front.get("tools")
-    if isinstance(tools, dict):
-        enabled = [k for k, v in tools.items() if v]
-        front["tools"] = ", ".join(_to_claude_tool_name(t) for t in enabled)
-    elif isinstance(tools, list):
-        front["tools"] = ", ".join(
-            _to_claude_tool_name(str(t)) for t in tools if t
-        )
-
-    for field in OPENCODE_ONLY_FIELDS:
-        front.pop(field, None)
-
-    return front
 
 
 class CursorTarget(MCPSupportMixin, BaseAssistantTarget):
@@ -140,7 +116,7 @@ class CursorTarget(MCPSupportMixin, BaseAssistantTarget):
             dest_dir,
             filename,
             {"name": agent_full_name, "model": "inherit"},
-            frontmatter_transforms=_transform_agent_frontmatter,
+            frontmatter_transforms=_transform_claude_agent_frontmatter,
         )
 
     def generate_instructions(

--- a/src/lola/targets/cursor.py
+++ b/src/lola/targets/cursor.py
@@ -21,6 +21,34 @@ from .base import (
 )
 
 
+OPENCODE_ONLY_FIELDS = ("mode", "temperature")
+
+
+def _transform_agent_frontmatter(front: dict) -> dict:
+    """Convert agent frontmatter fields to Cursor's expected format.
+
+    Same rules as Claude Code: tools as a comma-separated string, foreign
+    fields (``mode``, ``temperature``) stripped.
+    """
+    tools = front.get("tools")
+    if isinstance(tools, dict):
+        enabled = [k for k, v in tools.items() if v]
+        front["tools"] = ", ".join(
+            t if t == "*" else t[0].upper() + t[1:] for t in enabled
+        )
+    elif isinstance(tools, list):
+        front["tools"] = ", ".join(
+            str(t) if str(t) == "*" else str(t)[0].upper() + str(t)[1:]
+            for t in tools
+            if t
+        )
+
+    for field in OPENCODE_ONLY_FIELDS:
+        front.pop(field, None)
+
+    return front
+
+
 class CursorTarget(MCPSupportMixin, BaseAssistantTarget):
     """Target for Cursor assistant."""
 
@@ -115,6 +143,7 @@ class CursorTarget(MCPSupportMixin, BaseAssistantTarget):
             dest_dir,
             filename,
             {"name": agent_full_name, "model": "inherit"},
+            frontmatter_transforms=_transform_agent_frontmatter,
         )
 
     def generate_instructions(

--- a/src/lola/targets/opencode.py
+++ b/src/lola/targets/opencode.py
@@ -33,10 +33,20 @@ REMOTE_MCP_TYPES = ("http", "sse")
 
 # Built-in OpenCode tools. Used to explicitly deny unlisted tools when
 # converting from an allowlist, since OpenCode enables tools by default.
-KNOWN_OPENCODE_TOOLS = frozenset({
-    "bash", "edit", "glob", "grep", "fetch", "list",
-    "patch", "read", "todoreplace", "write",
-})
+KNOWN_OPENCODE_TOOLS = frozenset(
+    {
+        "bash",
+        "edit",
+        "glob",
+        "grep",
+        "fetch",
+        "list",
+        "patch",
+        "read",
+        "todoreplace",
+        "write",
+    }
+)
 
 # Claude/Cursor tool names (lowercased) that map to a different OpenCode name.
 _TO_OPENCODE_TOOL: dict[str, str] = {

--- a/src/lola/targets/opencode.py
+++ b/src/lola/targets/opencode.py
@@ -31,19 +31,37 @@ def _convert_env_var_syntax(value: str) -> str:
 # Lola standard: http and sse only. OpenCode uses "remote" as its canonical type.
 REMOTE_MCP_TYPES = ("http", "sse")
 
+# Built-in OpenCode tools. Used to explicitly deny unlisted tools when
+# converting from an allowlist, since OpenCode enables tools by default.
+KNOWN_OPENCODE_TOOLS = frozenset({
+    "bash", "edit", "glob", "grep", "fetch", "list",
+    "patch", "read", "todoreplace", "write",
+})
+
 
 def _transform_agent_frontmatter(front: dict) -> dict:
     """Convert agent frontmatter fields to OpenCode's expected format.
 
-    Normalises tools from any input dialect to OpenCode's {name: bool} map.
+    Normalises tools from any input dialect to OpenCode's ``{name: bool}``
+    map.  When the input is an allowlist (comma string or list), known
+    built-in tools that are **not** in the allowlist are explicitly set to
+    ``False`` so that OpenCode does not leave them enabled by default.
     """
     tools = front.get("tools")
     if isinstance(tools, str):
-        front["tools"] = {
-            t.strip().lower(): True for t in tools.split(",") if t.strip()
-        }
+        allowed = {t.strip().lower() for t in tools.split(",") if t.strip()}
+        result = {t: True for t in allowed}
+        if "*" not in allowed:
+            for t in KNOWN_OPENCODE_TOOLS - allowed:
+                result[t] = False
+        front["tools"] = result
     elif isinstance(tools, list):
-        front["tools"] = {str(t).strip().lower(): True for t in tools if t}
+        allowed = {str(t).strip().lower() for t in tools if t}
+        result = {t: True for t in allowed}
+        if "*" not in allowed:
+            for t in KNOWN_OPENCODE_TOOLS - allowed:
+                result[t] = False
+        front["tools"] = result
     return front
 
 

--- a/src/lola/targets/opencode.py
+++ b/src/lola/targets/opencode.py
@@ -32,6 +32,21 @@ def _convert_env_var_syntax(value: str) -> str:
 REMOTE_MCP_TYPES = ("http", "sse")
 
 
+def _transform_agent_frontmatter(front: dict) -> dict:
+    """Convert agent frontmatter fields to OpenCode's expected format.
+
+    Normalises tools from any input dialect to OpenCode's {name: bool} map.
+    """
+    tools = front.get("tools")
+    if isinstance(tools, str):
+        front["tools"] = {
+            t.strip().lower(): True for t in tools.split(",") if t.strip()
+        }
+    elif isinstance(tools, list):
+        front["tools"] = {str(t).strip().lower(): True for t in tools if t}
+    return front
+
+
 def _transform_mcp_to_opencode(server_config: dict[str, Any]) -> dict[str, Any]:
     """Transform Lola MCP config to OpenCode format.
 
@@ -263,6 +278,7 @@ class OpenCodeTarget(ManagedInstructionsTarget, BaseAssistantTarget):
             dest_dir,
             filename,
             {"mode": "subagent"},
+            frontmatter_transforms=_transform_agent_frontmatter,
         )
 
     def remove_command(self, dest_dir: Path, cmd_name: str, module_name: str) -> bool:

--- a/src/lola/targets/opencode.py
+++ b/src/lola/targets/opencode.py
@@ -38,6 +38,17 @@ KNOWN_OPENCODE_TOOLS = frozenset({
     "patch", "read", "todoreplace", "write",
 })
 
+# Claude/Cursor tool names (lowercased) that map to a different OpenCode name.
+_TO_OPENCODE_TOOL: dict[str, str] = {
+    "webfetch": "fetch",
+}
+
+
+def _normalize_tool_name(name: str) -> str:
+    """Lowercase a tool name and translate it to its OpenCode equivalent."""
+    lowered = name.strip().lower()
+    return _TO_OPENCODE_TOOL.get(lowered, lowered)
+
 
 def _transform_agent_frontmatter(front: dict) -> dict:
     """Convert agent frontmatter fields to OpenCode's expected format.
@@ -49,14 +60,14 @@ def _transform_agent_frontmatter(front: dict) -> dict:
     """
     tools = front.get("tools")
     if isinstance(tools, str):
-        allowed = {t.strip().lower() for t in tools.split(",") if t.strip()}
+        allowed = {_normalize_tool_name(t) for t in tools.split(",") if t.strip()}
         result = {t: True for t in allowed}
         if "*" not in allowed:
             for t in KNOWN_OPENCODE_TOOLS - allowed:
                 result[t] = False
         front["tools"] = result
     elif isinstance(tools, list):
-        allowed = {str(t).strip().lower() for t in tools if t}
+        allowed = {_normalize_tool_name(str(t)) for t in tools if t}
         result = {t: True for t in allowed}
         if "*" not in allowed:
             for t in KNOWN_OPENCODE_TOOLS - allowed:

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,8 +1,10 @@
 """Tests for agent support."""
 
+import yaml
+
 from lola.models import Agent, Module
 from lola.frontmatter import validate_agent
-from lola.targets import get_target
+from lola.targets import get_target, _generate_agent_with_frontmatter
 
 
 class TestAgentModel:
@@ -233,3 +235,40 @@ Instructions.
         target = get_target("claude-code")
         filename = target.get_agent_filename("mymodule", "myagent")
         assert filename == "myagent.md"
+
+
+class TestFrontmatterTransformsCallback:
+    """Tests for the frontmatter_transforms callback in _generate_agent_with_frontmatter."""
+
+    def test_callback_is_applied(self, tmp_path):
+        """frontmatter_transforms callback modifies output frontmatter."""
+        source = tmp_path / "agent.md"
+        source.write_text("---\ndescription: Test\ncustom: original\n---\n\nBody.\n")
+        dest = tmp_path / "out"
+
+        def uppercase_custom(fm: dict) -> dict:
+            if "custom" in fm:
+                fm["custom"] = fm["custom"].upper()
+            return fm
+
+        _generate_agent_with_frontmatter(
+            source, dest, "agent.md", {}, frontmatter_transforms=uppercase_custom
+        )
+
+        content = (dest / "agent.md").read_text()
+        parts = content.split("---")
+        fm = yaml.safe_load(parts[1])
+        assert fm["custom"] == "ORIGINAL"
+
+    def test_no_callback_preserves_fields(self, tmp_path):
+        """Without callback, fields pass through unchanged."""
+        source = tmp_path / "agent.md"
+        source.write_text("---\ndescription: Test\ntools: Read, Write\n---\n\nBody.\n")
+        dest = tmp_path / "out"
+
+        _generate_agent_with_frontmatter(source, dest, "agent.md", {})
+
+        content = (dest / "agent.md").read_text()
+        parts = content.split("---")
+        fm = yaml.safe_load(parts[1])
+        assert fm["tools"] == "Read, Write"

--- a/tests/test_opencode_target.py
+++ b/tests/test_opencode_target.py
@@ -226,11 +226,7 @@ def test_generate_agent_transforms_tools(tmp_path):
     source = tmp_path / "source" / "myagent.md"
     source.parent.mkdir()
     source.write_text(
-        "---\n"
-        "description: Test agent\n"
-        "tools: Read, Write, Bash\n"
-        "---\n\n"
-        "Instructions.\n"
+        "---\ndescription: Test agent\ntools: Read, Write, Bash\n---\n\nInstructions.\n"
     )
 
     target = OpenCodeTarget()
@@ -293,12 +289,7 @@ def test_generate_agent_without_tools_unchanged(tmp_path):
     """generate_agent with no tools field still works normally."""
     source = tmp_path / "source" / "simple.md"
     source.parent.mkdir()
-    source.write_text(
-        "---\n"
-        "description: Simple agent\n"
-        "---\n\n"
-        "Body.\n"
-    )
+    source.write_text("---\ndescription: Simple agent\n---\n\nBody.\n")
 
     target = OpenCodeTarget()
     dest_dir = tmp_path / "dest"

--- a/tests/test_opencode_target.py
+++ b/tests/test_opencode_target.py
@@ -1,8 +1,10 @@
-"""Tests for OpenCodeTarget scope-aware path resolution."""
+"""Tests for OpenCodeTarget scope-aware path resolution and agent generation."""
 
 from pathlib import Path
 
-from lola.targets.opencode import OpenCodeTarget
+import yaml
+
+from lola.targets.opencode import OpenCodeTarget, _transform_agent_frontmatter
 from lola.config import get_user_config_dir
 
 
@@ -159,3 +161,101 @@ def test_opencode_skill_path_default_scope():
     target = OpenCodeTarget()
     result = target.get_skill_path("/home/user/project")
     assert result == Path("/home/user/project/.opencode/skills")
+
+
+# --- Agent tools transform tests ---
+
+
+def test_transform_agent_frontmatter_comma_string():
+    """Comma-separated tools string is converted to OpenCode dict format."""
+    fm = {"description": "Test", "tools": "Read, Write, Bash, Grep"}
+    result = _transform_agent_frontmatter(fm)
+    assert result["tools"] == {
+        "read": True,
+        "write": True,
+        "bash": True,
+        "grep": True,
+    }
+
+
+def test_transform_agent_frontmatter_no_tools():
+    """Frontmatter without tools is passed through unchanged."""
+    fm = {"description": "Test", "mode": "subagent"}
+    result = _transform_agent_frontmatter(fm)
+    assert "tools" not in result
+    assert result["description"] == "Test"
+
+
+def test_transform_agent_frontmatter_dict_tools_unchanged():
+    """Tools already in dict format are left alone."""
+    tools_dict = {"read": True, "write": True}
+    fm = {"description": "Test", "tools": tools_dict}
+    result = _transform_agent_frontmatter(fm)
+    assert result["tools"] is tools_dict
+
+
+def test_transform_agent_frontmatter_list_tools():
+    """Tools list is converted to OpenCode dict format."""
+    fm = {"tools": ["Read", "Write", "Bash"]}
+    result = _transform_agent_frontmatter(fm)
+    assert result["tools"] == {"read": True, "write": True, "bash": True}
+
+
+def test_transform_agent_frontmatter_wildcard_string():
+    """Single wildcard '*' tools string is converted."""
+    fm = {"tools": "*"}
+    result = _transform_agent_frontmatter(fm)
+    assert result["tools"] == {"*": True}
+
+
+def test_generate_agent_transforms_tools(tmp_path):
+    """Full generate_agent converts Claude-format tools to OpenCode format."""
+    source = tmp_path / "source" / "myagent.md"
+    source.parent.mkdir()
+    source.write_text(
+        "---\n"
+        "description: Test agent\n"
+        "tools: Read, Write, Bash\n"
+        "---\n\n"
+        "Instructions.\n"
+    )
+
+    target = OpenCodeTarget()
+    dest_dir = tmp_path / "dest"
+    success = target.generate_agent(source, dest_dir, "myagent", "mymodule")
+
+    assert success
+    output_file = dest_dir / "myagent.md"
+    content = output_file.read_text()
+
+    assert "mode: subagent" in content
+    assert "Instructions." in content
+
+    # Parse the output frontmatter and verify tools dict
+    parts = content.split("---")
+    fm = yaml.safe_load(parts[1])
+    assert fm["tools"] == {"read": True, "write": True, "bash": True}
+
+
+def test_generate_agent_without_tools_unchanged(tmp_path):
+    """generate_agent with no tools field still works normally."""
+    source = tmp_path / "source" / "simple.md"
+    source.parent.mkdir()
+    source.write_text(
+        "---\n"
+        "description: Simple agent\n"
+        "---\n\n"
+        "Body.\n"
+    )
+
+    target = OpenCodeTarget()
+    dest_dir = tmp_path / "dest"
+    success = target.generate_agent(source, dest_dir, "simple", "mymodule")
+
+    assert success
+    output_file = dest_dir / "simple.md"
+    content = output_file.read_text()
+    parts = content.split("---")
+    fm = yaml.safe_load(parts[1])
+    assert "tools" not in fm
+    assert fm["mode"] == "subagent"

--- a/tests/test_opencode_target.py
+++ b/tests/test_opencode_target.py
@@ -269,6 +269,26 @@ def test_transform_agent_frontmatter_read_only_denies_writes():
     assert tools["patch"] is False
 
 
+def test_transform_agent_frontmatter_webfetch_maps_to_fetch_string():
+    """Claude's WebFetch is translated to OpenCode's fetch (comma string)."""
+    fm = {"tools": "Read, WebFetch"}
+    result = _transform_agent_frontmatter(fm)
+    tools = result["tools"]
+    assert tools["fetch"] is True
+    assert tools["read"] is True
+    assert "webfetch" not in tools
+
+
+def test_transform_agent_frontmatter_webfetch_maps_to_fetch_list():
+    """Claude's WebFetch is translated to OpenCode's fetch (list)."""
+    fm = {"tools": ["Read", "WebFetch"]}
+    result = _transform_agent_frontmatter(fm)
+    tools = result["tools"]
+    assert tools["fetch"] is True
+    assert tools["read"] is True
+    assert "webfetch" not in tools
+
+
 def test_generate_agent_without_tools_unchanged(tmp_path):
     """generate_agent with no tools field still works normally."""
     source = tmp_path / "source" / "simple.md"

--- a/tests/test_opencode_target.py
+++ b/tests/test_opencode_target.py
@@ -4,7 +4,11 @@ from pathlib import Path
 
 import yaml
 
-from lola.targets.opencode import OpenCodeTarget, _transform_agent_frontmatter
+from lola.targets.opencode import (
+    KNOWN_OPENCODE_TOOLS,
+    OpenCodeTarget,
+    _transform_agent_frontmatter,
+)
 from lola.config import get_user_config_dir
 
 
@@ -170,12 +174,14 @@ def test_transform_agent_frontmatter_comma_string():
     """Comma-separated tools string is converted to OpenCode dict format."""
     fm = {"description": "Test", "tools": "Read, Write, Bash, Grep"}
     result = _transform_agent_frontmatter(fm)
-    assert result["tools"] == {
-        "read": True,
-        "write": True,
-        "bash": True,
-        "grep": True,
-    }
+    tools = result["tools"]
+    assert tools["read"] is True
+    assert tools["write"] is True
+    assert tools["bash"] is True
+    assert tools["grep"] is True
+    # Unlisted known tools must be explicitly denied
+    for t in KNOWN_OPENCODE_TOOLS - {"read", "write", "bash", "grep"}:
+        assert tools[t] is False, f"expected {t} to be denied"
 
 
 def test_transform_agent_frontmatter_no_tools():
@@ -198,14 +204,21 @@ def test_transform_agent_frontmatter_list_tools():
     """Tools list is converted to OpenCode dict format."""
     fm = {"tools": ["Read", "Write", "Bash"]}
     result = _transform_agent_frontmatter(fm)
-    assert result["tools"] == {"read": True, "write": True, "bash": True}
+    tools = result["tools"]
+    assert tools["read"] is True
+    assert tools["write"] is True
+    assert tools["bash"] is True
+    for t in KNOWN_OPENCODE_TOOLS - {"read", "write", "bash"}:
+        assert tools[t] is False, f"expected {t} to be denied"
 
 
 def test_transform_agent_frontmatter_wildcard_string():
-    """Single wildcard '*' tools string is converted."""
+    """Wildcard '*' enables all tools without denying any."""
     fm = {"tools": "*"}
     result = _transform_agent_frontmatter(fm)
     assert result["tools"] == {"*": True}
+    # No False entries — wildcard means "all tools"
+    assert all(v is True for v in result["tools"].values())
 
 
 def test_generate_agent_transforms_tools(tmp_path):
@@ -234,7 +247,26 @@ def test_generate_agent_transforms_tools(tmp_path):
     # Parse the output frontmatter and verify tools dict
     parts = content.split("---")
     fm = yaml.safe_load(parts[1])
-    assert fm["tools"] == {"read": True, "write": True, "bash": True}
+    assert fm["tools"]["read"] is True
+    assert fm["tools"]["write"] is True
+    assert fm["tools"]["bash"] is True
+    # Unlisted known tools should be denied
+    for t in KNOWN_OPENCODE_TOOLS - {"read", "write", "bash"}:
+        assert fm["tools"][t] is False
+
+
+def test_transform_agent_frontmatter_read_only_denies_writes():
+    """A read-only allowlist must deny write-capable tools."""
+    fm = {"tools": "Read, Grep, Glob"}
+    result = _transform_agent_frontmatter(fm)
+    tools = result["tools"]
+    assert tools["read"] is True
+    assert tools["grep"] is True
+    assert tools["glob"] is True
+    assert tools["write"] is False
+    assert tools["edit"] is False
+    assert tools["bash"] is False
+    assert tools["patch"] is False
 
 
 def test_generate_agent_without_tools_unchanged(tmp_path):

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -13,6 +13,8 @@ from pathlib import Path
 import pytest
 
 from lola.exceptions import UnknownAssistantError
+import yaml
+
 from lola.targets import (
     ClaudeCodeTarget,
     CursorTarget,
@@ -325,6 +327,60 @@ Agent body content.
         assert "custom_field: custom_value" in content
         assert "tag1" in content
 
+    def test_generate_agent_converts_opencode_tools_dict(
+        self, tmp_path: Path, dest_path: Path
+    ):
+        """generate_agent converts OpenCode-style tools dict to comma string."""
+        agent_dir = tmp_path / "agents"
+        agent_dir.mkdir()
+        agent_file = agent_dir / "oc-agent.md"
+        agent_file.write_text(
+            "---\n"
+            "description: OpenCode agent\n"
+            "mode: subagent\n"
+            "tools:\n"
+            "  read: true\n"
+            "  bash: true\n"
+            "  write: false\n"
+            "---\n\n"
+            "Body.\n"
+        )
+
+        target = ClaudeCodeTarget()
+        target.generate_agent(agent_file, dest_path, "oc-agent", "mymod")
+
+        content = (dest_path / "oc-agent.md").read_text()
+        parts = content.split("---")
+        fm = yaml.safe_load(parts[1])
+        assert fm["tools"] == "Read, Bash"
+        assert "mode" not in fm
+
+    def test_generate_agent_strips_foreign_fields(
+        self, tmp_path: Path, dest_path: Path
+    ):
+        """generate_agent strips OpenCode-only mode and temperature fields."""
+        agent_dir = tmp_path / "agents"
+        agent_dir.mkdir()
+        agent_file = agent_dir / "foreign.md"
+        agent_file.write_text(
+            "---\n"
+            "description: Agent with foreign fields\n"
+            "mode: subagent\n"
+            "temperature: 0.7\n"
+            "---\n\n"
+            "Body.\n"
+        )
+
+        target = ClaudeCodeTarget()
+        target.generate_agent(agent_file, dest_path, "foreign", "mymod")
+
+        content = (dest_path / "foreign.md").read_text()
+        parts = content.split("---")
+        fm = yaml.safe_load(parts[1])
+        assert "mode" not in fm
+        assert "temperature" not in fm
+        assert fm["description"] == "Agent with foreign fields"
+
     def test_remove_skill_deletes_directory(self, dest_path: Path):
         """remove_skill should delete the skill directory."""
         target = ClaudeCodeTarget()
@@ -606,6 +662,33 @@ Agent body content.
         assert "model: inherit" in content
         assert "custom_field: custom_value" in content
         assert "tag1" in content
+
+    def test_generate_agent_converts_opencode_tools_dict(
+        self, tmp_path: Path, dest_path: Path
+    ):
+        """generate_agent converts OpenCode-style tools dict to comma string."""
+        agent_dir = tmp_path / "agents"
+        agent_dir.mkdir()
+        agent_file = agent_dir / "oc-agent.md"
+        agent_file.write_text(
+            "---\n"
+            "description: OpenCode agent\n"
+            "mode: subagent\n"
+            "tools:\n"
+            "  read: true\n"
+            "  bash: true\n"
+            "---\n\n"
+            "Body.\n"
+        )
+
+        target = CursorTarget()
+        target.generate_agent(agent_file, dest_path, "oc-agent", "mymod")
+
+        content = (dest_path / "oc-agent.md").read_text()
+        parts = content.split("---")
+        fm = yaml.safe_load(parts[1])
+        assert fm["tools"] == "Read, Bash"
+        assert "mode" not in fm
 
     def test_remove_skill_deletes_directory(self, dest_path: Path):
         """remove_skill should delete the skill directory (Cursor 2.4+)."""

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -355,6 +355,39 @@ Agent body content.
         assert fm["tools"] == "Read, Bash"
         assert "mode" not in fm
 
+    def test_generate_agent_maps_multiword_tool_names(
+        self, tmp_path: Path, dest_path: Path
+    ):
+        """generate_agent maps lowercased multi-word tools to correct casing."""
+        agent_dir = tmp_path / "agents"
+        agent_dir.mkdir()
+        agent_file = agent_dir / "multi.md"
+        agent_file.write_text(
+            "---\n"
+            "description: Multi-word tools\n"
+            "tools:\n"
+            "  webfetch: true\n"
+            "  websearch: true\n"
+            "  lsp: true\n"
+            "  notebookedit: true\n"
+            "---\n\n"
+            "Body.\n"
+        )
+
+        target = ClaudeCodeTarget()
+        target.generate_agent(agent_file, dest_path, "multi", "mymod")
+
+        content = (dest_path / "multi.md").read_text()
+        parts = content.split("---")
+        fm = yaml.safe_load(parts[1])
+        tools = fm["tools"]
+        assert "WebFetch" in tools
+        assert "WebSearch" in tools
+        assert "LSP" in tools
+        assert "NotebookEdit" in tools
+        assert "Webfetch" not in tools
+        assert "Websearch" not in tools
+
     def test_generate_agent_strips_foreign_fields(
         self, tmp_path: Path, dest_path: Path
     ):
@@ -689,6 +722,35 @@ Agent body content.
         fm = yaml.safe_load(parts[1])
         assert fm["tools"] == "Read, Bash"
         assert "mode" not in fm
+
+    def test_generate_agent_maps_multiword_tool_names(
+        self, tmp_path: Path, dest_path: Path
+    ):
+        """generate_agent maps lowercased multi-word tools to correct casing."""
+        agent_dir = tmp_path / "agents"
+        agent_dir.mkdir()
+        agent_file = agent_dir / "multi.md"
+        agent_file.write_text(
+            "---\n"
+            "description: Multi-word tools\n"
+            "tools:\n"
+            "  webfetch: true\n"
+            "  websearch: true\n"
+            "  lsp: true\n"
+            "---\n\n"
+            "Body.\n"
+        )
+
+        target = CursorTarget()
+        target.generate_agent(agent_file, dest_path, "multi", "mymod")
+
+        content = (dest_path / "multi.md").read_text()
+        parts = content.split("---")
+        fm = yaml.safe_load(parts[1])
+        tools = fm["tools"]
+        assert "WebFetch" in tools
+        assert "WebSearch" in tools
+        assert "LSP" in tools
 
     def test_remove_skill_deletes_directory(self, dest_path: Path):
         """remove_skill should delete the skill directory (Cursor 2.4+)."""


### PR DESCRIPTION
## Summary

Fixes #170 — agent frontmatter authored in one assistant's dialect (e.g. OpenCode's `{name: bool}` tools map or Claude Code's comma-separated string) was passed through verbatim to other targets, producing malformed output that the target could not parse.

- Adds a generic `frontmatter_transforms` callback parameter to `_generate_agent_with_frontmatter` so each target can declaratively transform fields during agent generation
- **OpenCode**: converts `tools: Read, Write, Bash` (string) and `tools: [Read, Write]` (list) → `tools: {read: true, write: true, bash: true}` (dict)
- **Claude Code / Cursor**: converts `tools: {read: true, bash: true, write: false}` (dict) → `tools: Read, Bash` (comma string, disabled tools excluded); strips foreign fields (`mode`, `temperature`)

## Test plan

- [x] Unit tests for each target's transform function (string, dict, list, wildcard, no-tools cases)
- [x] Integration tests via `generate_agent()` for OpenCode, Claude Code, and Cursor
- [x] Tests for the callback mechanism itself (applied vs not-applied)
- [x] Tests for foreign field stripping (`mode`, `temperature`)
- [x] Full test suite passes (1033 tests)
- [x] `ruff check` clean
- [x] `basedpyright` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent generation now applies frontmatter normalization for Claude Code, Cursor, and OpenCode, including `tools` rewrites into each platform’s expected format and tool-name casing.
  * Platform-incompatible frontmatter fields (such as `mode` and `temperature`-like entries) are stripped for Claude Code/Cursor output.
  * OpenCode tool allowlisting is enforced when `*` isn’t provided, including explicit denial of known unlisted tools.
  * Added support for custom frontmatter transformation callbacks during generation.
* **Tests**
  * Expanded unit and integration coverage for `tools` conversions across comma-string, list, dict, wildcard, and identity-preservation scenarios, plus verification of generated YAML frontmatter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->