### PR TITLE
fix(make): ensure Python is installed via uv

### DIFF
--- a/mk/dev.mk
+++ b/mk/dev.mk
@@ -12,6 +12,8 @@ export UV_MANAGED_PYTHON := 1
 .PHONY: install uninstall test lint clean distclean run
 
 install: ## - install project + dev dependencies into local .venv (creates/updates .venv as needed)
+	@echo "Ensuring Minimal Python version is available..."
+	@uv python install '>=3.13'
 	@echo "Syncing dev environment into $(UV_PROJECT_ENVIRONMENT)..."
 	@uv sync --group dev
 	@uv tool install --force --editable .


### PR DESCRIPTION
## Summary

- Adds `uv python install '>=3.13'` as the first step of `make install` so that uv-managed Python is guaranteed to be available before `uv sync` runs

## Related Issues

Fixes #192

## Test Plan

- [x] Run `make install` on a system without Python 3.13 pre-installed — should succeed
- [x] Run `make install` on a system with Python 3.13 already managed by uv — no-op for that step, rest proceeds normally

## Checklist

- [x] Tests pass (`pytest`) — 1034 passed
- [x] Linting passes (`ruff check src tests`) — all checks passed
- [x] Type checking passes (`ty check`) — 42 pre-existing diagnostics, none introduced by this change

## AI Disclosure

AI-assisted with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development install flow to ensure a compatible Python version is available before setting up the environment.
  * Added a brief status message during installation for clearer progress feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->