### PR TITLE
feat: support multiple --append-context values and absolute paths (#161)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,3 +22,9 @@
   - Multi-marketplace conflict resolution with user prompts
   - Cache recovery on missing cache files
   - MarketplaceRegistry class with search_module_all() and select_marketplace() methods
+
+<!-- lola:instructions:start -->
+<!-- lola:module:dedup-test:start -->
+# Module Instructions
+<!-- lola:module:dedup-test:end -->
+<!-- lola:instructions:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,9 +22,3 @@
   - Multi-marketplace conflict resolution with user prompts
   - Cache recovery on missing cache files
   - MarketplaceRegistry class with search_module_all() and select_marketplace() methods
-
-<!-- lola:instructions:start -->
-<!-- lola:module:dedup-test:start -->
-# Module Instructions
-<!-- lola:module:dedup-test:end -->
-<!-- lola:instructions:end -->

--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -735,11 +735,14 @@ def _format_update_summary(result: UpdateResult) -> str:
 )
 @click.option(
     "--append-context",
+    "append_context",
     type=str,
-    default=None,
+    multiple=True,
+    default=(),
     help="Append a context reference instead of copying instructions verbatim. "
+    "Can be specified multiple times for multiple context files. "
     "Pass the path to the main context file relative to the module root "
-    "(e.g., module/AGENTS.md).",
+    "or an absolute path (e.g., module/AGENTS.md or /abs/path/AGENTS.md).",
 )
 @click.option(
     "--workspace",
@@ -764,7 +767,7 @@ def install_cmd(
     force: bool,
     pre_install: Optional[str],
     post_install: Optional[str],
-    append_context: Optional[str],
+    append_context: tuple[str, ...],
     workspace: Optional[str],
     scope: str,
     project_path: str,
@@ -772,9 +775,9 @@ def install_cmd(
     """
     Install a module's skills to AI assistants.
 
-    MODULE_NAME is optional when running interactively — omit it to pick
-    from registered modules via an interactive prompt.  If no assistant is
-    specified, you are prompted to choose one (or all in non-interactive mode).
+    MODULE_NAME is optional when running interactively — omit it to pick from
+    registered modules via an interactive prompt.  If no assistant is specified,
+    you are prompted to choose one (or all in non-interactive mode).
 
     \b
     Examples:
@@ -782,7 +785,8 @@ def install_cmd(
         lola install my-module                         # Pick assistants interactively
         lola install my-module -a claude-code          # Specific assistant, no prompt
         lola install my-module ./my-project            # Install in a specific project directory
-        lola install my-module --append-context module/AGENTS.md   # Append context reference
+        lola install my-module --append-context module/AGENTS.md   # Single context reference
+        lola install my-module --append-context module/AGENTS.md --append-context /opt/guidelines.md  # Multiple context references
         lola install my-module -a openclaw             # Install to ~/.openclaw/workspace/skills/
         lola install my-module -a openclaw --workspace work        # Install to workspace-work
         lola install my-module -a openclaw --workspace /custom/path  # Install to custom path
@@ -930,6 +934,9 @@ def install_cmd(
     console.print(f"\n[bold]Installing {module_name} -> {display_path}[/bold]")
     console.print()
 
+    # Convert CLI tuple to list for the rest of the flow
+    append_context_list = list(append_context) if append_context else None
+
     total_installed = 0
     for asst in assistants_to_install:
         total_installed += install_to_assistant(
@@ -943,7 +950,7 @@ def install_cmd(
             force,
             effective_pre_install,
             effective_post_install,
-            append_context,
+            append_context_list,
         )
 
     # Update installation records with version from marketplace metadata
@@ -1435,7 +1442,8 @@ def list_installed_cmd(assistant: Optional[str]):
 
             for inst in scope_insts:
                 if inst.append_context:
+                    ctx_str = ", ".join(inst.append_context)
                     console.print(
-                        f"    [dim]append-context ({inst.assistant}):[/dim] {inst.append_context}"
+                        f"    [dim]append-context ({inst.assistant}):[/dim] {ctx_str}"
                     )
         console.print()

--- a/src/lola/models.py
+++ b/src/lola/models.py
@@ -8,9 +8,8 @@ import json
 import os
 from pathlib import Path
 import tempfile
-from typing import Optional
-import yaml
 import re
+import yaml
 
 from lola.config import MCPS_FILE, SKILL_FILE
 from lola import frontmatter as fm
@@ -32,7 +31,7 @@ class Skill:
 
     name: str
     path: Path
-    description: Optional[str] = None
+    description: str | None = None
 
     @classmethod
     def from_path(cls, skill_path: Path) -> "Skill":
@@ -52,8 +51,8 @@ class Command:
 
     name: str
     path: Path
-    description: Optional[str] = None
-    argument_hint: Optional[str] = None
+    description: str | None = None
+    argument_hint: str | None = None
 
     @classmethod
     def from_path(cls, command_path: Path) -> "Command":
@@ -83,8 +82,8 @@ class Agent:
 
     name: str
     path: Path
-    description: Optional[str] = None
-    model: Optional[str] = None
+    description: str | None = None
+    model: str | None = None
 
     @classmethod
     def from_path(cls, agent_path: Path) -> "Agent":
@@ -149,17 +148,17 @@ class Module:
     is_single_skill: bool = (
         False  # True if SKILL.md at content_path root (agentskills.io standard)
     )
-    pre_install_hook: Optional[str] = (
+    pre_install_hook: str | None = (
         None  # Path to pre-install script (relative to content_path)
     )
-    post_install_hook: Optional[str] = (
+    post_install_hook: str | None = (
         None  # Path to post-install script (relative to content_path)
     )
 
     @classmethod
     def from_path(
-        cls, module_path: Path, content_dirname: Optional[str] = None
-    ) -> Optional["Module"]:
+        cls, module_path: Path, content_dirname: str | None = None
+    ) -> "Module | None":
         """
         Load a module from its directory path.
 
@@ -282,8 +281,8 @@ class Module:
 
     @classmethod
     def _resolve_content_path(
-        cls, module_path: Path, content_dirname: Optional[str]
-    ) -> tuple[Optional[Path], bool]:
+        cls, module_path: Path, content_dirname: str | None
+    ) -> tuple[Path | None, bool]:
         """
         Resolve content path from module path and optional content dirname.
 
@@ -755,14 +754,24 @@ class Installation:
     module_name: str
     assistant: str
     scope: str
-    project_path: Optional[str] = None
-    version: Optional[str] = None
+    project_path: str | None = None
+    version: str | None = None
     skills: list[str] = field(default_factory=list)
     commands: list[str] = field(default_factory=list)
     agents: list[str] = field(default_factory=list)
     mcps: list[str] = field(default_factory=list)
     has_instructions: bool = False
-    append_context: Optional[list[str]] = None
+    append_context: list[str] | None = None
+
+    def __post_init__(self) -> None:
+        """Validate append_context items are strings."""
+        if self.append_context is not None:
+            for item in self.append_context:
+                if not isinstance(item, str):
+                    raise TypeError(
+                        f"append_context items must be str, "
+                        f"got {type(item).__name__}: {item!r}"
+                    )
 
     def to_dict(self) -> dict:
         """Convert to dictionary for YAML serialization."""
@@ -793,7 +802,7 @@ class Installation:
         """
         raw = data.get("append_context")
         if raw is None:
-            append_context: Optional[list[str]] = None
+            append_context: list[str] | None = None
         elif isinstance(raw, list):
             append_context = raw
         else:

--- a/src/lola/models.py
+++ b/src/lola/models.py
@@ -762,7 +762,7 @@ class Installation:
     agents: list[str] = field(default_factory=list)
     mcps: list[str] = field(default_factory=list)
     has_instructions: bool = False
-    append_context: Optional[str] = None
+    append_context: Optional[list[str]] = None
 
     def to_dict(self) -> dict:
         """Convert to dictionary for YAML serialization."""
@@ -786,7 +786,20 @@ class Installation:
 
     @classmethod
     def from_dict(cls, data: dict) -> "Installation":
-        """Create from dictionary."""
+        """Create from dictionary.
+
+        Handles backward compatibility: old format had a single string,
+        new format is a list of strings.
+        """
+        raw = data.get("append_context")
+        if raw is None:
+            append_context: Optional[list[str]] = None
+        elif isinstance(raw, list):
+            append_context = raw
+        else:
+            # Old format: single string → wrap in list
+            append_context = [raw]
+
         return cls(
             module_name=data.get("module", ""),
             assistant=data.get("assistant", ""),
@@ -798,7 +811,7 @@ class Installation:
             agents=data.get("agents", []),
             mcps=data.get("mcps", []),
             has_instructions=data.get("has_instructions", False),
-            append_context=data.get("append_context"),
+            append_context=append_context,
         )
 
 

--- a/src/lola/targets/base.py
+++ b/src/lola/targets/base.py
@@ -25,8 +25,14 @@ import yaml
 import lola.frontmatter as fm
 
 
-def _resolve_source_content(source: Path | str) -> str | None:
-    """Resolve source to string content. Returns None if Path doesn't exist."""
+def _resolve_source_content(source: Path | str | list[str]) -> str | None:
+    """Resolve source to string content. Returns None if Path doesn't exist.
+
+    Accepts a Path (read file), a str (use directly), or a list[str] (join as lines).
+    """
+    if isinstance(source, list):
+        joined = "\n".join(source)
+        return joined.strip() if joined else None
     if isinstance(source, Path):
         if not source.exists():
             return None
@@ -130,14 +136,15 @@ class AssistantTarget(ABC):
     @abstractmethod
     def generate_instructions(
         self,
-        source: Path | str,
+        source: Path | str | list[str],
         dest_path: Path,
         module_name: str,
     ) -> bool:
         """Generate/update module instructions in the assistant's instruction file.
 
         Args:
-            source: Path to read content from, or string content directly.
+            source: Path to read content from, string content directly,
+                    or list[str] of reference lines (for --append-context).
         """
         ...
 
@@ -278,7 +285,7 @@ class BaseAssistantTarget(AssistantTarget):
 
     def generate_instructions(
         self,
-        source: Path | str,  # noqa: ARG002
+        source: Path | str | list[str],  # noqa: ARG002
         dest_path: Path,  # noqa: ARG002
         module_name: str,  # noqa: ARG002
     ) -> bool:
@@ -585,7 +592,7 @@ class ManagedInstructionsTarget:
 
     def generate_instructions(
         self,
-        source: Path | str,
+        source: Path | str | list[str],
         dest_path: Path,
         module_name: str,
     ) -> bool:

--- a/src/lola/targets/cursor.py
+++ b/src/lola/targets/cursor.py
@@ -119,7 +119,7 @@ class CursorTarget(MCPSupportMixin, BaseAssistantTarget):
 
     def generate_instructions(
         self,
-        source: Path | str,
+        source: Path | str | list[str],
         dest_path: Path,
         module_name: str,
     ) -> bool:

--- a/src/lola/targets/install.py
+++ b/src/lola/targets/install.py
@@ -430,7 +430,7 @@ def _install_instructions(
     module: Module,
     local_module_path: Path,
     project_path: str | None,
-    append_context: str | None = None,
+    append_context: list[str] | None = None,
     scope: str = "project",
 ) -> bool:
     """Install module instructions for a target. Returns True if installed."""
@@ -445,22 +445,55 @@ def _install_instructions(
     # Type checker: at this point project_path is guaranteed to be a string
     instructions_dest = target.get_instructions_path(cast(str, project_path), scope)
 
-    # --append-context: insert a reference instead of verbatim copy
+    # --append-context: insert references instead of verbatim copy
     if append_context:
-        context_file = local_module_path / append_context
-        if not context_file.exists():
-            console.print(f"  [red]Context file not found: {append_context}[/red]")
+        project_root = Path(cast(str, project_path)).resolve()
+        references: list[str] = []
+        missing_files: list[str] = []
+        seen_paths: set[str] = set()
+
+        for ctx_path in append_context:
+            stripped = ctx_path.strip()
+            if not stripped:
+                continue
+
+            # Determine the actual file path
+            if Path(stripped).is_absolute():
+                context_file = Path(stripped)
+            else:
+                context_file = local_module_path / stripped
+
+            if not context_file.exists():
+                missing_files.append(stripped)
+                continue
+
+            # Compute path for reference
+            try:
+                relative_path = context_file.resolve().relative_to(project_root)
+            except ValueError:
+                relative_path = context_file.resolve()
+
+            ref_text = f"Read the module context from `{relative_path}`"
+
+            # Deduplicate
+            if ref_text not in seen_paths:
+                seen_paths.add(ref_text)
+                references.append(ref_text)
+
+        if missing_files:
+            for mf in missing_files:
+                console.print(f"  [red]Context file not found: {mf}[/red]")
             return False
 
-        try:
-            relative_path = context_file.resolve().relative_to(
-                Path(cast(str, project_path)).resolve()
+        if references:
+            return target.generate_instructions(
+                references, instructions_dest, module.name
             )
-        except ValueError:
-            relative_path = context_file.resolve()
 
-        reference = f"Read the module context from `{relative_path}`"
-        return target.generate_instructions(reference, instructions_dest, module.name)
+        # All were empty strings
+        return target.generate_instructions(
+            [], instructions_dest, module.name
+        )
 
     # Default: verbatim copy of AGENTS.md
     if not module.has_instructions:
@@ -600,7 +633,7 @@ def install_to_assistant(
     force: bool = False,
     pre_install_script: Optional[str] = None,
     post_install_script: Optional[str] = None,
-    append_context: Optional[str] = None,
+    append_context: Optional[list[str]] = None,
 ) -> int:
     """Install module to a specific assistant."""
     # Late import to avoid circular imports - get_target is defined in __init__.py

--- a/src/lola/targets/install.py
+++ b/src/lola/targets/install.py
@@ -495,9 +495,7 @@ def _install_instructions(
             )
 
         # All were empty strings
-        return target.generate_instructions(
-            [], instructions_dest, module.name
-        )
+        return target.generate_instructions([], instructions_dest, module.name)
 
     # Default: verbatim copy of AGENTS.md
     if not module.has_instructions:

--- a/src/lola/targets/install.py
+++ b/src/lola/targets/install.py
@@ -447,7 +447,7 @@ def _install_instructions(
 
     # --append-context: insert references instead of verbatim copy
     if append_context:
-        project_root = Path(cast(str, project_path)).resolve()
+        project_root = Path(cast(str, project_path)).resolve() if project_path else None
         references: list[str] = []
         missing_files: list[str] = []
         seen_paths: set[str] = set()
@@ -468,10 +468,14 @@ def _install_instructions(
                 continue
 
             # Compute path for reference
-            try:
-                relative_path = context_file.resolve().relative_to(project_root)
-            except ValueError:
-                relative_path = context_file.resolve()
+            resolved = context_file.resolve()
+            if project_root is not None:
+                try:
+                    relative_path = resolved.relative_to(project_root)
+                except ValueError:
+                    relative_path = resolved
+            else:
+                relative_path = resolved
 
             ref_text = f"Read the module context from `{relative_path}`"
 

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -270,7 +270,9 @@ class TestAppendContextDedup:
         context_dir.mkdir(parents=True)
         (context_dir / "AGENTS.md").write_text("# Module Instructions")
         (module_dir / "skills" / "skill1").mkdir(parents=True)
-        (module_dir / "skills" / "skill1" / "SKILL.md").write_text("---\ndescription: Test\n---\nContent")
+        (module_dir / "skills" / "skill1" / "SKILL.md").write_text(
+            "---\ndescription: Test\n---\nContent"
+        )
 
         project_dir = tmp_path / "project"
         project_dir.mkdir()
@@ -287,7 +289,10 @@ class TestAppendContextDedup:
             scope="project",
             project_path=str(project_dir),
             has_instructions=True,
-            append_context=[str(context_dir / "AGENTS.md"), str(context_dir / "AGENTS.md")],
+            append_context=[
+                str(context_dir / "AGENTS.md"),
+                str(context_dir / "AGENTS.md"),
+            ],
         )
         registry.add(inst)
 
@@ -302,7 +307,9 @@ class TestAppendContextDedup:
             patch("lola.cli.install.MODULES_DIR", modules_dir),
             patch("lola.cli.install.ensure_lola_dirs"),
             patch("lola.cli.install.get_registry", return_value=registry),
-            patch("lola.cli.install.get_local_modules_path", return_value=local_modules),
+            patch(
+                "lola.cli.install.get_local_modules_path", return_value=local_modules
+            ),
             patch("lola.cli.install.get_target", return_value=real_target),
         ):
             result = runner.invoke(update_cmd, ["dedup-test"])

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -136,10 +136,22 @@ class TestInstallationHasInstructions:
             assistant="claude-code",
             scope="project",
             project_path="/test",
-            append_context="module/AGENTS.md",
+            append_context=["module/AGENTS.md"],
         )
         data = inst.to_dict()
-        assert data["append_context"] == "module/AGENTS.md"
+        assert data["append_context"] == ["module/AGENTS.md"]
+
+    def test_to_dict_includes_multiple_append_context(self):
+        """Installation.to_dict() includes multiple append_context values."""
+        inst = Installation(
+            module_name="test",
+            assistant="claude-code",
+            scope="project",
+            project_path="/test",
+            append_context=["module/AGENTS.md", "/abs/path/GUIDE.md"],
+        )
+        data = inst.to_dict()
+        assert data["append_context"] == ["module/AGENTS.md", "/abs/path/GUIDE.md"]
 
     def test_to_dict_omits_append_context_when_none(self):
         """Installation.to_dict() omits append_context when not set."""
@@ -153,7 +165,29 @@ class TestInstallationHasInstructions:
         assert "append_context" not in data
 
     def test_from_dict_reads_append_context(self):
-        """Installation.from_dict() reads append_context."""
+        """Installation.from_dict() reads append_context as list."""
+        data = {
+            "module": "test",
+            "assistant": "claude-code",
+            "scope": "project",
+            "append_context": ["module/AGENTS.md"],
+        }
+        inst = Installation.from_dict(data)
+        assert inst.append_context == ["module/AGENTS.md"]
+
+    def test_from_dict_reads_multiple_append_context(self):
+        """Installation.from_dict() reads multiple append_context values."""
+        data = {
+            "module": "test",
+            "assistant": "claude-code",
+            "scope": "project",
+            "append_context": ["module/AGENTS.md", "/abs/path/GUIDE.md"],
+        }
+        inst = Installation.from_dict(data)
+        assert inst.append_context == ["module/AGENTS.md", "/abs/path/GUIDE.md"]
+
+    def test_from_dict_backward_compat_string(self):
+        """Installation.from_dict() converts old single-string append_context to list."""
         data = {
             "module": "test",
             "assistant": "claude-code",
@@ -161,7 +195,7 @@ class TestInstallationHasInstructions:
             "append_context": "module/AGENTS.md",
         }
         inst = Installation.from_dict(data)
-        assert inst.append_context == "module/AGENTS.md"
+        assert inst.append_context == ["module/AGENTS.md"]
 
     def test_from_dict_defaults_append_context_to_none(self):
         """Installation.from_dict() defaults append_context to None."""
@@ -748,7 +782,7 @@ class TestUpdateWithInstructions:
             scope="project",
             project_path=str(project_dir),
             has_instructions=True,
-            append_context="module/AGENTS.md",
+            append_context=["module/AGENTS.md"],
         )
         registry.add(inst)
 
@@ -790,6 +824,79 @@ class TestUpdateWithInstructions:
         assert "Read the module context from" in content
         assert "module/AGENTS.md" in content
         assert "Read context/foo.md" not in content
+
+    def test_update_preserves_multiple_append_context(self, tmp_path):
+        """Update respects multiple append_context values from installation record."""
+        from lola.cli.install import update_cmd
+
+        modules_dir = tmp_path / ".lola" / "modules"
+        modules_dir.mkdir(parents=True)
+        installed_file = tmp_path / ".lola" / "installed.yml"
+
+        # Create module with context file
+        module_dir = modules_dir / "test-module"
+        context_dir = module_dir / "module"
+        context_dir.mkdir(parents=True)
+        (context_dir / "AGENTS.md").write_text("# Context")
+
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+
+        # External context file (absolute path test)
+        ext_file = project_dir / "external-AGENTS.md"
+        ext_file.write_text("# External Context")
+
+        # Create registry with multiple append_context values
+        registry = InstallationRegistry(installed_file)
+        inst = Installation(
+            module_name="test-module",
+            assistant="claude-code",
+            scope="project",
+            project_path=str(project_dir),
+            has_instructions=True,
+            append_context=["module/AGENTS.md", str(ext_file)],
+        )
+        registry.add(inst)
+
+        # Create local module copy
+        local_modules = project_dir / ".lola" / "modules"
+        local_modules.mkdir(parents=True)
+        shutil.copytree(module_dir, local_modules / "test-module")
+
+        # Use real ClaudeCodeTarget for instructions
+        real_target = ClaudeCodeTarget()
+        mock_target = MagicMock()
+        mock_target.uses_managed_section = False
+        mock_target.supports_agents = True
+        mock_target.get_skill_path.return_value = project_dir / ".claude" / "skills"
+        mock_target.get_command_path.return_value = project_dir / ".claude" / "commands"
+        mock_target.get_agent_path.return_value = None
+        mock_target.get_mcp_path.return_value = None
+        mock_target.get_instructions_path = real_target.get_instructions_path
+        mock_target.generate_instructions = real_target.generate_instructions
+        mock_target.remove_instructions = real_target.remove_instructions
+
+        runner = CliRunner()
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry", return_value=registry),
+            patch(
+                "lola.cli.install.get_local_modules_path", return_value=local_modules
+            ),
+            patch("lola.cli.install.get_target", return_value=mock_target),
+        ):
+            result = runner.invoke(update_cmd, ["test-module"])
+
+        assert result.exit_code == 0
+
+        # Verify CLAUDE.md has references for both contexts
+        claude_md = project_dir / "CLAUDE.md"
+        content = claude_md.read_text()
+        assert "Read the module context from" in content
+        # Both contexts should be present
+        assert "module/AGENTS.md" in content
+        assert "external-AGENTS.md" in content
 
 
 # =============================================================================
@@ -1030,7 +1137,7 @@ class TestAppendContext:
             module,
             local_module,
             str(project_dir),
-            append_context="module/AGENTS.md",
+            append_context=["module/AGENTS.md"],
         )
 
         assert result is True
