### PR TITLE
feat: support lola.yml module config

### DIFF
--- a/docs/guides/install-hooks.md
+++ b/docs/guides/install-hooks.md
@@ -9,7 +9,7 @@ Execute custom scripts before or after module installation for setup, validation
 
 ## Configuration
 
-**Module metadata** (`lola.yaml` or `module/lola.yaml`):
+**Module metadata** (`lola.yaml` or `lola.yml`, at the module root or in `module/`):
 
 ```yaml
 hooks:
@@ -75,7 +75,7 @@ exit 0
 ## Precedence
 
 1. **CLI flags** - highest priority
-2. **Module metadata** (`lola.yaml`)
+2. **Module metadata** (`lola.yaml`, or `lola.yml` when `.yaml` is absent)
 3. **Marketplace definition** - lowest priority
 
 ## Error Handling

--- a/src/lola/models.py
+++ b/src/lola/models.py
@@ -240,6 +240,8 @@ class Module:
         pre_install_hook = None
         post_install_hook = None
         lola_yaml = content_path / "lola.yaml"
+        if not lola_yaml.exists():
+            lola_yaml = content_path / "lola.yml"
         if lola_yaml.exists():
             try:
                 with open(lola_yaml) as f:

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,5 +1,7 @@
 """Tests for Module model including hook discovery."""
 
+import pytest
+
 from lola.models import Module
 
 VALID_SKILL_MD = """---
@@ -10,13 +12,14 @@ description: Test skill
 """
 
 
-def test_module_with_lola_yaml_hooks(tmp_path):
-    """Test that hooks are discovered from lola.yaml."""
+@pytest.mark.parametrize("config_filename", ["lola.yaml", "lola.yml"])
+def test_module_with_lola_yaml_hooks(tmp_path, config_filename):
+    """Test that hooks are discovered from both supported config filenames."""
     module_dir = tmp_path / "test-module"
     module_dir.mkdir()
 
-    # Create lola.yaml with hooks
-    lola_yaml = module_dir / "lola.yaml"
+    # Create module config with hooks
+    lola_yaml = module_dir / config_filename
     lola_yaml.write_text(
         """hooks:
   pre-install: scripts/pre.sh
@@ -34,6 +37,19 @@ def test_module_with_lola_yaml_hooks(tmp_path):
     assert module is not None
     assert module.pre_install_hook == "scripts/pre.sh"
     assert module.post_install_hook == "scripts/post.sh"
+
+
+def test_lola_yaml_takes_precedence_over_lola_yml(tmp_path):
+    """Keep lola.yaml as the canonical config when both files exist."""
+    module_dir = tmp_path / "test-module"
+    module_dir.mkdir()
+    (module_dir / "AGENTS.md").write_text("# Test module")
+    (module_dir / "lola.yaml").write_text("hooks:\n  pre-install: scripts/yaml.sh\n")
+    (module_dir / "lola.yml").write_text("hooks:\n  pre-install: scripts/yml.sh\n")
+
+    module = Module.from_path(module_dir)
+    assert module is not None
+    assert module.pre_install_hook == "scripts/yaml.sh"
 
 
 def test_module_without_lola_yaml(tmp_path):


### PR DESCRIPTION
## Summary

- load module hooks from `lola.yml` when `lola.yaml` is absent
- preserve `lola.yaml` precedence when both files exist
- document and test both supported filenames

## Related Issues

Fixes #41

## Test Plan

- [x] `uv run pytest -q` (1,036 passed)
- [x] `uv run ruff check src tests`
- [x] `uv run ruff format --check src tests`
- [x] `uv run ty check`
- [x] `uv run mypy src`

## Checklist

- [x] Tests pass (`pytest`)
- [x] Linting passes (`ruff check src tests`)
- [x] Type checking passes (`ty check`)

## AI Disclosure

AI-assisted with OpenAI Codex. I reviewed the focused diff and ran the full local test, lint, formatting, and type-check gates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Module hook configuration now supports both `lola.yaml` and `lola.yml`.
  * When both files exist, `lola.yaml` takes precedence.

* **Documentation**
  * Clarified supported configuration locations and precedence rules for module metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->