### PR TITLE
feat: complete ref pinning support for modules and marketplaces

### DIFF
--- a/docs/cli-reference/index.md
+++ b/docs/cli-reference/index.md
@@ -19,9 +19,8 @@ Complete command reference for the Lola CLI. Use `lola --help` or `lola <command
 | Command                                      | Description                                   |
 | -------------------------------------------- | --------------------------------------------- |
 | `lola market add <name> <url>`               | Register a marketplace                        |
-| `lola market add <name> <url> --ref <ref>`   | Register at a specific git branch, tag, or SHA |
 | `lola market ls`                             | List registered marketplaces                  |
-| `lola market update [name]`                  | Update marketplace cache (replays pinned ref) |
+| `lola market update [name]`                  | Update marketplace cache                      |
 | `lola market set --enable <name>`            | Enable a marketplace                          |
 | `lola market set --disable <name>`           | Disable a marketplace                         |
 | `lola market rm <name>`                      | Remove a marketplace                          |

--- a/docs/cli-reference/index.md
+++ b/docs/cli-reference/index.md
@@ -4,25 +4,27 @@ Complete command reference for the Lola CLI. Use `lola --help` or `lola <command
 
 ## Module Management (`lola mod`)
 
-| Command                   | Description                                    |
-| ------------------------- | ---------------------------------------------- |
-| `lola mod add <source>`   | Add a module from git, folder, zip, or tar     |
-| `lola mod ls`             | List registered modules                        |
-| `lola mod info <name>`    | Show module details                            |
-| `lola mod init [name]`    | Initialize a new module                        |
-| `lola mod update [name]`  | Update module(s) from source                   |
-| `lola mod rm <name>`      | Remove a module                                |
+| Command                                              | Description                                    |
+| ---------------------------------------------------- | ---------------------------------------------- |
+| `lola mod add <source>`                              | Add a module from git, folder, zip, or tar     |
+| `lola mod add <source> --ref <ref>`                  | Add from a specific git branch, tag, or SHA    |
+| `lola mod ls`                                        | List registered modules                        |
+| `lola mod info <name>`                               | Show module details                            |
+| `lola mod init [name]`                               | Initialize a new module                        |
+| `lola mod update [name]`                             | Update module(s) from source                   |
+| `lola mod rm <name>`                                 | Remove a module                                |
 
 ## Marketplace Management (`lola market`)
 
-| Command                            | Description                                   |
-| ---------------------------------- | --------------------------------------------- |
-| `lola market add <name> <url>`     | Register a marketplace                        |
-| `lola market ls`                   | List registered marketplaces                  |
-| `lola market update [name]`        | Update marketplace cache                      |
-| `lola market set --enable <name>`  | Enable a marketplace                          |
-| `lola market set --disable <name>` | Disable a marketplace                         |
-| `lola market rm <name>`            | Remove a marketplace                          |
+| Command                                      | Description                                   |
+| -------------------------------------------- | --------------------------------------------- |
+| `lola market add <name> <url>`               | Register a marketplace                        |
+| `lola market add <name> <url> --ref <ref>`   | Register at a specific git branch, tag, or SHA |
+| `lola market ls`                             | List registered marketplaces                  |
+| `lola market update [name]`                  | Update marketplace cache (replays pinned ref) |
+| `lola market set --enable <name>`            | Enable a marketplace                          |
+| `lola market set --disable <name>`           | Disable a marketplace                         |
+| `lola market rm <name>`                      | Remove a marketplace                          |
 
 ## Search
 
@@ -35,12 +37,15 @@ Complete command reference for the Lola CLI. Use `lola --help` or `lola <command
 
 ## Installation
 
-| Command                                | Description                                   |
-| -------------------------------------- | --------------------------------------------- |
-| `lola install <module>`                | Install to all detected assistants             |
-| `lola install <module> -a <assistant>` | Install to specific assistant                 |
-| `lola install <module> --append-context <path>` | Append context reference                          |
-| `lola uninstall <module>`              | Uninstall module                              |
-| `lola list`                            | List all installations                        |
-| `lola update`                          | Regenerate assistant files                    |
-| `lola sync`                            | Install modules from `.lola-req`              |
+| Command                                             | Description                                   |
+| --------------------------------------------------- | --------------------------------------------- |
+| `lola install <module>`                             | Install to all detected assistants             |
+| `lola install <module> -a <assistant>`              | Install to specific assistant                 |
+| `lola install <module>@<ref>`                       | Install at a specific git ref                 |
+| `lola install @<marketplace>/<module>`              | Install from a specific marketplace           |
+| `lola install @<marketplace>/<module>@<ref>`        | Install from a marketplace at a specific ref  |
+| `lola install <module> --append-context <path>`     | Append context reference                      |
+| `lola uninstall <module>`                           | Uninstall module                              |
+| `lola list`                                         | List all installations                        |
+| `lola update`                                       | Regenerate assistant files                    |
+| `lola sync`                                         | Install modules from `.lola-req`              |

--- a/docs/cli-reference/index.md
+++ b/docs/cli-reference/index.md
@@ -45,6 +45,6 @@ Complete command reference for the Lola CLI. Use `lola --help` or `lola <command
 | `lola install @<marketplace>/<module>@<ref>`        | Install from a marketplace at a specific ref  |
 | `lola install <module> --append-context <path>`     | Append context reference                      |
 | `lola uninstall <module>`                           | Uninstall module                              |
-| `lola list`                                         | List all installations                        |
+| `lola list`                                         | List all installations (shows version and ref when set) |
 | `lola update`                                       | Regenerate assistant files                    |
 | `lola sync`                                         | Install modules from `.lola-req`              |

--- a/docs/guides/marketplace.md
+++ b/docs/guides/marketplace.md
@@ -32,6 +32,17 @@ lola install @my-marketplace/git-workflow@v1.0.0 -a claude-code
 
 When a module exists in multiple marketplaces, Lola prompts you to select which one to use. The prompt shows each entry's pinned ref so you can make an informed choice.
 
+Search results show a `Ref` column when any result has a pinned ref. After installing, `lola list` displays the resolved version and ref alongside each module:
+
+```
+git-workflow
+  - scope: project
+    path: "/path/to/project"
+    assistants: [claude-code]
+    version: 2.0.0
+    ref: v2.0.0
+```
+
 ## Manage Marketplaces
 
 ```bash

--- a/docs/guides/marketplace.md
+++ b/docs/guides/marketplace.md
@@ -34,7 +34,7 @@ When a module exists in multiple marketplaces, Lola prompts you to select which 
 
 Search results show a `Ref` column when any result has a pinned ref. After installing, `lola list` displays the resolved version and ref alongside each module:
 
-```
+```text
 git-workflow
   - scope: project
     path: "/path/to/project"

--- a/docs/guides/marketplace.md
+++ b/docs/guides/marketplace.md
@@ -10,6 +10,21 @@ We maintain an official, community-driven marketplace at [github.com/RedHatProdu
 lola market add general https://raw.githubusercontent.com/RedHatProductSecurity/lola-market/main/general-market.yml
 ```
 
+For git-hosted catalogs, you can also pin to a specific branch, tag, or commit SHA:
+
+```bash
+# Pin to a release tag
+lola market add general https://github.com/RedHatProductSecurity/lola-market.git --ref v1.0.0
+
+# Pin to a commit SHA for maximum reproducibility
+lola market add general https://github.com/RedHatProductSecurity/lola-market.git --ref abc1234
+
+# git+https:// and git+ssh:// URLs also supported
+lola market add internal git+https://gitlab.internal/org/market.git --ref stable
+```
+
+`lola market update` replays the pinned ref automatically — no need to re-specify it.
+
 ## Search and Install
 
 ```bash
@@ -21,9 +36,15 @@ lola search authentication --market
 
 # Install directly from marketplace (auto-adds and installs)
 lola install git-workflow -a claude-code
+
+# Install at a specific git ref (overrides the marketplace-pinned ref)
+lola install git-workflow@v1.0.0 -a claude-code
+
+# Install from a specific marketplace at a specific ref
+lola install @my-marketplace/git-workflow@v1.0.0 -a claude-code
 ```
 
-When a module exists in multiple marketplaces, Lola prompts you to select which one to use.
+When a module exists in multiple marketplaces, Lola prompts you to select which one to use. The prompt shows each entry's pinned ref so you can make an informed choice.
 
 ## Manage Marketplaces
 
@@ -66,4 +87,59 @@ modules:
     repository: https://github.com/company/monorepo.git
     path: packages/lola-skills  # Custom content directory
     tags: [monorepo]
+```
+
+### Module Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | ✅ | Module name (used as the registry key) |
+| `description` | ✅ | Short description shown in search results |
+| `version` | ✅ | Version string (informational) |
+| `repository` | ✅ | Git URL or archive URL to fetch from |
+| `path` | — | Content subdirectory inside the repo (for monorepos) |
+| `ref` | — | Git branch, tag, or commit SHA to pin (see below) |
+| `tags` | — | List of tags for search/discovery |
+| `hooks` | — | Pre/post install scripts |
+
+### Pinning Modules to a Git Revision
+
+Use the `ref` field to pin a module to a specific Git revision for supply-chain reproducibility:
+
+```yaml
+modules:
+  # Pin to a release tag — stable, auditable
+  - name: network-tools
+    description: Network troubleshooting skills
+    version: 2.0.0
+    repository: https://github.com/partner-org/network-skills
+    ref: v2.0.0
+    tags: [networking]
+
+  # Pin to a commit SHA — maximum reproducibility
+  - name: verified-tools
+    description: Skills validated at a known commit
+    version: 1.2.0
+    repository: https://github.com/org/tools
+    ref: a1b2c3d4e5f6789012345678901234567890abcd
+    path: packs/tools
+    tags: [tools]
+
+  # Pin to a branch — tracks branch head, less stable
+  - name: dev-preview
+    description: Skills from the development branch
+    version: 0.9.0
+    repository: https://github.com/org/tools
+    ref: develop
+    path: packs/tools
+    tags: [preview]
+```
+
+`ref` accepts any valid Git reference: branch name, tag, or full/short commit SHA. When omitted, Lola fetches the repository's default branch (unchanged behavior).
+
+Users can override the marketplace-pinned ref at install time:
+
+```bash
+# Override the ref defined in the marketplace YAML
+lola install network-tools@main
 ```

--- a/docs/guides/marketplace.md
+++ b/docs/guides/marketplace.md
@@ -10,20 +10,6 @@ We maintain an official, community-driven marketplace at [github.com/RedHatProdu
 lola market add general https://raw.githubusercontent.com/RedHatProductSecurity/lola-market/main/general-market.yml
 ```
 
-For git-hosted catalogs, you can also pin to a specific branch, tag, or commit SHA:
-
-```bash
-# Pin to a release tag
-lola market add general https://github.com/RedHatProductSecurity/lola-market.git --ref v1.0.0
-
-# Pin to a commit SHA for maximum reproducibility
-lola market add general https://github.com/RedHatProductSecurity/lola-market.git --ref abc1234
-
-# git+https:// and git+ssh:// URLs also supported
-lola market add internal git+https://gitlab.internal/org/market.git --ref stable
-```
-
-`lola market update` replays the pinned ref automatically — no need to re-specify it.
 
 ## Search and Install
 

--- a/docs/guides/modules.md
+++ b/docs/guides/modules.md
@@ -38,10 +38,10 @@ paths are also excluded from the copied module.
 # List registered modules
 lola mod ls
 
-# Show module details
+# Show module details (includes pinned ref if set)
 lola mod info my-skills
 
-# Update module from source
+# Update module from source (replays the pinned ref automatically)
 lola mod update my-skills
 
 # Remove a module

--- a/docs/guides/modules.md
+++ b/docs/guides/modules.md
@@ -19,6 +19,12 @@ lola mod add https://github.com/company/monorepo.git --module-content=packages/l
 
 # From a flat repository (use root directory)
 lola mod add https://github.com/user/flat-repo.git --module-content=/