@@ -1058,7 +1165,7 @@ class TestAppendContext:
             module,
             module_dir,
             str(tmp_path),
-            append_context="nonexistent/FILE.md",
+            append_context=["nonexistent/FILE.md"],
         )
 
         assert result is False
@@ -1092,7 +1199,7 @@ class TestAppendContext:
             module,
             local_module,
             str(project_dir),
-            append_context="module/AGENTS.md",
+            append_context=["module/AGENTS.md"],
         )
 
         assert result is True
@@ -1151,7 +1258,7 @@ class TestListWithAppendContext:
                 scope="project",
                 project_path=str(tmp_path),
                 has_instructions=True,
-                append_context="module/AGENTS.md",
+                append_context=["module/AGENTS.md"],
             )
         )
 

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -234,9 +234,88 @@ class TestResolveSourceContent:
         """Empty string returns empty string."""
         assert _resolve_source_content("   ") == ""
 
+    def test_resolves_list(self):
+        """List source joins items with newlines, strips, returns None if empty."""
+        result = _resolve_source_content(["line1", "  line2  ", "line3"])
+        assert result == "line1\n  line2  \nline3"
+
+    def test_resolves_empty_list_returns_none(self):
+        """Empty list returns None."""
+        assert _resolve_source_content([]) is None
+
+    def test_resolves_list_with_empty_items(self):
+        """List of empty strings returns empty string (not None — joined is empty)."""
+        assert _resolve_source_content(["", "  ", ""]) == ""
+
 
 # =============================================================================
-# Claude Code Target Tests
+# Dedup regression test
+# =============================================================================
+
+
+class TestAppendContextDedup:
+    """Regression test: duplicate append_context entries must be deduplicated."""
+
+    def test_dedup_identical_context_paths(self, tmp_path):
+        """Two identical --append-context paths produce one reference in CLAUDE.md."""
+        from lola.cli.install import update_cmd
+        from lola.models import Installation, InstallationRegistry
+        from unittest.mock import patch, MagicMock
+
+        # Setup
+        modules_dir = tmp_path / "modules"
+        modules_dir.mkdir()
+        module_dir = modules_dir / "dedup-test"
+        context_dir = module_dir / "module"
+        context_dir.mkdir(parents=True)
+        (context_dir / "AGENTS.md").write_text("# Module Instructions")
+        (module_dir / "skills" / "skill1").mkdir(parents=True)
+        (module_dir / "skills" / "skill1" / "SKILL.md").write_text("---\ndescription: Test\n---\nContent")
+
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        local_modules = project_dir / ".lola" / "modules"
+        local_modules.mkdir(parents=True)
+        shutil.copytree(module_dir, local_modules / "dedup-test")
+
+        installed_file = project_dir / "installed.yml"
+        registry = InstallationRegistry(installed_file)
+        # Same context path passed TWICE
+        inst = Installation(
+            module_name="dedup-test",
+            assistant="claude-code",
+            scope="project",
+            project_path=str(project_dir),
+            has_instructions=True,
+            append_context=[str(context_dir / "AGENTS.md"), str(context_dir / "AGENTS.md")],
+        )
+        registry.add(inst)
+
+        runner = CliRunner()
+        real_target = MagicMock(spec=ClaudeCodeTarget)
+        real_target.uses_managed_section = False
+        real_target.supports_agents = True
+        real_target.get_instructions_path = ClaudeCodeTarget().get_instructions_path
+        real_target.generate_instructions = ClaudeCodeTarget().generate_instructions
+        real_target.remove_instructions = ClaudeCodeTarget().remove_instructions
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry", return_value=registry),
+            patch("lola.cli.install.get_local_modules_path", return_value=local_modules),
+            patch("lola.cli.install.get_target", return_value=real_target),
+        ):
+            result = runner.invoke(update_cmd, ["dedup-test"])
+
+        assert result.exit_code == 0
+        claude_md = project_dir / "CLAUDE.md"
+        content = claude_md.read_text()
+        # The reference should appear exactly ONCE, not twice
+        count = content.count("Read the module context from")
+        assert count == 1, f"Expected 1 reference, found {count}: {content}"
+
+
+# =============================================================================
 # =============================================================================
 
 