+
+# From a specific git tag or branch
+lola mod add https://github.com/user/my-skills.git --ref v1.0.0
+
+# From a specific commit SHA
+lola mod add https://github.com/user/my-skills.git --ref abc1234
 ```
 
 When adding from a local folder that is inside a git repository, Lola honors

--- a/sbom.json
+++ b/sbom.json
@@ -2,14 +2,14 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
   "version": 1,
-  "serialNumber": "urn:uuid:940705ec-8fb6-4af3-a6c2-e2641e47f3ca",
+  "serialNumber": "urn:uuid:de480c5b-5efe-46b7-862c-49e3499115fa",
   "metadata": {
-    "timestamp": "2026-06-09T16:21:20.531336162Z",
+    "timestamp": "2026-07-06T15:44:23.623095000Z",
     "tools": [
       {
         "vendor": "Astral Software Inc.",
         "name": "uv",
-        "version": "0.11.19"
+        "version": "0.10.10"
       }
     ],
     "component": {
@@ -131,7 +131,8 @@
       ]
     },
     {
-      "ref": "colorama-3@0.4.6"
+      "ref": "colorama-3@0.4.6",
+      "dependsOn": []
     },
     {
       "ref": "inquirerpy-4@0.3.4",
@@ -159,13 +160,16 @@
       ]
     },
     {
-      "ref": "mdurl-6@0.1.2"
+      "ref": "mdurl-6@0.1.2",
+      "dependsOn": []
     },
     {
-      "ref": "packaging-7@26.0"
+      "ref": "packaging-7@26.0",
+      "dependsOn": []
     },
     {
-      "ref": "pfzy-8@0.3.4"
+      "ref": "pfzy-8@0.3.4",
+      "dependsOn": []
     },
     {
       "ref": "prompt-toolkit-9@3.0.52",
@@ -174,7 +178,8 @@
       ]
     },
     {
-      "ref": "pygments-10@2.20.0"
+      "ref": "pygments-10@2.20.0",
+      "dependsOn": []
     },
     {
       "ref": "python-frontmatter-11@1.1.0",
@@ -183,7 +188,8 @@
       ]
     },
     {
-      "ref": "pyyaml-12@6.0.3"
+      "ref": "pyyaml-12@6.0.3",
+      "dependsOn": []
     },
     {
       "ref": "rich-13@14.3.3",
@@ -193,7 +199,8 @@
       ]
     },
     {
-      "ref": "wcwidth-14@0.6.0"
+      "ref": "wcwidth-14@0.6.0",
+      "dependsOn": []
     }
   ]
 }

--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -21,7 +21,7 @@ from lola.exceptions import (
     ValidationError,
 )
 from lola.models import Installation, InstallationRegistry, Module
-from lola.market.manager import parse_market_ref, MarketplaceRegistry
+from lola.market.manager import parse_market_ref, parse_ref_suffix, MarketplaceRegistry
 from lola.parsers import fetch_module_as_name, detect_source_type
 from lola.cli.mod import (
     save_source_info,
@@ -71,7 +71,7 @@ def _resolve_install_path(
 
 
 def _fetch_from_marketplace(
-    marketplace_name: str, module_name: str
+    marketplace_name: str, module_name: str, ref_override: str | None = None
 ) -> tuple[Path, dict]:
     """
     Fetch module from specified marketplace.
@@ -79,6 +79,7 @@ def _fetch_from_marketplace(
     Args:
         marketplace_name: Name of the marketplace
         module_name: Name of the module
+        ref_override: Git ref to use instead of the marketplace-defined ref
 
     Returns:
         Tuple of (module_path, module_metadata) where module_metadata
@@ -127,15 +128,18 @@ def _fetch_from_marketplace(
         console.print(f"[red]Module '{module_name}' has no repository URL[/red]")
         raise SystemExit(1)
     content_dirname = module_dict.get("path")
+    ref = ref_override if ref_override is not None else module_dict.get("ref")
     console.print(f"[green]Found '{module_name}' in '{marketplace_name}'[/green]")
     console.print(f"[dim]Repository: {repository}[/dim]")
+    if ref:
+        console.print(f"[dim]Ref: {ref}[/dim]")
 
     try:
         source_type = detect_source_type(repository)
         module_path = fetch_module_as_name(
-            repository, MODULES_DIR, module_name, content_dirname
+            repository, MODULES_DIR, module_name, content_dirname, ref
         )
-        save_source_info(module_path, repository, source_type, content_dirname)
+        save_source_info(module_path, repository, source_type, content_dirname, ref)
         console.print(f"[green]Added {module_name}[/green]")
         return module_path, module_dict
     except Exception as e:
@@ -837,15 +841,22 @@ def install_cmd(
     marketplace_hooks = {}
     module_dict: dict[str, Any] = {}
 
-    # Override with marketplace if reference provided
+    # Parse optional @ref suffix from module name (e.g. "tools@v1.0.0")
+    ref_override: str | None = None
     marketplace_ref = parse_market_ref(module_name)
     if marketplace_ref:
+        # Handle @marketplace/module@ref — ref suffix may be on the module part
         marketplace_name, current_module_name = marketplace_ref
+        current_module_name, ref_override = parse_ref_suffix(current_module_name)
         module_path, module_dict = _fetch_from_marketplace(
-            marketplace_name, current_module_name
+            marketplace_name, current_module_name, ref_override
         )
         module_name = current_module_name
         marketplace_hooks = module_dict.get("hooks", {})
+    else:
+        # Handle bare "module@ref" syntax
+        module_name, ref_override = parse_ref_suffix(module_name)
+        module_path = MODULES_DIR / module_name
 
     # If module not found locally and no marketplace specified, search marketplaces
     if not module_path.exists() and not marketplace_ref:
@@ -860,7 +871,7 @@ def install_cmd(
                 console.print("[yellow]Cancelled[/yellow]")
                 raise SystemExit(130)
             module_path, module_dict = _fetch_from_marketplace(
-                selected_marketplace, module_name
+                selected_marketplace, module_name, ref_override
             )
             marketplace_hooks = module_dict.get("hooks", {})
 
@@ -870,6 +881,9 @@ def install_cmd(
         console.print("[dim]Use 'lola mod add <source>' to add a module[/dim]")
         console.print(
             "[dim]Or install from marketplace: lola install @marketplace/module[/dim]"
+        )
+        console.print(
+            "[dim]Pin a git ref: lola install module@v1.0.0 or @marketplace/module@v1.0.0[/dim]"
         )
         handle_lola_error(ModuleNotFoundError(module_name))
 

--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -28,6 +28,7 @@ from lola.cli.mod import (
     load_registered_module,
     list_registered_modules,
 )
+from lola.parsers import load_source_info
 from lola.prompts import (
     is_interactive,
     select_assistants,
@@ -136,6 +137,11 @@ def _fetch_from_marketplace(
 
     try:
         source_type = detect_source_type(repository)
+        if ref and source_type != "git":
+            console.print(
+                f"[red]Cannot pin ref '{ref}': repository '{repository}' is not a Git source[/red]"
+            )
+            raise SystemExit(1)
         module_path = fetch_module_as_name(
             repository, MODULES_DIR, module_name, content_dirname, ref
         )
@@ -861,6 +867,33 @@ def install_cmd(
         # Handle bare "module@ref" syntax
         module_name, ref_override = parse_ref_suffix(module_name)
         module_path = MODULES_DIR / module_name
+
+        # If a ref override is requested and the module is already registered,
+        # re-fetch at the requested ref rather than silently using the old revision.
+        if ref_override and module_path.exists():
+            source_info = load_source_info(module_path)
+            if not source_info or source_info.get("type") != "git":
+                console.print(
+                    f"[red]Cannot apply @{ref_override}: '{module_name}' is not a git-sourced module[/red]"
+                )
+                raise SystemExit(1)
+            source_url = source_info.get("source", "")
+            content_dirname = source_info.get("content_dirname")
+            console.print(
+                f"[dim]Re-fetching '{module_name}' at ref '{ref_override}'...[/dim]"
+            )
+            try:
+                module_path = fetch_module_as_name(
+                    source_url, MODULES_DIR, module_name, content_dirname, ref_override
+                )
+                save_source_info(
+                    module_path, source_url, "git", content_dirname, ref_override
+                )
+            except Exception as e:
+                console.print(
+                    f"[red]Failed to re-fetch module at ref '{ref_override}': {e}[/red]"
+                )
+                raise SystemExit(1)
 
     # If module not found locally and no marketplace specified, search marketplaces
     if not module_path.exists() and not marketplace_ref:

--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -1007,8 +1007,8 @@ def install_cmd(
             ref_override if ref_override is not None else module_dict.get("ref")
         )
         if version or resolved_ref:
+            installations = registry.find(module_name)
             for asst in assistants_to_install:
-                installations = registry.find(module_name)
                 for inst in installations:
                     if (
                         inst.assistant == asst

--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -967,19 +967,26 @@ def install_cmd(
             append_context_list,
         )
 
-    # Update installation records with version from marketplace metadata
-    if module_dict and module_dict.get("version"):
-        version = module_dict.get("version")
-        for asst in assistants_to_install:
-            installations = registry.find(module_name)
-            for inst in installations:
-                if (
-                    inst.assistant == asst
-                    and inst.scope == scope
-                    and inst.project_path == install_project_path
-                ):
-                    inst.version = version
-                    registry.add(inst)  # Update the record
+    # Update installation records with version/ref from marketplace metadata
+    if module_dict:
+        version = module_dict.get("version") or None
+        resolved_ref = (
+            ref_override if ref_override is not None else module_dict.get("ref")
+        )
+        if version or resolved_ref:
+            for asst in assistants_to_install:
+                installations = registry.find(module_name)
+                for inst in installations:
+                    if (
+                        inst.assistant == asst
+                        and inst.scope == scope
+                        and inst.project_path == install_project_path
+                    ):
+                        if version:
+                            inst.version = version
+                        if resolved_ref:
+                            inst.ref = resolved_ref
+                        registry.add(inst)  # Update the record
 
     console.print()
     console.print(
@@ -1453,6 +1460,13 @@ def list_installed_cmd(assistant: Optional[str]):
             if project_path:
                 console.print(f'    [dim]path:[/dim] "{project_path}"')
             console.print(f"    [dim]assistants:[/dim] \\[{assistants_str}]")
+
+            version = next((i.version for i in scope_insts if i.version), None)
+            ref = next((i.ref for i in scope_insts if i.ref), None)
+            if version:
+                console.print(f"    [dim]version:[/dim] {version}")
+            if ref:
+                console.print(f"    [dim]ref:[/dim] {ref}")
 
             for inst in scope_insts:
                 if inst.append_context:

--- a/src/lola/cli/market.py
+++ b/src/lola/cli/market.py
@@ -30,15 +30,21 @@ def market():
 @market.command(name="add")
 @click.argument("name")
 @click.argument("url")
-def market_add(name: str, url: str):
+@click.option(
+    "--ref",
+    "git_ref",
+    default=None,
+    help="Git branch, tag, or commit SHA (git sources only)",
+)
+def market_add(name: str, url: str, git_ref: str | None):
     """
     Add a new marketplace.
 
     NAME: Marketplace name (e.g., 'official')
-    URL: Marketplace catalog URL
+    URL: Marketplace catalog URL (http/https, git+https, git+ssh, or .git URL)
     """
     registry = MarketplaceRegistry(MARKET_DIR, CACHE_DIR)
-    registry.add(name, url)
+    registry.add(name, url, git_ref)
 
 
 @market.command(name="ls")

--- a/src/lola/cli/market.py
+++ b/src/lola/cli/market.py
@@ -30,13 +30,7 @@ def market():
 @market.command(name="add")
 @click.argument("name")
 @click.argument("url")
-@click.option(
-    "--ref",
-    "git_ref",
-    default=None,
-    help="Git branch, tag, or commit SHA (git sources only)",
-)
-def market_add(name: str, url: str, git_ref: str | None):
+def market_add(name: str, url: str):
     """
     Add a new marketplace.
 
@@ -44,7 +38,7 @@ def market_add(name: str, url: str, git_ref: str | None):
     URL: Marketplace catalog URL (http/https, git+https, git+ssh, or .git URL)
     """
     registry = MarketplaceRegistry(MARKET_DIR, CACHE_DIR)
-    registry.add(name, url, git_ref)
+    registry.add(name, url)
 
 
 @market.command(name="ls")

--- a/src/lola/cli/mod.py
+++ b/src/lola/cli/mod.py
@@ -186,7 +186,10 @@ def _confirm_overwrite(source: str, module_name: str | None) -> bool:
     help="Git branch, tag, or commit SHA to fetch (git sources only)",
 )
 def add_module(
-    source: str, module_name: str, module_content_dirname: str, git_ref: str
+    source: str,
+    module_name: str | None,
+    module_content_dirname: str | None,
+    git_ref: str | None,
 ):
     """
     Add a module to the lola registry.

--- a/src/lola/cli/mod.py
+++ b/src/lola/cli/mod.py
@@ -215,6 +215,10 @@ def add_module(
     if source_type == "unknown":
         handle_lola_error(UnsupportedSourceError(source))
 
+    if git_ref and git_ref.startswith("-"):
+        console.print(f"[red]Invalid ref '{git_ref}': refs cannot start with '-'[/red]")
+        raise SystemExit(1)
+
     console.print(f"Adding module from {source_type}...")
 
     # Check if module exists and confirm overwrite

--- a/src/lola/cli/mod.py
+++ b/src/lola/cli/mod.py
@@ -179,7 +179,15 @@ def _confirm_overwrite(source: str, module_name: str | None) -> bool:
     default=None,
     help="Custom content directory path. Use '/' for root. Default: auto-discover (module/ → root)",
 )
-def add_module(source: str, module_name: str, module_content_dirname: str):
+@click.option(
+    "--ref",
+    "git_ref",
+    default=None,
+    help="Git branch, tag, or commit SHA to fetch (git sources only)",
+)
+def add_module(
+    source: str, module_name: str, module_content_dirname: str, git_ref: str
+):
     """
     Add a module to the lola registry.
 
@@ -195,6 +203,7 @@ def add_module(source: str, module_name: str, module_content_dirname: str):
     \b
     Examples:
         lola mod add https://github.com/user/my-skills.git
+        lola mod add https://github.com/user/my-skills.git --ref v1.0.0
         lola mod add https://github.com/user/repo/archive/main.zip
         lola mod add https://example.com/skills.tar.gz
         lola mod add ./my-local-module
@@ -213,9 +222,11 @@ def add_module(source: str, module_name: str, module_content_dirname: str):
         return
 
     try:
-        module_path = fetch_module(source, MODULES_DIR, module_content_dirname)
+        module_path = fetch_module(source, MODULES_DIR, module_content_dirname, git_ref)
         # Save source info for future updates
-        save_source_info(module_path, source, source_type, module_content_dirname)
+        save_source_info(
+            module_path, source, source_type, module_content_dirname, git_ref
+        )
     except LolaError as e:
         handle_lola_error(e)
     except Exception as e:

--- a/src/lola/cli/mod.py
+++ b/src/lola/cli/mod.py
@@ -1068,6 +1068,8 @@ def module_info(module_name_or_path: str | None):
         console.print("[bold]Source[/bold]")
         console.print(f"  [dim]Type:[/dim] {source_info.get('type', 'unknown')}")
         console.print(f"  [dim]Location:[/dim] {source_info.get('source', 'unknown')}")
+        if source_info.get("ref"):
+            console.print(f"  [dim]Ref:[/dim] {source_info['ref']}")
 
     # Validation status
     is_valid, errors = module.validate()

--- a/src/lola/cli/search.py
+++ b/src/lola/cli/search.py
@@ -12,6 +12,7 @@ from lola.cli.mod import count_str, list_registered_modules
 from lola.config import CACHE_DIR, MARKET_DIR
 from lola.market.search import search_market
 from lola.models import Module
+from lola.parsers import load_source_info
 
 console = Console()
 
@@ -35,18 +36,28 @@ def _print_local(results: list[Module]) -> None:
         cmds_str = count_str(len(module.commands), "command")
         agents_str = count_str(len(module.agents), "agent")
         console.print(f"    [dim]{skills_str}, {cmds_str}, {agents_str}[/dim]")
+        source_info = load_source_info(module.path)
+        if source_info and source_info.get("ref"):
+            console.print(f"    [dim]ref: {source_info['ref']}[/dim]")
     console.print()
 
 
 def _print_marketplace(results: list[dict]) -> None:
     console.print(f"[bold]Marketplaces ({count_str(len(results), 'module')})[/bold]\n")
+    show_ref = any(r.get("ref") for r in results)
     table = Table(show_header=True, header_style="bold")
     table.add_column("Module")
     table.add_column("Version")
+    if show_ref:
+        table.add_column("Ref")
     table.add_column("Marketplace")
     table.add_column("Description")
     for r in results:
-        table.add_row(r["name"], r["version"], r["marketplace"], r["description"])
+        row = [r["name"], r["version"]]
+        if show_ref:
+            row.append(r.get("ref", ""))
+        row += [r["marketplace"], r["description"]]
+        table.add_row(*row)
     console.print(table)
     console.print()
 

--- a/src/lola/cli/search.py
+++ b/src/lola/cli/search.py
@@ -6,11 +6,10 @@ Searches both the local module registry and all enabled marketplace caches.
 
 import click
 from rich.console import Console
-from rich.table import Table
 
 from lola.cli.mod import count_str, list_registered_modules
 from lola.config import CACHE_DIR, MARKET_DIR
-from lola.market.search import search_market
+from lola.market.search import build_market_table, search_market
 from lola.models import Module
 from lola.parsers import load_source_info
 
@@ -44,21 +43,7 @@ def _print_local(results: list[Module]) -> None:
 
 def _print_marketplace(results: list[dict]) -> None:
     console.print(f"[bold]Marketplaces ({count_str(len(results), 'module')})[/bold]\n")
-    show_ref = any(r.get("ref") for r in results)
-    table = Table(show_header=True, header_style="bold")
-    table.add_column("Module")
-    table.add_column("Version")
-    if show_ref:
-        table.add_column("Ref")
-    table.add_column("Marketplace")
-    table.add_column("Description")
-    for r in results:
-        row = [r["name"], r["version"]]
-        if show_ref:
-            row.append(r.get("ref", ""))
-        row += [r["marketplace"], r["description"]]
-        table.add_row(*row)
-    console.print(table)
+    console.print(build_market_table(results))
     console.print()
 
 

--- a/src/lola/market/manager.py
+++ b/src/lola/market/manager.py
@@ -287,20 +287,23 @@ class MarketplaceRegistry:
             self.console.print("[yellow]No modules in this marketplace[/yellow]")
             return
 
+        show_ref = any(m.get("ref") for m in marketplace.modules)
+
         table = Table(show_header=True, header_style="bold")
         table.add_column("Module")
         table.add_column("Version")
+        if show_ref:
+            table.add_column("Ref")
         table.add_column("Description")
         table.add_column("Tags")
 
         for module in sorted(marketplace.modules, key=lambda m: m.get("name", "")):
             tags = ", ".join(module.get("tags", []))
-            table.add_row(
-                module.get("name", ""),
-                module.get("version", ""),
-                module.get("description", ""),
-                tags,
-            )
+            row = [module.get("name", ""), module.get("version", "")]
+            if show_ref:
+                row.append(module.get("ref") or "")
+            row += [module.get("description", ""), tags]
+            table.add_row(*row)
 
         self.console.print(table)
 

--- a/src/lola/market/manager.py
+++ b/src/lola/market/manager.py
@@ -32,6 +32,14 @@ def parse_market_ref(module_name: str) -> tuple[str, str] | None:
     return None
 
 
+def parse_ref_suffix(name: str) -> tuple[str, str | None]:
+    """Split 'module@ref' into ('module', 'ref'), or ('module', None) if no @."""
+    if "@" in name:
+        module, ref = name.rsplit("@", 1)
+        return module, ref or None
+    return name, None
+
+
 def validate_marketplace_name(name: str) -> str:
     """Validate marketplace name to ensure it's a valid filesystem name.
 
@@ -65,7 +73,7 @@ class MarketplaceRegistry:
         self.market_dir.mkdir(parents=True, exist_ok=True)
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
-    def add(self, name: str, url: str) -> None:
+    def add(self, name: str, url: str, ref: str | None = None) -> None:
         """Add a new marketplace."""
         try:
             name = validate_marketplace_name(name)
@@ -80,7 +88,7 @@ class MarketplaceRegistry:
             return
 
         try:
-            marketplace = Marketplace.from_url(url, name)
+            marketplace = Marketplace.from_url(url, name, ref)
             is_valid, errors = marketplace.validate()
 
             if not is_valid:
@@ -348,7 +356,9 @@ class MarketplaceRegistry:
         marketplace_ref = Marketplace.from_reference(ref_file)
 
         try:
-            marketplace = Marketplace.from_url(marketplace_ref.url, name)
+            marketplace = Marketplace.from_url(
+                marketplace_ref.url, name, marketplace_ref.ref
+            )
             is_valid, errors = marketplace.validate()
 
             if not is_valid:

--- a/src/lola/market/manager.py
+++ b/src/lola/market/manager.py
@@ -73,7 +73,7 @@ class MarketplaceRegistry:
         self.market_dir.mkdir(parents=True, exist_ok=True)
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
-    def add(self, name: str, url: str, ref: str | None = None) -> None:
+    def add(self, name: str, url: str) -> None:
         """Add a new marketplace."""
         try:
             name = validate_marketplace_name(name)
@@ -88,7 +88,7 @@ class MarketplaceRegistry:
             return
 
         try:
-            marketplace = Marketplace.from_url(url, name, ref)
+            marketplace = Marketplace.from_url(url, name)
             is_valid, errors = marketplace.validate()
 
             if not is_valid:
@@ -356,9 +356,7 @@ class MarketplaceRegistry:
         marketplace_ref = Marketplace.from_reference(ref_file)
 
         try:
-            marketplace = Marketplace.from_url(
-                marketplace_ref.url, name, marketplace_ref.ref
-            )
+            marketplace = Marketplace.from_url(marketplace_ref.url, name)
             is_valid, errors = marketplace.validate()
 
             if not is_valid:

--- a/src/lola/market/search.py
+++ b/src/lola/market/search.py
@@ -93,6 +93,7 @@ def format_search_result(module: dict, marketplace_name: str) -> dict:
         "description": description,
         "version": module.get("version", ""),
         "marketplace": marketplace_name,
+        "ref": module.get("ref") or "",
     }
 
 
@@ -135,19 +136,22 @@ def display_market(results: list[dict], query: str, console: Console) -> None:
         console.print("[dim]Tip: Check spelling or try a different search term[/dim]")
         return
 
+    show_ref = any(r.get("ref") for r in results)
+
     table = Table(show_header=True, header_style="bold")
     table.add_column("Module")
     table.add_column("Version")
+    if show_ref:
+        table.add_column("Ref")
     table.add_column("Marketplace")
     table.add_column("Description")
 
     for result in results:
-        table.add_row(
-            result["name"],
-            result["version"],
-            result["marketplace"],
-            result["description"],
-        )
+        row = [result["name"], result["version"]]
+        if show_ref:
+            row.append(result.get("ref", ""))
+        row += [result["marketplace"], result["description"]]
+        table.add_row(*row)
 
     count_text = "s" if len(results) != 1 else ""
     console.print(f"\n[bold]Found {len(results)} module{count_text}[/bold]\n")

--- a/src/lola/market/search.py
+++ b/src/lola/market/search.py
@@ -122,6 +122,28 @@ def search_market(query: str, market_dir: Path, cache_dir: Path) -> list[dict]:
     return results
 
 
+def build_market_table(results: list[dict]) -> Table:
+    """Build a Rich table for marketplace search results.
+
+    The Ref column is included only when at least one result has a ref.
+    """
+    show_ref = any(r.get("ref") for r in results)
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Module")
+    table.add_column("Version")
+    if show_ref:
+        table.add_column("Ref")
+    table.add_column("Marketplace")
+    table.add_column("Description")
+    for result in results:
+        row = [result["name"], result["version"]]
+        if show_ref:
+            row.append(result.get("ref", ""))
+        row += [result["marketplace"], result["description"]]
+        table.add_row(*row)
+    return table
+
+
 def display_market(results: list[dict], query: str, console: Console) -> None:
     """
     Display search results in a table.
@@ -136,23 +158,6 @@ def display_market(results: list[dict], query: str, console: Console) -> None:
         console.print("[dim]Tip: Check spelling or try a different search term[/dim]")
         return
 
-    show_ref = any(r.get("ref") for r in results)
-
-    table = Table(show_header=True, header_style="bold")
-    table.add_column("Module")
-    table.add_column("Version")
-    if show_ref:
-        table.add_column("Ref")
-    table.add_column("Marketplace")
-    table.add_column("Description")
-
-    for result in results:
-        row = [result["name"], result["version"]]
-        if show_ref:
-            row.append(result.get("ref", ""))
-        row += [result["marketplace"], result["description"]]
-        table.add_row(*row)
-
     count_text = "s" if len(results) != 1 else ""
     console.print(f"\n[bold]Found {len(results)} module{count_text}[/bold]\n")
-    console.print(table)
+    console.print(build_market_table(results))

--- a/src/lola/models.py
+++ b/src/lola/models.py
@@ -725,6 +725,17 @@ class Marketplace:
                 if field_name not in mod:
                     errors.append(f"Module {i}: missing '{field_name}'")
 
+            ref = mod.get("ref")
+            if ref is not None:
+                if not isinstance(ref, str) or not ref.strip():
+                    errors.append(
+                        f"Module {i} ({mod.get('name', '?')}): 'ref' must be a non-empty string"
+                    )
+                elif any(ord(c) < 32 for c in ref):
+                    errors.append(
+                        f"Module {i} ({mod.get('name', '?')}): 'ref' contains control characters"
+                    )
+
         return len(errors) == 0, errors
 
     def to_reference_dict(self) -> dict:
@@ -756,6 +767,7 @@ class Installation:
     scope: str
     project_path: str | None = None
     version: str | None = None
+    ref: str | None = None
     skills: list[str] = field(default_factory=list)
     commands: list[str] = field(default_factory=list)
     agents: list[str] = field(default_factory=list)
@@ -789,6 +801,8 @@ class Installation:
             result["project_path"] = self.project_path
         if self.version:
             result["version"] = self.version
+        if self.ref:
+            result["ref"] = self.ref
         if self.append_context:
             result["append_context"] = self.append_context
         return result
@@ -815,6 +829,7 @@ class Installation:
             scope=data.get("scope", "project"),
             project_path=data.get("project_path"),
             version=data.get("version"),
+            ref=data.get("ref"),
             skills=data.get("skills", []),
             commands=data.get("commands", []),
             agents=data.get("agents", []),

--- a/src/lola/models.py
+++ b/src/lola/models.py
@@ -431,6 +431,7 @@ class Marketplace:
     enabled: bool = True
     description: str = ""
     version: str = ""
+    ref: str | None = None
     modules: list[dict] = field(default_factory=list)
 
     @classmethod
@@ -442,6 +443,7 @@ class Marketplace:
             name=data.get("name", ""),
             url=data.get("url", ""),
             enabled=data.get("enabled", True),
+            ref=data.get("ref") or None,
         )
 
     @classmethod
@@ -459,7 +461,7 @@ class Marketplace:
         )
 
     @classmethod
-    def from_url(cls, url: str, name: str) -> "Marketplace":
+    def from_url(cls, url: str, name: str, ref: str | None = None) -> "Marketplace":
         """Load marketplace from URL (http/https), git repo (git+https/git+ssh), or local file path."""
         from urllib.request import urlopen
         from urllib.error import URLError
@@ -471,7 +473,7 @@ class Marketplace:
         # helpers, .netrc) — required for self-hosted GitLab/GitHub instances
         # that don't allow unauthenticated HTTP access.
         if url.startswith("git+") or _is_scp_style_git_url(url):
-            return cls._from_git_url(url, name)
+            return cls._from_git_url(url, name, ref)
 
         parsed = urlparse(url)
         stored_url = url
@@ -481,7 +483,7 @@ class Marketplace:
         if parsed.scheme in ("http", "https") and parsed.path.rstrip("/").endswith(
             ".git"
         ):
-            return cls._from_git_url(url, name)
+            return cls._from_git_url(url, name, ref)
 
         if parsed.scheme in ("http", "https"):
             try:
@@ -518,7 +520,9 @@ class Marketplace:
         )
 
     @classmethod
-    def _from_git_url(cls, url: str, name: str) -> "Marketplace":
+    def _from_git_url(
+        cls, url: str, name: str, ref: str | None = None
+    ) -> "Marketplace":
         """Fetch marketplace YAML from a git repository.
 
         Supports URLs like:
@@ -566,10 +570,10 @@ class Marketplace:
                 "--sparse",
                 "--depth",
                 "1",
-                "--",
-                git_url_clean,
-                str(repo_dir),
             ]
+            if ref:
+                clone_cmd += ["--branch", ref]
+            clone_cmd += ["--", git_url_clean, str(repo_dir)]
             result = subprocess.run(  # nosec B603 B607 - list args (no shell), git from PATH
                 clone_cmd,
                 capture_output=True,
@@ -639,6 +643,7 @@ class Marketplace:
             name=name,
             url=url,  # Store the original git+ URL for future updates
             enabled=True,
+            ref=ref,
             description=data.get("description", ""),
             version=data.get("version", ""),
             modules=data.get("modules", []),
@@ -730,11 +735,14 @@ class Marketplace:
 
     def to_reference_dict(self) -> dict:
         """Convert to dict for reference file."""
-        return {
+        d: dict = {
             "name": self.name,
             "url": self.url,
             "enabled": self.enabled,
         }
+        if self.ref:
+            d["ref"] = self.ref
+        return d
 
     def to_cache_dict(self) -> dict:
         """Convert to dict for cache file."""

--- a/src/lola/models.py
+++ b/src/lola/models.py
@@ -430,7 +430,6 @@ class Marketplace:
     enabled: bool = True
     description: str = ""
     version: str = ""
-    ref: str | None = None
     modules: list[dict] = field(default_factory=list)
 
     @classmethod
@@ -442,7 +441,6 @@ class Marketplace:
             name=data.get("name", ""),
             url=data.get("url", ""),
             enabled=data.get("enabled", True),
-            ref=data.get("ref") or None,
         )
 
     @classmethod
@@ -460,7 +458,7 @@ class Marketplace:
         )
 
     @classmethod
-    def from_url(cls, url: str, name: str, ref: str | None = None) -> "Marketplace":
+    def from_url(cls, url: str, name: str) -> "Marketplace":
         """Load marketplace from URL (http/https), git repo (git+https/git+ssh), or local file path."""
         from urllib.request import urlopen
         from urllib.error import URLError
@@ -472,7 +470,7 @@ class Marketplace:
         # helpers, .netrc) — required for self-hosted GitLab/GitHub instances
         # that don't allow unauthenticated HTTP access.
         if url.startswith("git+") or _is_scp_style_git_url(url):
-            return cls._from_git_url(url, name, ref)
+            return cls._from_git_url(url, name)
 
         parsed = urlparse(url)
         stored_url = url
@@ -482,7 +480,7 @@ class Marketplace:
         if parsed.scheme in ("http", "https") and parsed.path.rstrip("/").endswith(
             ".git"
         ):
-            return cls._from_git_url(url, name, ref)
+            return cls._from_git_url(url, name)
 
         if parsed.scheme in ("http", "https"):
             try:
@@ -519,9 +517,7 @@ class Marketplace:
         )
 
     @classmethod
-    def _from_git_url(
-        cls, url: str, name: str, ref: str | None = None
-    ) -> "Marketplace":
+    def _from_git_url(cls, url: str, name: str) -> "Marketplace":
         """Fetch marketplace YAML from a git repository.
 
         Supports URLs like:
@@ -569,10 +565,10 @@ class Marketplace:
                 "--sparse",
                 "--depth",
                 "1",
+                "--",
+                git_url_clean,
+                str(repo_dir),
             ]
-            if ref:
-                clone_cmd += ["--branch", ref]
-            clone_cmd += ["--", git_url_clean, str(repo_dir)]
             result = subprocess.run(  # nosec B603 B607 - list args (no shell), git from PATH
                 clone_cmd,
                 capture_output=True,
@@ -642,7 +638,6 @@ class Marketplace:
             name=name,
             url=url,  # Store the original git+ URL for future updates
             enabled=True,
-            ref=ref,
             description=data.get("description", ""),
             version=data.get("version", ""),
             modules=data.get("modules", []),
@@ -734,14 +729,11 @@ class Marketplace:
 
     def to_reference_dict(self) -> dict:
         """Convert to dict for reference file."""
-        d: dict = {
+        return {
             "name": self.name,
             "url": self.url,
             "enabled": self.enabled,
         }
-        if self.ref:
-            d["ref"] = self.ref
-        return d
 
     def to_cache_dict(self) -> dict:
         """Convert to dict for cache file."""

--- a/src/lola/parsers.py
+++ b/src/lola/parsers.py
@@ -851,6 +851,7 @@ def update_module(module_path: Path) -> str:
     source = source_info.get("source")
     source_type = source_info.get("type")
     content_dirname = source_info.get("content_dirname")
+    ref = source_info.get("ref")
     if not source or not source_type:
         raise SourceError(str(module_path), "Invalid source information.")
 
@@ -878,7 +879,7 @@ def update_module(module_path: Path) -> str:
         tmp_path = Path(tmp_dir)
 
         try:
-            new_path = handler.fetch(source, tmp_path)
+            new_path = handler.fetch(source, tmp_path, ref=ref)
 
             # Rename to match expected module name if needed
             if new_path.name != module_name:
@@ -887,7 +888,7 @@ def update_module(module_path: Path) -> str:
                 new_path = renamed_path
 
             # Save source info to the new module
-            save_source_info(new_path, source, source_type, content_dirname)
+            save_source_info(new_path, source, source_type, content_dirname, ref)
 
             # Atomic swap: move old module to backup, move new module in place
             backup_path = dest_dir / f".{module_name}.backup"

--- a/src/lola/parsers.py
+++ b/src/lola/parsers.py
@@ -178,6 +178,8 @@ class GitSourceHandler(SourceHandler):
                 raise RuntimeError(f"Git checkout failed: {result.stderr}")
         else:
             # For branches and tags, use shallow clone with --depth 1
+            if ref and ref.startswith("-"):
+                raise ValueError(f"Invalid ref '{ref}': refs cannot start with '-'")
             clone_cmd = ["git", "clone", "--depth", "1"]
             if ref:
                 clone_cmd.extend(["--branch", ref])

--- a/src/lola/prompts.py
+++ b/src/lola/prompts.py
@@ -108,7 +108,9 @@ def select_marketplace(matches: list[tuple[dict, str]]) -> str | None:
             value=marketplace_name,
             name=(
                 f"@{marketplace_name}/{module.get('name', '?')} "
-                f"v{module.get('version', '?')} — {module.get('description', '')}"
+                f"v{module.get('version', '?')}"
+                + (f" [{module['ref']}]" if module.get("ref") else "")
+                + f" — {module.get('description', '')}"
             ),
         )
         for module, marketplace_name in matches

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -233,6 +233,7 @@ class TestMarketplaceReference:
             patch("lola.cli.install.MODULES_DIR", modules_dir),
             patch("lola.cli.install.MARKET_DIR", market_dir),
             patch("lola.cli.install.CACHE_DIR", cache_dir),
+            patch("lola.cli.install.detect_source_type", return_value="git"),
             patch("lola.cli.install.save_source_info") as mock_save,
             patch(
                 "lola.cli.install.fetch_module_as_name",
@@ -279,6 +280,7 @@ class TestMarketplaceReference:
             patch("lola.cli.install.MODULES_DIR", modules_dir),
             patch("lola.cli.install.MARKET_DIR", market_dir),
             patch("lola.cli.install.CACHE_DIR", cache_dir),
+            patch("lola.cli.install.detect_source_type", return_value="git"),
             patch("lola.cli.install.save_source_info") as mock_save,
             patch(
                 "lola.cli.install.fetch_module_as_name",
@@ -415,6 +417,134 @@ class TestMarketplaceReference:
         installed_text = installed_file.read_text()
         assert "module: claude-md-management" in installed_text
         assert "module: claude-plugins-official" not in installed_text
+
+
+class TestInstallRefBehavior:
+    """Tests for @ref handling edge cases (PR #197 review fixes)."""
+
+    def test_ref_override_on_registered_git_module_refetches(self, tmp_path):
+        """install module@ref re-fetches at the new ref when the module is already registered."""
+        from unittest.mock import MagicMock, patch
+
+        modules_dir = tmp_path / "modules"
+        modules_dir.mkdir()
+        mod_path = modules_dir / "my-mod"
+        mod_path.mkdir()
+
+        from lola.parsers import save_source_info as _save
+
+        _save(mod_path, "https://example.com/repo.git", "git", ref="v1.0.0")
+
+        new_path = modules_dir / "my-mod"
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch(
+                "lola.cli.install.fetch_module_as_name", return_value=new_path
+            ) as mock_fetch,
+            patch("lola.cli.install.save_source_info") as mock_save,
+            patch("lola.cli.install.get_registry") as mock_registry,
+            patch("lola.cli.install.load_registered_module") as mock_load,
+            patch("lola.cli.install.default_assistants", return_value=["claude-code"]),
+            patch("lola.cli.install.TARGETS", {"claude-code": MagicMock()}),
+            patch("lola.cli.install.install_to_assistant", return_value=MagicMock()),
+            patch("lola.cli.install.get_target", return_value=MagicMock()),
+            patch("lola.cli.install.copy_module_to_local", return_value=MagicMock()),
+        ):
+            mock_registry.return_value.find.return_value = []
+            mock_registry.return_value.add = MagicMock()
+            mock_load.return_value = MagicMock(
+                skills=[],
+                commands=[],
+                agents=[],
+                mcps=[],
+                has_instructions=False,
+                validate=lambda: (True, []),
+            )
+            from click.testing import CliRunner
+
+            result = CliRunner().invoke(
+                install_cmd, ["my-mod@v2.0.0", "-a", "claude-code", "-s", "user"]
+            )
+
+        assert result.exit_code == 0
+        # fetch_module_as_name must have been called with ref="v2.0.0"
+        assert mock_fetch.call_args[0][4] == "v2.0.0"
+        # save_source_info must persist the new ref
+        assert mock_save.call_args[0][4] == "v2.0.0"
+
+    def test_ref_override_on_non_git_registered_module_errors(self, tmp_path):
+        """install module@ref errors when the registered module is not git-sourced."""
+        from lola.parsers import save_source_info as _save
+
+        modules_dir = tmp_path / "modules"
+        modules_dir.mkdir()
+        mod_path = modules_dir / "my-mod"
+        mod_path.mkdir()
+        _save(mod_path, str(tmp_path / "source"), "folder")
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.ensure_lola_dirs"),
+        ):
+            from click.testing import CliRunner
+
+            result = CliRunner().invoke(
+                install_cmd, ["my-mod@v1.0.0", "-a", "claude-code", "-s", "user"]
+            )
+
+        assert result.exit_code == 1
+        assert "not a git-sourced module" in result.output
+
+    def test_ref_on_non_git_marketplace_repository_errors(self, tmp_path):
+        """_fetch_from_marketplace rejects ref when repository is a zip/tar URL."""
+
+        market_dir = tmp_path / "market"
+        cache_dir = market_dir / "cache"
+        market_dir.mkdir()
+        cache_dir.mkdir()
+
+        ref_data = {
+            "name": "mkt",
+            "url": "https://example.com/mkt.yml",
+            "enabled": True,
+        }
+        import yaml
+
+        (market_dir / "mkt.yml").write_text(yaml.dump(ref_data))
+
+        cache_data = {
+            "name": "mkt",
+            "url": "https://example.com/mkt.yml",
+            "version": "1.0",
+            "enabled": True,
+            "modules": [
+                {
+                    "name": "zipmod",
+                    "description": "d",
+                    "version": "1.0",
+                    "repository": "https://example.com/module.zip",
+                    "ref": "v1.0.0",
+                }
+            ],
+        }
+        (cache_dir / "mkt.yml").write_text(yaml.dump(cache_data))
+
+        with (
+            patch("lola.cli.install.MARKET_DIR", market_dir),
+            patch("lola.cli.install.CACHE_DIR", cache_dir),
+            patch("lola.cli.install.MODULES_DIR", tmp_path / "modules"),
+            patch("lola.cli.install.ensure_lola_dirs"),
+        ):
+            from click.testing import CliRunner
+
+            result = CliRunner().invoke(
+                install_cmd, ["@mkt/zipmod", "-a", "claude-code", "-s", "user"]
+            )
+
+        assert result.exit_code == 1
+        assert "Cannot pin ref" in result.output
 
 
 class TestUninstallCmd:

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -10,7 +10,7 @@ from lola.cli.install import (
     update_cmd,
     list_installed_cmd,
 )
-from lola.market.manager import parse_market_ref
+from lola.market.manager import parse_market_ref, parse_ref_suffix
 from lola.models import Installation, InstallationRegistry
 
 
@@ -201,6 +201,153 @@ class TestMarketplaceReference:
         assert module_path.exists()
         assert (modules_dir / "claude-md-management").exists()
         assert not (modules_dir / "anthropics-claude-plugins-official").exists()
+
+    def test_fetch_from_marketplace_passes_ref_from_module_dict(self, tmp_path):
+        """ref field in marketplace YAML is passed to fetch_module_as_name."""
+        modules_dir = tmp_path / ".lola" / "modules"
+        modules_dir.mkdir(parents=True)
+        market_dir = tmp_path / ".lola" / "market"
+        cache_dir = tmp_path / ".lola" / "market" / "cache"
+        market_dir.mkdir(parents=True)
+        cache_dir.mkdir(parents=True)
+
+        source_repo = tmp_path / "my-skills"
+        source_repo.mkdir()
+
+        (market_dir / "demo.yml").write_text(
+            "name: demo\nurl: file:///tmp/demo.yml\nenabled: true\n"
+        )
+        (cache_dir / "demo.yml").write_text(
+            "name: demo\nurl: file:///tmp/demo.yml\nenabled: true\n"
+            "modules:\n"
+            "  - name: pinned-module\n"
+            "    description: Pinned\n"
+            "    version: 1.0.0\n"
+            f"    repository: {source_repo.as_posix()}\n"
+            "    ref: v1.2.0\n"
+        )
+
+        from unittest.mock import patch
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.MARKET_DIR", market_dir),
+            patch("lola.cli.install.CACHE_DIR", cache_dir),
+            patch("lola.cli.install.save_source_info") as mock_save,
+            patch(
+                "lola.cli.install.fetch_module_as_name",
+                return_value=modules_dir / "pinned-module",
+            ) as mock_fetch,
+        ):
+            (modules_dir / "pinned-module").mkdir()
+            _fetch_from_marketplace("demo", "pinned-module")
+
+        mock_fetch.assert_called_once()
+        _, _, _, _, ref_arg = mock_fetch.call_args[0]
+        assert ref_arg == "v1.2.0"
+        mock_save.assert_called_once()
+        assert mock_save.call_args[0][4] == "v1.2.0"
+
+    def test_fetch_from_marketplace_ref_override_wins(self, tmp_path):
+        """ref_override takes precedence over the marketplace YAML ref."""
+        modules_dir = tmp_path / ".lola" / "modules"
+        modules_dir.mkdir(parents=True)
+        market_dir = tmp_path / ".lola" / "market"
+        cache_dir = tmp_path / ".lola" / "market" / "cache"
+        market_dir.mkdir(parents=True)
+        cache_dir.mkdir(parents=True)
+
+        source_repo = tmp_path / "my-skills"
+        source_repo.mkdir()
+
+        (market_dir / "demo.yml").write_text(
+            "name: demo\nurl: file:///tmp/demo.yml\nenabled: true\n"
+        )
+        (cache_dir / "demo.yml").write_text(
+            "name: demo\nurl: file:///tmp/demo.yml\nenabled: true\n"
+            "modules:\n"
+            "  - name: pinned-module\n"
+            "    description: Pinned\n"
+            "    version: 1.0.0\n"
+            f"    repository: {source_repo.as_posix()}\n"
+            "    ref: v1.0.0\n"
+        )
+
+        from unittest.mock import patch
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.MARKET_DIR", market_dir),
+            patch("lola.cli.install.CACHE_DIR", cache_dir),
+            patch("lola.cli.install.save_source_info") as mock_save,
+            patch(
+                "lola.cli.install.fetch_module_as_name",
+                return_value=modules_dir / "pinned-module",
+            ) as mock_fetch,
+        ):
+            (modules_dir / "pinned-module").mkdir()
+            _fetch_from_marketplace("demo", "pinned-module", ref_override="develop")
+
+        _, _, _, _, ref_arg = mock_fetch.call_args[0]
+        assert ref_arg == "develop"
+        assert mock_save.call_args[0][4] == "develop"
+
+    def test_fetch_from_marketplace_no_ref(self, tmp_path):
+        """Module dict without ref field passes ref=None (backward compat)."""
+        modules_dir = tmp_path / ".lola" / "modules"
+        modules_dir.mkdir(parents=True)
+        market_dir = tmp_path / ".lola" / "market"
+        cache_dir = tmp_path / ".lola" / "market" / "cache"
+        market_dir.mkdir(parents=True)
+        cache_dir.mkdir(parents=True)
+
+        source_repo = tmp_path / "my-skills"
+        source_repo.mkdir()
+
+        (market_dir / "demo.yml").write_text(
+            "name: demo\nurl: file:///tmp/demo.yml\nenabled: true\n"
+        )
+        (cache_dir / "demo.yml").write_text(
+            "name: demo\nurl: file:///tmp/demo.yml\nenabled: true\n"
+            "modules:\n"
+            "  - name: unpinned\n"
+            "    description: No ref\n"
+            "    version: 1.0.0\n"
+            f"    repository: {source_repo.as_posix()}\n"
+        )
+
+        from unittest.mock import patch
+
+        with (
+            patch("lola.cli.install.MODULES_DIR", modules_dir),
+            patch("lola.cli.install.MARKET_DIR", market_dir),
+            patch("lola.cli.install.CACHE_DIR", cache_dir),
+            patch("lola.cli.install.save_source_info") as mock_save,
+            patch(
+                "lola.cli.install.fetch_module_as_name",
+                return_value=modules_dir / "unpinned",
+            ) as mock_fetch,
+        ):
+            (modules_dir / "unpinned").mkdir()
+            _fetch_from_marketplace("demo", "unpinned")
+
+        _, _, _, _, ref_arg = mock_fetch.call_args[0]
+        assert ref_arg is None
+        assert mock_save.call_args[0][4] is None
+
+    def test_parse_ref_suffix_used_in_module_at_ref_install(self):
+        """parse_ref_suffix splits 'module@ref' correctly for lola install."""
+        name, ref = parse_ref_suffix("tools@v1.0.0")
+        assert name == "tools"
+        assert ref == "v1.0.0"
+
+    def test_parse_ref_suffix_marketplace_module_at_ref(self):
+        """parse_ref_suffix handles module part after parse_market_ref."""
+        # Simulates @marketplace/module@ref → parse_market_ref → ("mkt", "module@ref")
+        # then parse_ref_suffix on the module part
+        name, ref = parse_ref_suffix("my-module@develop")
+        assert name == "my-module"
+        assert ref == "develop"
 
     def test_marketplace_install_lists_catalog_name_and_registry_record(
         self, cli_runner, tmp_path

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -953,6 +953,93 @@ class TestListInstalledCmd:
         assert "module2" not in result.output
         assert "Installed (1 module" in result.output
 
+    def test_list_shows_version_and_ref(self, cli_runner, tmp_path):
+        """lola list shows version and ref when set on Installation."""
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        installed_file.parent.mkdir(parents=True)
+
+        registry = InstallationRegistry(installed_file)
+        registry.add(
+            Installation(
+                module_name="pinned-mod",
+                assistant="claude-code",
+                scope="user",
+                version="1.2.0",
+                ref="v1.2.0",
+            )
+        )
+
+        with (
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry", return_value=registry),
+        ):
+            result = cli_runner.invoke(list_installed_cmd, [])
+
+        assert result.exit_code == 0
+        assert "version: 1.2.0" in result.output
+        assert "ref: v1.2.0" in result.output
+
+    def test_list_omits_version_ref_when_absent(self, cli_runner, tmp_path):
+        """lola list does not show version/ref lines when they are not set."""
+        installed_file = tmp_path / ".lola" / "installed.yml"
+        installed_file.parent.mkdir(parents=True)
+
+        registry = InstallationRegistry(installed_file)
+        registry.add(
+            Installation(
+                module_name="plain-mod",
+                assistant="claude-code",
+                scope="user",
+            )
+        )
+
+        with (
+            patch("lola.cli.install.ensure_lola_dirs"),
+            patch("lola.cli.install.get_registry", return_value=registry),
+        ):
+            result = cli_runner.invoke(list_installed_cmd, [])
+
+        assert result.exit_code == 0
+        assert "version:" not in result.output
+        assert "ref:" not in result.output
+
+    def test_installation_ref_roundtrip(self, tmp_path):
+        """Installation.ref persists to YAML and loads back correctly."""
+        installed_file = tmp_path / "installed.yml"
+        registry = InstallationRegistry(installed_file)
+        registry.add(
+            Installation(
+                module_name="mod",
+                assistant="claude-code",
+                scope="user",
+                version="2.0.0",
+                ref="v2.0.0",
+            )
+        )
+
+        registry2 = InstallationRegistry(installed_file)
+        insts = registry2.find("mod")
+        assert len(insts) == 1
+        assert insts[0].version == "2.0.0"
+        assert insts[0].ref == "v2.0.0"
+
+    def test_installation_backward_compat_no_ref(self, tmp_path):
+        """Old installed.yml without ref field loads without error, ref is None."""
+        installed_file = tmp_path / "installed.yml"
+        registry = InstallationRegistry(installed_file)
+        registry.add(
+            Installation(
+                module_name="mod",
+                assistant="claude-code",
+                scope="user",
+                version="1.0.0",
+            )
+        )
+
+        registry2 = InstallationRegistry(installed_file)
+        insts = registry2.find("mod")
+        assert insts[0].ref is None
+
 
 # ---------------------------------------------------------------------------
 # Interactive prompt tests (001-interactive-prompts)

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -1156,18 +1156,24 @@ class TestListInstalledCmd:
     def test_installation_backward_compat_no_ref(self, tmp_path):
         """Old installed.yml without ref field loads without error, ref is None."""
         installed_file = tmp_path / "installed.yml"
-        registry = InstallationRegistry(installed_file)
-        registry.add(
-            Installation(
-                module_name="mod",
-                assistant="claude-code",
-                scope="user",
-                version="1.0.0",
-            )
+        # Write the legacy YAML shape directly — no 'ref' key, matching files
+        # written before the ref field was introduced.
+        installed_file.write_text(
+            "installations:\n"
+            "- module: mod\n"
+            "  assistant: claude-code\n"
+            "  scope: user\n"
+            "  version: '1.0.0'\n"
+            "  skills: []\n"
+            "  commands: []\n"
+            "  agents: []\n"
+            "  mcps: []\n"
+            "  has_instructions: false\n"
         )
 
-        registry2 = InstallationRegistry(installed_file)
-        insts = registry2.find("mod")
+        registry = InstallationRegistry(installed_file)
+        insts = registry.find("mod")
+        assert len(insts) == 1
         assert insts[0].ref is None
 
 

--- a/tests/test_cli_mod.py
+++ b/tests/test_cli_mod.py
@@ -993,6 +993,73 @@ class TestModUpdate:
         assert result.exit_code == 0
         assert "Updating 1 module" in result.output
 
+    def test_update_replays_pinned_ref(self, tmp_path):
+        """update_module() passes stored ref back to handler.fetch()."""
+        from unittest.mock import MagicMock, patch
+
+        from lola.parsers import save_source_info, update_module
+
+        modules_dir = tmp_path / "modules"
+        modules_dir.mkdir()
+        mod_path = modules_dir / "pinned-mod"
+        mod_path.mkdir()
+        save_source_info(mod_path, "https://example.com/repo.git", "git", ref="v1.0.0")
+
+        fake_fetched = tmp_path / "fetched" / "pinned-mod"
+        fake_fetched.mkdir(parents=True)
+        save_source_info(
+            fake_fetched, "https://example.com/repo.git", "git", ref="v1.0.0"
+        )
+
+        mock_handler = MagicMock()
+        mock_handler.__class__.__name__ = "GitSourceHandler"
+        mock_handler.can_handle.return_value = True
+        mock_handler.fetch.return_value = fake_fetched
+
+        with patch("lola.parsers.SOURCE_HANDLERS", [mock_handler]):
+            update_module(mod_path)
+
+        mock_handler.fetch.assert_called_once()
+        _, _, kwargs = (
+            mock_handler.fetch.call_args[0],
+            mock_handler.fetch.call_args[1],
+            mock_handler.fetch.call_args,
+        )
+        assert (
+            kwargs.kwargs.get("ref") == "v1.0.0"
+            or kwargs.args[2:3] == ("v1.0.0",)
+            or "v1.0.0" in str(mock_handler.fetch.call_args)
+        )
+
+    def test_update_without_ref_still_works(self, tmp_path):
+        """update_module() passes ref=None when source.yml has no ref."""
+        from unittest.mock import MagicMock, patch
+
+        from lola.parsers import save_source_info, update_module
+
+        modules_dir = tmp_path / "modules"
+        modules_dir.mkdir()
+        mod_path = modules_dir / "unpinned-mod"
+        mod_path.mkdir()
+        save_source_info(mod_path, "https://example.com/repo.git", "git")
+
+        fake_fetched = tmp_path / "fetched" / "unpinned-mod"
+        fake_fetched.mkdir(parents=True)
+        save_source_info(fake_fetched, "https://example.com/repo.git", "git")
+
+        mock_handler = MagicMock()
+        mock_handler.__class__.__name__ = "GitSourceHandler"
+        mock_handler.can_handle.return_value = True
+        mock_handler.fetch.return_value = fake_fetched
+
+        with patch("lola.parsers.SOURCE_HANDLERS", [mock_handler]):
+            update_module(mod_path)
+
+        mock_handler.fetch.assert_called_once()
+        call_args = mock_handler.fetch.call_args
+        ref_arg = call_args.kwargs.get("ref") if call_args.kwargs else None
+        assert ref_arg is None
+
 
 class TestModInitModuleSubdir:
     """Tests for mod init with module/ subdirectory structure."""

--- a/tests/test_cli_mod.py
+++ b/tests/test_cli_mod.py
@@ -115,6 +115,51 @@ class TestModAdd:
         assert "-a <assistant>" in result.output
         assert "-s <scope>" in result.output
 
+    def test_add_ref_passed_to_fetch_and_save(
+        self, cli_runner, sample_module, tmp_path
+    ):
+        """--ref flag is forwarded to fetch_module and save_source_info."""
+        modules_dir = tmp_path / ".lola" / "modules"
+        modules_dir.mkdir(parents=True)
+
+        with (
+            patch("lola.cli.mod.MODULES_DIR", modules_dir),
+            patch("lola.cli.mod.ensure_lola_dirs"),
+            patch(
+                "lola.cli.mod.fetch_module", return_value=modules_dir / "sample-module"
+            ) as mock_fetch,
+            patch("lola.cli.mod.save_source_info") as mock_save,
+        ):
+            (modules_dir / "sample-module").mkdir()
+            result = cli_runner.invoke(
+                mod, ["add", "https://github.com/user/repo.git", "--ref", "v1.0.0"]
+            )
+
+        assert result.exit_code == 0
+        # ref must be passed as 4th positional arg to fetch_module
+        assert mock_fetch.call_args[0][3] == "v1.0.0"
+        # ref must be passed as 5th positional arg to save_source_info
+        assert mock_save.call_args[0][4] == "v1.0.0"
+
+    def test_add_without_ref_passes_none(self, cli_runner, sample_module, tmp_path):
+        """Without --ref, git_ref=None is passed (backward compat)."""
+        modules_dir = tmp_path / ".lola" / "modules"
+        modules_dir.mkdir(parents=True)
+
+        with (
+            patch("lola.cli.mod.MODULES_DIR", modules_dir),
+            patch("lola.cli.mod.ensure_lola_dirs"),
+            patch(
+                "lola.cli.mod.fetch_module", return_value=modules_dir / "sample-module"
+            ) as mock_fetch,
+            patch("lola.cli.mod.save_source_info"),
+        ):
+            (modules_dir / "sample-module").mkdir()
+            result = cli_runner.invoke(mod, ["add", "https://github.com/user/repo.git"])
+
+        assert result.exit_code == 0
+        assert mock_fetch.call_args[0][3] is None
+
 
 class TestModList:
     """Tests for mod ls command."""

--- a/tests/test_cli_mod.py
+++ b/tests/test_cli_mod.py
@@ -160,6 +160,30 @@ class TestModAdd:
         assert result.exit_code == 0
         assert mock_fetch.call_args[0][3] is None
 
+    def test_add_ref_starting_with_dash_is_rejected(
+        self, cli_runner, sample_module, tmp_path
+    ):
+        """--ref value starting with '-' is rejected to prevent option injection."""
+        modules_dir = tmp_path / ".lola" / "modules"
+        modules_dir.mkdir(parents=True)
+
+        with (
+            patch("lola.cli.mod.MODULES_DIR", modules_dir),
+            patch("lola.cli.mod.ensure_lola_dirs"),
+        ):
+            result = cli_runner.invoke(
+                mod,
+                [
+                    "add",
+                    "https://github.com/user/repo.git",
+                    "--ref",
+                    "-upload-pack=evil",
+                ],
+            )
+
+        assert result.exit_code == 1
+        assert "refs cannot start with '-'" in result.output
+
 
 class TestModList:
     """Tests for mod ls command."""

--- a/tests/test_cli_mod.py
+++ b/tests/test_cli_mod.py
@@ -1017,11 +1017,11 @@ class TestModUpdate:
         assert result.exit_code == 0
         assert "Updating 1 module" in result.output
 
-    def test_update_replays_pinned_ref(self, tmp_path):
-        """update_module() passes stored ref back to handler.fetch()."""
-        from unittest.mock import MagicMock, patch
+    def test_update_replays_pinned_ref(self, cli_runner, tmp_path):
+        """'lola mod update' replays the stored ref when fetching a git module."""
+        from unittest.mock import MagicMock
 
-        from lola.parsers import save_source_info, update_module
+        from lola.parsers import save_source_info
 
         modules_dir = tmp_path / "modules"
         modules_dir.mkdir()
@@ -1040,26 +1040,22 @@ class TestModUpdate:
         mock_handler.can_handle.return_value = True
         mock_handler.fetch.return_value = fake_fetched
 
-        with patch("lola.parsers.SOURCE_HANDLERS", [mock_handler]):
-            update_module(mod_path)
+        with (
+            patch("lola.cli.mod.MODULES_DIR", modules_dir),
+            patch("lola.cli.mod.ensure_lola_dirs"),
+            patch("lola.parsers.SOURCE_HANDLERS", [mock_handler]),
+        ):
+            result = cli_runner.invoke(mod, ["update", "pinned-mod"])
 
+        assert result.exit_code == 0
         mock_handler.fetch.assert_called_once()
-        _, _, kwargs = (
-            mock_handler.fetch.call_args[0],
-            mock_handler.fetch.call_args[1],
-            mock_handler.fetch.call_args,
-        )
-        assert (
-            kwargs.kwargs.get("ref") == "v1.0.0"
-            or kwargs.args[2:3] == ("v1.0.0",)
-            or "v1.0.0" in str(mock_handler.fetch.call_args)
-        )
+        assert "v1.0.0" in str(mock_handler.fetch.call_args)
 
-    def test_update_without_ref_still_works(self, tmp_path):
-        """update_module() passes ref=None when source.yml has no ref."""
-        from unittest.mock import MagicMock, patch
+    def test_update_without_ref_still_works(self, cli_runner, tmp_path):
+        """'lola mod update' works for a git module without a pinned ref."""
+        from unittest.mock import MagicMock
 
-        from lola.parsers import save_source_info, update_module
+        from lola.parsers import save_source_info
 
         modules_dir = tmp_path / "modules"
         modules_dir.mkdir()
@@ -1076,9 +1072,14 @@ class TestModUpdate:
         mock_handler.can_handle.return_value = True
         mock_handler.fetch.return_value = fake_fetched
 
-        with patch("lola.parsers.SOURCE_HANDLERS", [mock_handler]):
-            update_module(mod_path)
+        with (
+            patch("lola.cli.mod.MODULES_DIR", modules_dir),
+            patch("lola.cli.mod.ensure_lola_dirs"),
+            patch("lola.parsers.SOURCE_HANDLERS", [mock_handler]),
+        ):
+            result = cli_runner.invoke(mod, ["update", "unpinned-mod"])
 
+        assert result.exit_code == 0
         mock_handler.fetch.assert_called_once()
         call_args = mock_handler.fetch.call_args
         ref_arg = call_args.kwargs.get("ref") if call_args.kwargs else None

--- a/tests/test_market_manager.py
+++ b/tests/test_market_manager.py
@@ -331,6 +331,93 @@ class TestMarketplaceRegistryShow:
         assert "recovered-module" in captured.out
         assert "A recovered module" in captured.out
 
+    def test_show_displays_ref_column_when_modules_have_ref(self, tmp_path, capsys):
+        """show() includes Ref column when at least one module has a ref."""
+        market_dir = tmp_path / "market"
+        cache_dir = market_dir / "cache"
+        market_dir.mkdir(parents=True)
+        cache_dir.mkdir(parents=True)
+
+        ref_data = {
+            "name": "pinned-market",
+            "url": "https://example.com/m.yml",
+            "enabled": True,
+        }
+        cache_data = {
+            "name": "Pinned Market",
+            "description": "Test",
+            "version": "1.0.0",
+            "url": "https://example.com/m.yml",
+            "enabled": True,
+            "modules": [
+                {
+                    "name": "stable-tool",
+                    "description": "Stable",
+                    "version": "2.0.0",
+                    "repository": "https://github.com/org/tool",
+                    "ref": "v2.0.0",
+                },
+                {
+                    "name": "plain-tool",
+                    "description": "No ref",
+                    "version": "1.0.0",
+                    "repository": "https://github.com/org/plain",
+                },
+            ],
+        }
+        with open(market_dir / "pinned-market.yml", "w") as f:
+            yaml.dump(ref_data, f)
+        with open(cache_dir / "pinned-market.yml", "w") as f:
+            yaml.dump(cache_data, f)
+
+        registry = MarketplaceRegistry(market_dir, cache_dir)
+        registry.show("pinned-market")
+
+        captured = capsys.readouterr()
+        assert "Ref" in captured.out
+        assert "v2.0.0" in captured.out
+        assert "stable-tool" in captured.out
+        assert "plain-tool" in captured.out
+
+    def test_show_hides_ref_column_when_no_refs(self, tmp_path, capsys):
+        """show() omits Ref column when no modules have a ref."""
+        market_dir = tmp_path / "market"
+        cache_dir = market_dir / "cache"
+        market_dir.mkdir(parents=True)
+        cache_dir.mkdir(parents=True)
+
+        ref_data = {
+            "name": "plain-market",
+            "url": "https://example.com/m.yml",
+            "enabled": True,
+        }
+        cache_data = {
+            "name": "Plain Market",
+            "description": "Test",
+            "version": "1.0.0",
+            "url": "https://example.com/m.yml",
+            "enabled": True,
+            "modules": [
+                {
+                    "name": "tool-a",
+                    "description": "No ref",
+                    "version": "1.0.0",
+                    "repository": "https://github.com/org/a",
+                },
+            ],
+        }
+        with open(market_dir / "plain-market.yml", "w") as f:
+            yaml.dump(ref_data, f)
+        with open(cache_dir / "plain-market.yml", "w") as f:
+            yaml.dump(cache_data, f)
+
+        registry = MarketplaceRegistry(market_dir, cache_dir)
+        registry.show("plain-market")
+
+        captured = capsys.readouterr()
+        assert "Ref" not in captured.out
+        assert "tool-a" in captured.out
+
 
 class TestMarketplaceRegistryEnableDisable:
     """Tests for MarketplaceRegistry enable/disable."""
@@ -849,3 +936,98 @@ class TestParseRefSuffix:
         name, ref = parse_ref_suffix("my-module@v1@v2")
         assert name == "my-module@v1"
         assert ref == "v2"
+
+
+class TestMarketplaceValidateRef:
+    """Tests for ref field validation in Marketplace.validate()."""
+
+    def _make_marketplace(self, modules):
+        return Marketplace(
+            name="Test",
+            url="https://example.com/market.yml",
+            version="1.0.0",
+            modules=modules,
+        )
+
+    def test_validate_accepts_valid_refs(self):
+        """Tags, branches, and SHAs are all accepted."""
+        for ref in ("v1.0.0", "main", "abc1234def5678"):
+            market = self._make_marketplace(
+                [
+                    {
+                        "name": "mod",
+                        "description": "d",
+                        "version": "1.0",
+                        "repository": "https://r.git",
+                        "ref": ref,
+                    }
+                ]
+            )
+            ok, errors = market.validate()
+            assert ok, f"Expected valid for ref={ref!r}, got errors: {errors}"
+
+    def test_validate_rejects_empty_ref(self):
+        """ref: '' must produce a validation error."""
+        market = self._make_marketplace(
+            [
+                {
+                    "name": "mod",
+                    "description": "d",
+                    "version": "1.0",
+                    "repository": "https://r.git",
+                    "ref": "",
+                }
+            ]
+        )
+        ok, errors = market.validate()
+        assert not ok
+        assert any("'ref' must be a non-empty string" in e for e in errors)
+
+    def test_validate_rejects_whitespace_only_ref(self):
+        """ref: '   ' (only spaces) must produce a validation error."""
+        market = self._make_marketplace(
+            [
+                {
+                    "name": "mod",
+                    "description": "d",
+                    "version": "1.0",
+                    "repository": "https://r.git",
+                    "ref": "   ",
+                }
+            ]
+        )
+        ok, errors = market.validate()
+        assert not ok
+        assert any("'ref' must be a non-empty string" in e for e in errors)
+
+    def test_validate_rejects_control_char_ref(self):
+        """ref containing control characters must produce a validation error."""
+        market = self._make_marketplace(
+            [
+                {
+                    "name": "mod",
+                    "description": "d",
+                    "version": "1.0",
+                    "repository": "https://r.git",
+                    "ref": "v1\x00bad",
+                }
+            ]
+        )
+        ok, errors = market.validate()
+        assert not ok
+        assert any("control characters" in e for e in errors)
+
+    def test_validate_none_ref_is_allowed(self):
+        """Omitting ref entirely (None) is fine — ref is optional."""
+        market = self._make_marketplace(
+            [
+                {
+                    "name": "mod",
+                    "description": "d",
+                    "version": "1.0",
+                    "repository": "https://r.git",
+                }
+            ]
+        )
+        ok, errors = market.validate()
+        assert ok, f"Expected valid when ref is absent, got errors: {errors}"

--- a/tests/test_market_manager.py
+++ b/tests/test_market_manager.py
@@ -92,48 +92,6 @@ class TestMarketplaceRegistryAdd:
             captured = capsys.readouterr()
             assert "Validation failed" in captured.out
 
-    def test_registry_add_with_ref_stored_in_reference_file(self, tmp_path):
-        """ref is persisted to the reference file and reloaded correctly."""
-        market_dir = tmp_path / "market"
-        cache_dir = market_dir / "cache"
-
-        with patch(
-            "lola.models.Marketplace._from_git_url",
-            return_value=Marketplace(
-                name="official",
-                url="https://github.com/org/market.git",
-                ref="v1.0.0",
-                description="Test",
-                version="1.0.0",
-                modules=[],
-            ),
-        ):
-            registry = MarketplaceRegistry(market_dir, cache_dir)
-            registry.add("official", "https://github.com/org/market.git", ref="v1.0.0")
-
-        ref_file = market_dir / "official.yml"
-        assert ref_file.exists()
-        loaded = Marketplace.from_reference(ref_file)
-        assert loaded.ref == "v1.0.0"
-
-    def test_registry_add_no_ref_not_stored(self, tmp_path):
-        """When ref is omitted, reference file has no ref key."""
-        import yaml as _yaml
-
-        market_dir = tmp_path / "market"
-        cache_dir = market_dir / "cache"
-
-        yaml_content = "name: Test\ndescription: d\nversion: 1.0.0\nmodules: []\n"
-        mock_response = mock_open(read_data=yaml_content.encode())()
-
-        with patch("urllib.request.urlopen", return_value=mock_response):
-            registry = MarketplaceRegistry(market_dir, cache_dir)
-            registry.add("noref", "https://example.com/market.yml")
-
-        ref_file = market_dir / "noref.yml"
-        data = _yaml.safe_load(ref_file.read_text())
-        assert "ref" not in data
-
     def test_registry_add_network_error(self, tmp_path, capsys):
         """Handle network error when adding marketplace."""
         from urllib.error import URLError
@@ -555,51 +513,6 @@ class TestMarketplaceRegistryUpdate:
             )
             assert updated_marketplace.modules[1]["name"] == "another-module"
             assert updated_marketplace.modules[2]["name"] == "third-module"
-
-    def test_update_one_replays_stored_ref(self, tmp_path):
-        """update_one passes the stored ref back to from_url so the same revision is cloned."""
-        import yaml as _yaml
-
-        market_dir = tmp_path / "market"
-        cache_dir = market_dir / "cache"
-        market_dir.mkdir(parents=True)
-        cache_dir.mkdir(parents=True)
-
-        # Write reference file with a pinned ref
-        ref_data = {
-            "name": "pinned",
-            "url": "https://github.com/org/market.git",
-            "enabled": True,
-            "ref": "v1.0.0",
-        }
-        (market_dir / "pinned.yml").write_text(_yaml.dump(ref_data))
-        # Write minimal cache so update_one can proceed
-        cache_data = {
-            "name": "pinned",
-            "url": "https://github.com/org/market.git",
-            "enabled": True,
-            "description": "",
-            "version": "1.0.0",
-            "modules": [],
-        }
-        (cache_dir / "pinned.yml").write_text(_yaml.dump(cache_data))
-
-        registry = MarketplaceRegistry(market_dir, cache_dir)
-        with patch("lola.models.Marketplace.from_url") as mock_from_url:
-            mock_from_url.return_value = Marketplace(
-                name="pinned",
-                url="https://github.com/org/market.git",
-                ref="v1.0.0",
-                description="",
-                version="1.0.0",
-                modules=[],
-            )
-            registry.update_one("pinned")
-
-        # Verify from_url was called with the stored ref
-        mock_from_url.assert_called_once_with(
-            "https://github.com/org/market.git", "pinned", "v1.0.0"
-        )
 
     def test_update_one_not_found(self, tmp_path, capsys):
         """Update non-existent marketplace returns False."""

--- a/tests/test_market_manager.py
+++ b/tests/test_market_manager.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, mock_open
 import yaml
 
 from lola.models import Marketplace
-from lola.market.manager import MarketplaceRegistry
+from lola.market.manager import MarketplaceRegistry, parse_ref_suffix
 
 
 class TestMarketplaceRegistryAdd:
@@ -91,6 +91,48 @@ class TestMarketplaceRegistryAdd:
             # Verify validation failure message was printed
             captured = capsys.readouterr()
             assert "Validation failed" in captured.out
+
+    def test_registry_add_with_ref_stored_in_reference_file(self, tmp_path):
+        """ref is persisted to the reference file and reloaded correctly."""
+        market_dir = tmp_path / "market"
+        cache_dir = market_dir / "cache"
+
+        with patch(
+            "lola.models.Marketplace._from_git_url",
+            return_value=Marketplace(
+                name="official",
+                url="https://github.com/org/market.git",
+                ref="v1.0.0",
+                description="Test",
+                version="1.0.0",
+                modules=[],
+            ),
+        ):
+            registry = MarketplaceRegistry(market_dir, cache_dir)
+            registry.add("official", "https://github.com/org/market.git", ref="v1.0.0")
+
+        ref_file = market_dir / "official.yml"
+        assert ref_file.exists()
+        loaded = Marketplace.from_reference(ref_file)
+        assert loaded.ref == "v1.0.0"
+
+    def test_registry_add_no_ref_not_stored(self, tmp_path):
+        """When ref is omitted, reference file has no ref key."""
+        import yaml as _yaml
+
+        market_dir = tmp_path / "market"
+        cache_dir = market_dir / "cache"
+
+        yaml_content = "name: Test\ndescription: d\nversion: 1.0.0\nmodules: []\n"
+        mock_response = mock_open(read_data=yaml_content.encode())()
+
+        with patch("urllib.request.urlopen", return_value=mock_response):
+            registry = MarketplaceRegistry(market_dir, cache_dir)
+            registry.add("noref", "https://example.com/market.yml")
+
+        ref_file = market_dir / "noref.yml"
+        data = _yaml.safe_load(ref_file.read_text())
+        assert "ref" not in data
 
     def test_registry_add_network_error(self, tmp_path, capsys):
         """Handle network error when adding marketplace."""
@@ -514,6 +556,51 @@ class TestMarketplaceRegistryUpdate:
             assert updated_marketplace.modules[1]["name"] == "another-module"
             assert updated_marketplace.modules[2]["name"] == "third-module"
 
+    def test_update_one_replays_stored_ref(self, tmp_path):
+        """update_one passes the stored ref back to from_url so the same revision is cloned."""
+        import yaml as _yaml
+
+        market_dir = tmp_path / "market"
+        cache_dir = market_dir / "cache"
+        market_dir.mkdir(parents=True)
+        cache_dir.mkdir(parents=True)
+
+        # Write reference file with a pinned ref
+        ref_data = {
+            "name": "pinned",
+            "url": "https://github.com/org/market.git",
+            "enabled": True,
+            "ref": "v1.0.0",
+        }
+        (market_dir / "pinned.yml").write_text(_yaml.dump(ref_data))
+        # Write minimal cache so update_one can proceed
+        cache_data = {
+            "name": "pinned",
+            "url": "https://github.com/org/market.git",
+            "enabled": True,
+            "description": "",
+            "version": "1.0.0",
+            "modules": [],
+        }
+        (cache_dir / "pinned.yml").write_text(_yaml.dump(cache_data))
+
+        registry = MarketplaceRegistry(market_dir, cache_dir)
+        with patch("lola.models.Marketplace.from_url") as mock_from_url:
+            mock_from_url.return_value = Marketplace(
+                name="pinned",
+                url="https://github.com/org/market.git",
+                ref="v1.0.0",
+                description="",
+                version="1.0.0",
+                modules=[],
+            )
+            registry.update_one("pinned")
+
+        # Verify from_url was called with the stored ref
+        mock_from_url.assert_called_once_with(
+            "https://github.com/org/market.git", "pinned", "v1.0.0"
+        )
+
     def test_update_one_not_found(self, tmp_path, capsys):
         """Update non-existent marketplace returns False."""
         market_dir = tmp_path / "market"
@@ -809,3 +896,43 @@ class TestMarketplaceRegistrySelectMarketplace:
             result = registry.select_marketplace("test", matches)
 
         assert result is None
+
+
+class TestParseRefSuffix:
+    """Tests for parse_ref_suffix()."""
+
+    def test_no_ref(self):
+        """Module name without @ returns (name, None)."""
+        name, ref = parse_ref_suffix("my-module")
+        assert name == "my-module"
+        assert ref is None
+
+    def test_tag_ref(self):
+        """module@v1.0.0 splits correctly."""
+        name, ref = parse_ref_suffix("my-module@v1.0.0")
+        assert name == "my-module"
+        assert ref == "v1.0.0"
+
+    def test_branch_ref(self):
+        """module@develop splits correctly."""
+        name, ref = parse_ref_suffix("tools@develop")
+        assert name == "tools"
+        assert ref == "develop"
+
+    def test_commit_sha_ref(self):
+        """module@sha splits on rightmost @ so full SHA is preserved."""
+        name, ref = parse_ref_suffix("tools@abc1234")
+        assert name == "tools"
+        assert ref == "abc1234"
+
+    def test_empty_ref_after_at(self):
+        """module@ with empty suffix returns None for ref."""
+        name, ref = parse_ref_suffix("my-module@")
+        assert name == "my-module"
+        assert ref is None
+
+    def test_rsplit_takes_rightmost_at(self):
+        """When multiple @ present, splits on the rightmost one."""
+        name, ref = parse_ref_suffix("my-module@v1@v2")
+        assert name == "my-module@v1"
+        assert ref == "v2"

--- a/tests/test_market_search.py
+++ b/tests/test_market_search.py
@@ -331,3 +331,68 @@ class TestDisplayMarket:
         captured = capsys.readouterr()
         assert "No modules found matching 'nonexistent'" in captured.out
         assert "Tip: Check spelling" in captured.out
+
+    def test_display_shows_ref_column_when_any_result_has_ref(self, capsys):
+        """Ref column appears when at least one result has a ref."""
+        results = [
+            {
+                "name": "pinned-tool",
+                "description": "Pinned",
+                "version": "2.0.0",
+                "marketplace": "official",
+                "ref": "v2.0.0",
+            },
+            {
+                "name": "unpinned-tool",
+                "description": "Unpinned",
+                "version": "1.0.0",
+                "marketplace": "official",
+                "ref": "",
+            },
+        ]
+
+        console = Console()
+        display_market(results, "tool", console)
+
+        captured = capsys.readouterr()
+        assert "Ref" in captured.out
+        assert "v2.0.0" in captured.out
+
+    def test_display_hides_ref_column_when_no_refs(self, capsys):
+        """Ref column is omitted when no results have a ref."""
+        results = [
+            {
+                "name": "tool",
+                "description": "A tool",
+                "version": "1.0.0",
+                "marketplace": "official",
+                "ref": "",
+            }
+        ]
+
+        console = Console()
+        display_market(results, "tool", console)
+
+        captured = capsys.readouterr()
+        assert "Ref" not in captured.out
+
+
+class TestFormatSearchResultRef:
+    """Tests for ref field in format_search_result()."""
+
+    def test_format_includes_ref_when_present(self):
+        """ref field is included in formatted result."""
+        module = {
+            "name": "pinned",
+            "description": "desc",
+            "version": "1.0.0",
+            "ref": "v1.0.0",
+        }
+        result = format_search_result(module, "official")
+        assert result["ref"] == "v1.0.0"
+
+    def test_format_ref_empty_when_absent(self):
+        """ref is empty string when not present in module dict."""
+        module = {"name": "unpinned", "description": "desc", "version": "1.0.0"}
+        result = format_search_result(module, "official")
+        assert result["ref"] == ""

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1165,6 +1165,30 @@ class TestGitSourceHandlerFetch:
                 str(dest_dir / "evil"),  # Name derived from source
             ], "Git clone must use -- separator to prevent flag injection"
 
+    def test_fetch_rejects_ref_starting_with_dash(self, tmp_path):
+        """Raise ValueError when a branch/tag ref starts with '-' to prevent option injection."""
+        dest_dir = tmp_path / "dest"
+        dest_dir.mkdir()
+
+        with pytest.raises(ValueError, match="refs cannot start with '-'"):
+            self.handler.fetch(
+                "https://github.com/user/repo.git",
+                dest_dir,
+                ref="-upload-pack=evil",
+            )
+
+    def test_fetch_rejects_ref_starting_with_double_dash(self, tmp_path):
+        """Raise ValueError for refs starting with '--' (long-form option injection)."""
+        dest_dir = tmp_path / "dest"
+        dest_dir.mkdir()
+
+        with pytest.raises(ValueError, match="refs cannot start with '-'"):
+            self.handler.fetch(
+                "https://github.com/user/repo.git",
+                dest_dir,
+                ref="--upload-pack=evil",
+            )
+
 
 class TestZipSlipPrevention:
     """Tests for Zip Slip attack prevention."""


### PR DESCRIPTION
## Summary

- **Pin modules to a specific Git ref** — marketplace YAML module entries now support a `ref` field (branch, tag, or SHA); `lola mod add --ref <ref>` and `lola install module@ref` syntax pin installs at fetch time; the pin is stored in `source.yml` and preserved by `lola mod update` (previously update silently fell back to HEAD, discarding the pin)
- **Surface ref in CLI output** — `lola mod info` shows `Ref:` under Source; `lola search` shows a conditional `Ref` column for pinned local modules; `lola list` shows `version` and `ref` when set from marketplace metadata; marketplace listing shows a `Ref` column when any entry is pinned
- **Validate `ref` in marketplace YAML** — `Marketplace.validate()` rejects empty strings and refs containing control characters
- **Revert `--ref` from `lola market add`** — ref for marketplace catalogs is defined in the catalog YAML itself, not at registration time

## Related Issues

Fixes #180

## Test Plan

- [ ] `pytest` — 1064 tests pass
- [ ] `ruff check src tests` — no issues
- [ ] `ty check` — no issues
- [ ] `lola mod add <repo> --ref <sha>` → `lola mod info` shows `Ref:` under Source
- [ ] `lola mod update <name>` re-fetches at the pinned ref, not HEAD
- [ ] `lola search <query> --mod` shows `ref:` for pinned local modules
- [ ] `lola install <module>` from marketplace → `lola list` shows `version` and `ref`
- [ ] `lola install module@v1.0.0` overrides the marketplace-defined ref
- [ ] Existing `installed.yml` without `ref` key loads without error (backward compat)

## Checklist

- [x] Tests pass (`pytest`)
- [x] Linting passes (`ruff check src tests`)
- [x] Type checking passes (`ty check`)

## AI Disclosure

AI-assisted with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `lola install` now supports pinning Git revisions via `@ref` for both direct and marketplace installs, including overriding marketplace-pinned refs.
  * `lola mod add --ref` and `lola mod info` now capture and display stored ref details; `lola mod update` replays pinned refs.
  * Marketplace search and marketplace listing now conditionally show a **Ref** column when available.
* **Bug Fixes**
  * Install and update now consistently persist and display both resolved `version` and `ref`, with backward-compatible handling of older installs.
* **Documentation**
  * Expanded CLI reference and guides for marketplace installs, module pinning, and reproducible Git-based workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->