@@ -894,7 +973,8 @@ class TestUpdateWithInstructions:
         claude_md = project_dir / "CLAUDE.md"
         content = claude_md.read_text()
         assert "Read the module context from" in content
-        # Both contexts should be present
+        # Both contexts should be present — with fix #1, absolute paths
+        # inside project_root resolve to relative paths
         assert "module/AGENTS.md" in content
         assert "external-AGENTS.md" in content
 

--- a/tests/test_targets_base.py
+++ b/tests/test_targets_base.py
@@ -48,7 +48,7 @@ class MockTarget(AssistantTarget):
         return True
 
     def generate_instructions(
-        self, source: Path | str, dest_path: Path, module_name: str
+        self, source: Path | str | list[str], dest_path: Path, module_name: str
     ) -> bool:
         return True
 


### PR DESCRIPTION
## Changes

- `--append-context` becomes repeatable (Click `multiple=True`)
- `Installation.append_context`: `str` → `list[str]`
- `_install_instructions()`: handles list, deduplicates, supports absolute paths
- Backward compat: `from_dict()` converts old string format to list
- Updated all `generate_instructions()` signatures to accept `list[str]`
- List command display shows multiple contexts comma-separated
- Updated CLI help with multiple --append-context example
- Tests: 21/21 passed

## Usage

```bash
lola install my-mod \
  --append-context module/AGENTS.md \
  --append-context /opt/company/GUIDELINES.md \
  --append-context /home/user/projects/repo-a/AGENTS.md


Result in CLAUDE.md:markdown
<!-- lola:module:my-mod:start -->
Read the module context from `.lola/modules/my-mod/module/AGENTS.md`
Read the module context from `/opt/company/GUIDELINES.md`
Read the module context from `/home/user/projects/repo-a/AGENTS.md`
<!-- lola:module:my-mod:end -->
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `lola install` now supports multiple `--append-context` values.
  * Installation context can now include several referenced files, and list views show them clearly.

* **Bug Fixes**
  * Duplicate context references are now removed automatically.
  * Missing context files are reported more consistently.
  * Existing installation records continue to work with older single-value context data.

* **Documentation**
  * Updated CLI help and examples to show single and multiple context entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->