### PR TITLE
docs(adr): ComplyTime-style go-plugin provider architecture (alt to #110)

### DIFF
--- a/docs/adr/provider-architecture.md
+++ b/docs/adr/provider-architecture.md
@@ -1,0 +1,153 @@
+# ADR: Provider Architecture
+
+**Status**: Proposed
+**Date**: 2026-07-14
+**Last Updated**: 2026-07-14
+**Authors**: SecKatie
+**Reviewers**:
+
+## Context
+
+Lola's current Python implementation has hardcoded registries for assistant targets
+(`TARGETS` dict in `targets/__init__.py`) and source handlers (`SOURCE_HANDLERS` list
+in `parsers.py`). Adding support for a new AI assistant or module source type requires
+modifying the core codebase.
+
+As the AI assistant ecosystem grows — new assistants, agent frameworks, skill
+registries, and security scanning needs emerging regularly — this hardcoded approach
+does not scale. We need a provider system that allows any developer to add support
+for new capabilities without forking or modifying the Lola core binary.
+
+This ADR is an **alternative** to the extension architecture proposed in
+[PR #110](https://github.com/LobsterTrap/lola/pull/110) (YAML manifests and a
+language-agnostic stdin/stdout protocol, with gRPC deferred). Both share the same
+goal — pluggable targets/sources without forking core — but disagree on the host
+transport. This document proposes adopting the ComplyTime-style
+[hashicorp/go-plugin](https://github.com/hashicorp/go-plugin) model from the start.
+The team should pick one direction; these PRs are not meant to merge together.
+
+## Decision
+
+Introduce a ComplyTime-style **host / provider** architecture for Lola:
+
+- The `lola` binary is the **host**: it discovers providers, launches them, and
+  orchestrates CLI flows (for example `lola install -a <target>`).
+- Capabilities are **providers**: standalone binaries that speak gRPC through
+  `hashicorp/go-plugin`.
+- **All providers are external**, including shipped defaults. There is no special
+  compiled-in path that contributors cannot copy.
+- Default target and source providers live in this repository under `providers/`
+  and are installed into `~/.lola/providers/` (via `LOLA_HOME`). A separate
+  community provider repository may be adopted later; discovery still uses the
+  same local directory.
+
+**Provider kinds (v1 and later):**
+
+| Kind | What it provides | v1 |
+|------|------------------|----|
+| `target` | Where skills are installed (assistant file formats and paths) | yes |
+| `source` | How skills are fetched (transport protocols) | yes |
+| `repo` | Where skills are discovered (catalogs and registries) | later |
+| `runtime` | Where skills are executed (agent framework environments) | later |
+| `scan` | How skills are validated (security scanning) | later |
+
+**Conventions:**
+
+- Binary name: `lola-provider-<name>` (for example `lola-provider-cursor`,
+  `lola-provider-git`); CLI id is the `<name>` suffix (e.g. `-a cursor`)
+- Kind comes from the provider's `Describe` RPC (not the filename or manifest);
+  CLI id is only the binary name suffix
+- Sidecar manifest: YAML (`.yml` or `.yaml`) next to the binary under
+  `~/.lola/providers/`
+- Defaults and docs are **Go-first**. The gRPC contract can be language-agnostic;
+  see the design doc for pointers to other `go-plugin` ecosystems.
+
+Detailed discovery rules, RPC shapes, install flow, error handling, and testing
+are in the paired design document. New kinds extend the same pattern: add a
+typed interface, teach the host to select that kind from `Describe`, and ship or
+document providers that implement it.
+
+## Rationale
+
+- **ComplyTime alignment**: Same subprocess + `go-plugin` + gRPC model used by
+  `complyctl` providers — battle-tested and familiar to contributors in that
+  ecosystem
+- **Process isolation**: A panic or bug in a provider cannot crash the Lola host
+- **Contributor model**: Shipped defaults are real providers under `providers/`,
+  so adding `lola-provider-new-assistant` is copy-modify-install
+- **Forward-compatible**: New kinds reuse discovery and launch; only interfaces
+  and host call sites grow
+- **Go-first, not Go-only**: Defaults are Go; gRPC leaves the door open for other
+  languages without a second plugin system
+
+## Consequences
+
+### Positive Consequences
+
+- Community can add assistants and sources without forking Lola
+- `lola install -a <id>` resolves to a discovered target provider that performs
+  the assistant-specific file writes (including managed-section edits)
+- Built-in and third-party providers share one contract
+- Host stays focused on CLI, registry, and orchestration
+
+### Negative Consequences
+
+- Subprocess and handshake overhead versus in-process code
+- `hashicorp/go-plugin` (and protobuf/gRPC) are intentional dependency exceptions
+  to the Go migration ADR's stdlib-first preference
+- Protocol/version skew must be handled with clear user errors
+- Provider inventory requires launching binaries for `Describe` (acceptable at
+  expected small scale; no cache required initially)
+
+## Alternatives Considered
+
+### Alternative 1: Hardcoded handlers only
+- Description: Continue adding targets and sources directly in the core binary
+- Pros: Simple; no provider infrastructure
+- Cons: Every new assistant needs a core release; community cannot contribute
+  independently
+- Reason for rejection: Does not scale with the AI assistant ecosystem
+
+### Alternative 2: Shared library plugins (`plugin` stdlib / `.so`)
+- Description: Load providers as in-process Go shared libraries from a directory
+- Pros: No subprocess overhead; feels like normal Go interfaces
+- Cons: Go-only; fragile across Go versions and platforms; weaker isolation
+  (provider panic can take down the host)
+- Reason for rejection: Isolation and a clear external contributor model matter
+  more than in-process performance for Lola
+
+### Alternative 3: Custom stdin/stdout JSON protocol ([PR #110](https://github.com/LobsterTrap/lola/pull/110))
+- Description: Language-agnostic subprocess protocol with YAML manifests;
+  gRPC deferred. Proposed as ADR “Extension Architecture” in #110.
+- Pros: Minimal dependencies; easy bash/Python hello-worlds; smaller initial stack
+- Cons: Reimplements versioning, logging, and handshake; diverges from ComplyTime
+- Why this ADR prefers go-plugin: Align with ComplyTime/`hashicorp/go-plugin`
+  instead of a bespoke protocol — open for discussion with #110’s authors
+
+### Alternative 4: Kind encoded in binary name or manifest
+- Description: `lola-target-provider-<name>` and/or `kind:` in the YAML manifest
+- Pros: Kind visible without launching; cheap filtering
+- Cons: Duplicates what `Describe` already returns; drift between name and reality
+- Reason for rejection: Single source of truth for kind is `Describe`; names stay
+  simple (`lola-provider-<name>`)
+
+## Implementation Notes
+
+- Prerequisite: [ADR: Go Migration](go-migration.md)
+- Paired design: [Provider Architecture design](../dev-guide/design/provider-architecture.md)
+- v1 implements `target` and `source` providers only; `repo`, `runtime`, and
+  `scan` are explicitly reserved for the same host/provider pattern
+- Default providers in `providers/` replace in-process `TARGETS` /
+  `SOURCE_HANDLERS` as the Go port lands
+
+## References
+
+- [ADR: Go Migration](go-migration.md)
+- [Provider Architecture design](../dev-guide/design/provider-architecture.md)
+- [hashicorp/go-plugin](https://github.com/hashicorp/go-plugin)
+- [ComplyTime provider guide](https://complytime.dev/docs/projects/complytime-providers/provider-guide/)
+- [complyctl](https://github.com/complytime/complyctl) / [complytime-providers](https://github.com/complytime/complytime-providers)
+- [Current Architecture](../dev-guide/architecture.md) — existing SourceHandler
+  strategy pattern that providers generalize
+- Alternative proposal: [LobsterTrap/lola#110](https://github.com/LobsterTrap/lola/pull/110)
+  (extension architecture / stdin-stdout protocol)

--- a/docs/adr/provider-architecture.md
+++ b/docs/adr/provider-architecture.md
@@ -145,6 +145,13 @@ typed interface, teach the host to select that kind (and CLI id) from
 - Default providers in `providers/` replace in-process `TARGETS` /
   `SOURCE_HANDLERS` as the Go port lands
 
+## Stretch Goals
+
+- **Provider filesystem sandbox**: v1 relies on a contract that providers only
+  write under host-supplied roots. A later hardening step may enforce that
+  boundary with [nono-go](https://github.com/nolabs-ai/nono-go) (kernel
+  Landlock / Seatbelt). Mechanism (host-wrap vs SDK `Apply`) is left open.
+
 ## References
 
 - [ADR: Go Migration](go-migration.md)
@@ -152,6 +159,8 @@ typed interface, teach the host to select that kind (and CLI id) from
 - [hashicorp/go-plugin](https://github.com/hashicorp/go-plugin)
 - [ComplyTime provider guide](https://complytime.dev/docs/projects/complytime-providers/provider-guide/)
 - [complyctl](https://github.com/complytime/complyctl) / [complytime-providers](https://github.com/complytime/complytime-providers)
+- [nono-go](https://github.com/nolabs-ai/nono-go) — candidate for later
+  provider path sandboxing
 - [Current Architecture](../dev-guide/architecture.md) — existing SourceHandler
   strategy pattern that providers generalize
 - Alternative proposal: [LobsterTrap/lola#110](https://github.com/LobsterTrap/lola/pull/110)

--- a/docs/adr/provider-architecture.md
+++ b/docs/adr/provider-architecture.md
@@ -54,18 +54,21 @@ Introduce a ComplyTime-style **host / provider** architecture for Lola:
 **Conventions:**
 
 - Binary name: `lola-provider-<name>` (for example `lola-provider-cursor`,
-  `lola-provider-git`); CLI id is the `<name>` suffix (e.g. `-a cursor`)
-- Kind comes from the provider's `Describe` RPC (not the filename or manifest);
-  CLI id is only the binary name suffix
-- Sidecar manifest: YAML (`.yml` or `.yaml`) next to the binary under
-  `~/.lola/providers/`
+  `lola-provider-git`; on Windows, `lola-provider-cursor.exe`)
+- CLI id and kind both come from the provider's `Describe` RPC (not the
+  filename or manifest). Example: `Describe.id == "cursor"` for `-a cursor`.
+  Binary naming is a packaging convention only; discovery must tolerate
+  platform executable suffixes (e.g. `.exe`) when matching files.
+- Sidecar manifest: YAML (`.yml` or `.yaml`) under `~/.lola/providers/`;
+  discovery scans manifests and resolves each `executablePath` (platform
+  executable suffixes such as `.exe` allowed)
 - Defaults and docs are **Go-first**. The gRPC contract can be language-agnostic;
   see the design doc for pointers to other `go-plugin` ecosystems.
 
 Detailed discovery rules, RPC shapes, install flow, error handling, and testing
 are in the paired design document. New kinds extend the same pattern: add a
-typed interface, teach the host to select that kind from `Describe`, and ship or
-document providers that implement it.
+typed interface, teach the host to select that kind (and CLI id) from
+`Describe`, and ship or document providers that implement it.
 
 ## Rationale
 
@@ -124,12 +127,14 @@ document providers that implement it.
 - Why this ADR prefers go-plugin: Align with ComplyTime/`hashicorp/go-plugin`
   instead of a bespoke protocol — open for discussion with #110’s authors
 
-### Alternative 4: Kind encoded in binary name or manifest
-- Description: `lola-target-provider-<name>` and/or `kind:` in the YAML manifest
-- Pros: Kind visible without launching; cheap filtering
-- Cons: Duplicates what `Describe` already returns; drift between name and reality
-- Reason for rejection: Single source of truth for kind is `Describe`; names stay
-  simple (`lola-provider-<name>`)
+### Alternative 4: Kind or CLI id encoded in binary name or manifest
+- Description: `lola-target-provider-<name>`, CLI id as binary-name suffix, and/or
+  `kind:` / `id:` in the YAML manifest
+- Pros: Kind/id visible without launching; cheap filtering
+- Cons: Duplicates what `Describe` already returns; drift between name and
+  reality; binary-suffix ids break on Windows (`.exe` becomes part of the id)
+- Reason for rejection: Single source of truth for kind and CLI id is `Describe`;
+  names stay simple (`lola-provider-<name>`)
 
 ## Implementation Notes
 

--- a/docs/dev-guide/design/provider-architecture.md
+++ b/docs/dev-guide/design/provider-architecture.md
@@ -39,15 +39,15 @@ lists and release packaging to implementation.
 
 **Host responsibilities**
 
-- Discover binaries and manifests under `~/.lola/providers/`
-- Launch providers with `hashicorp/go-plugin`
+- Discover manifests under `~/.lola/providers/`, resolve their binaries, and
+  launch providers with `hashicorp/go-plugin`
 - Call `Describe` and kind-specific RPCs
 - Pass explicit filesystem roots in requests
 - Update the installation registry (`installed.yml`) from successful results
 
 **Provider responsibilities**
 
-- Implement `Describe` (reports `kind`, version, health, capabilities)
+- Implement `Describe` (reports `id`, `kind`, version, health, capabilities)
 - Perform kind-specific work, including **all filesystem writes** for that work
 - Stay within the roots passed by the host
 
@@ -55,14 +55,16 @@ lists and release packaging to implementation.
 
 | Item | Convention |
 |------|------------|
-| Binary | `lola-provider-<name>` |
+| Binary | `lola-provider-<name>` (Windows: `lola-provider-<name>.exe`) |
 | Manifest | `lola-provider-<name>.yml` **or** `.yaml` (not both) |
 | Install dir | `$LOLA_HOME/providers/` (default `~/.lola/providers/`) |
-| CLI id | Binary name suffix (e.g. `lola-provider-cursor` → `-a cursor`) |
-| Kind | From `Describe` only |
+| CLI id | From `Describe.id` (e.g. `"cursor"` → `-a cursor`) |
+| Kind | From `Describe.kind` only |
 
-Identity for CLI selection comes from the binary name (and matching
-`executablePath` in the manifest). `Describe` does not carry a separate `id`.
+Identity for CLI selection comes from `Describe.id`. The binary name is only a
+packaging convention; it need not equal the CLI id. Discovery starts from
+sidecar manifests; each manifest's `executablePath` must resolve to an
+on-disk binary next to it (platform suffix allowed).
 
 ### Manifest (YAML)
 
@@ -77,17 +79,26 @@ configuration: []
 
 ### Discovery algorithm
 
-1. Scan `$LOLA_HOME/providers/` for executables named `lola-provider-*`
-2. Require a matching sidecar manifest (`.yml` or `.yaml`)
-3. If both `.yml` and `.yaml` exist for the same binary → reject with error
-4. Reject if `executablePath` does not match the binary filename
-5. When `sha256` is set, verify before launch; mismatch → reject
-6. Launch and call `Describe` when the host needs kind / health / version
+1. Scan `$LOLA_HOME/providers/` for manifests named `lola-provider-*.yml` or
+   `lola-provider-*.yaml`
+2. If both `.yml` and `.yaml` exist for the same stem (e.g.
+   `lola-provider-cursor`) → reject with error
+3. Resolve `executablePath` to a binary beside the manifest (accept platform
+   suffixes, e.g. `lola-provider-cursor` → `lola-provider-cursor.exe` on
+   Windows); missing/non-executable → reject
+4. When `sha256` is set, verify before launch; mismatch → reject
+5. Launch and call `Describe` to obtain `id`, `kind`, health, and version
+6. Reject providers with empty `Describe.id`, or duplicate `id` values among
+   discovered providers
+
+Orphan binaries (no matching manifest) are ignored. The manifest is the
+registration record; the binary is what it points at.
 
 `Describe` is cheap once connected; cost is process spawn + go-plugin handshake
 (typically tens of milliseconds per provider on a laptop). At small provider
-counts, launch-on-demand without a cache is fine. Hot paths should launch only
-the providers they need (e.g. one target for `-a`, relevant sources for fetch).
+counts, launch-on-demand without a cache is fine. Resolving `-a <id>` and
+listing targets requires `Describe` (or a prior inventory pass) so the host
+knows each provider's `id` and `kind`.
 
 ## Provider kinds
 
@@ -95,7 +106,8 @@ the providers they need (e.g. one target for `-a`, relevant sources for fetch).
 
 Shared:
 
-- `Describe(ctx) → { kind, version, healthy, capabilities, config schema }`
+- `Describe(ctx) → { id, kind, version, healthy, capabilities, config schema }`  
+  `id` is the stable CLI selector (e.g. `cursor` for `-a cursor`).
 
 **SourceProvider** — fetch / materialize modules:
 
@@ -131,7 +143,8 @@ When a feature needs a new kind (e.g. `repo`, `runtime`, `scan`):
 1. Resolve module identity (local registry / repo config)
 2. If content is not local, select a `source` provider and call `Fetch` into
    `$LOLA_HOME/modules/`
-3. Resolve `-a cursor` to `lola-provider-cursor` with `Describe.kind == target`
+3. Resolve `-a cursor` to the provider whose `Describe.id == "cursor"` and
+   `Describe.kind == target`
 4. Call `Install` with module path and scope roots
 5. On success, host records the installation in `installed.yml`
 
@@ -178,12 +191,14 @@ internal split.
 
 | Case | Behavior |
 |------|----------|
-| Missing/unreadable manifest | Skip provider; warn |
-| Both `.yml` and `.yaml` | Reject that provider; error |
+| Unreadable / invalid manifest | Skip provider; warn |
+| Both `.yml` and `.yaml` for same stem | Reject that provider; error |
+| `executablePath` missing / not executable | Reject provider; error |
 | sha256 mismatch | Do not launch; error |
 | Spawn / `Describe` failure | Unhealthy; exclude from selection |
+| Empty or duplicate `Describe.id` | Reject provider; error |
 | Unknown `-a` id | Error; list known target ids |
-| `executablePath` ≠ binary filename | Reject provider |
+| Orphan binary (no manifest) | Ignore |
 | No source provider for URI | Error with install/add hint |
 | RPC / provider failure | Fail the CLI command; surface provider message |
 | Partial writes | No host-invented rollback; providers should be idempotent; `Uninstall` is recovery |
@@ -196,8 +211,8 @@ enforcement can be added later.
 
 **Host**
 
-- Unit: discovery, manifest parse, sha256 reject, dual-extension conflict,
-  duplicate ids
+- Unit: discovery (manifest-first), manifest parse, sha256 reject, dual-extension
+  conflict, missing binary, duplicate ids
 - Integration: test provider binaries implementing go-plugin + minimal RPCs
 - CLI: temp `LOLA_HOME` + project dir through `install` / `uninstall`
 

--- a/docs/dev-guide/design/provider-architecture.md
+++ b/docs/dev-guide/design/provider-architecture.md
@@ -205,7 +205,8 @@ internal split.
 | Protocol version mismatch | Human-readable too old/new error |
 
 Providers must not write outside host-supplied roots (contract). Stronger
-enforcement can be added later.
+enforcement can be added later; [nono-go](https://github.com/nolabs-ai/nono-go)
+is a candidate (mechanism TBD).
 
 ## Testing
 

--- a/docs/dev-guide/design/provider-architecture.md
+++ b/docs/dev-guide/design/provider-architecture.md
@@ -1,0 +1,221 @@
+# Provider Architecture — Design
+
+Paired with [ADR: Provider Architecture](../../adr/provider-architecture.md).
+
+This document records the host/provider layout agreed for the Go port. It is
+intentionally more detailed than the ADR while still leaving protobuf field
+lists and release packaging to implementation.
+
+## Goals
+
+- Let contributors add a new assistant or fetch transport by dropping a
+  `lola-provider-<name>` binary (plus YAML manifest) into `~/.lola/providers/`
+- Make `lola install <module> -a <target-id>` resolve that target provider and
+  have **the provider** write assistant files (including managed-section edits)
+- Ship every default target and source as a real external provider under
+  in-repo `providers/` so defaults are the contributor template
+- Start with `target` + `source`; extend the same pattern for `repo`, `runtime`,
+  and `scan` later
+
+## Non-goals (for this design)
+
+- Community provider repository layout (decide later)
+- Describe-result caching (not needed at expected scale)
+- Non-Go provider SDKs (document possibility only)
+- Full protobuf schemas (defined when `pkg/provider` is implemented)
+
+## Architecture
+
+```text
+┌───────────┐   discover / launch / orchestrate    ┌──────────────────────┐
+│ lola host │ ───────────────────────────────────► │ lola-provider-<name> │
+│           │ ◄── gRPC via hashicorp/go-plugin ─── │  (target | source)   │
+└───────────┘                                      └──────────────────────┘
+      │                                                       │
+      │ installed.yml, CLI                                    │ writes under
+      ▼                                                       ▼
+ ~/.lola/                                     modules / project / user roots
+```
+
+**Host responsibilities**
+
+- Discover binaries and manifests under `~/.lola/providers/`
+- Launch providers with `hashicorp/go-plugin`
+- Call `Describe` and kind-specific RPCs
+- Pass explicit filesystem roots in requests
+- Update the installation registry (`installed.yml`) from successful results
+
+**Provider responsibilities**
+
+- Implement `Describe` (reports `kind`, version, health, capabilities)
+- Perform kind-specific work, including **all filesystem writes** for that work
+- Stay within the roots passed by the host
+
+## Naming and discovery
+
+| Item | Convention |
+|------|------------|
+| Binary | `lola-provider-<name>` |
+| Manifest | `lola-provider-<name>.yml` **or** `.yaml` (not both) |
+| Install dir | `$LOLA_HOME/providers/` (default `~/.lola/providers/`) |
+| CLI id | Binary name suffix (e.g. `lola-provider-cursor` → `-a cursor`) |
+| Kind | From `Describe` only |
+
+Identity for CLI selection comes from the binary name (and matching
+`executablePath` in the manifest). `Describe` does not carry a separate `id`.
+
+### Manifest (YAML)
+
+```yaml
+metadata:
+  description: Cursor assistant target
+  version: 0.1.0
+executablePath: lola-provider-cursor
+sha256: "<sha256-of-binary>"
+configuration: []
+```
+
+### Discovery algorithm
+
+1. Scan `$LOLA_HOME/providers/` for executables named `lola-provider-*`
+2. Require a matching sidecar manifest (`.yml` or `.yaml`)
+3. If both `.yml` and `.yaml` exist for the same binary → reject with error
+4. Reject if `executablePath` does not match the binary filename
+5. When `sha256` is set, verify before launch; mismatch → reject
+6. Launch and call `Describe` when the host needs kind / health / version
+
+`Describe` is cheap once connected; cost is process spawn + go-plugin handshake
+(typically tens of milliseconds per provider on a laptop). At small provider
+counts, launch-on-demand without a cache is fine. Hot paths should launch only
+the providers they need (e.g. one target for `-a`, relevant sources for fetch).
+
+## Provider kinds
+
+### v1: `target` and `source`
+
+Shared:
+
+- `Describe(ctx) → { kind, version, healthy, capabilities, config schema }`
+
+**SourceProvider** — fetch / materialize modules:
+
+- `Fetch(ctx, req) → result`  
+  Host passes source URI/ref and a destination under `$LOLA_HOME/modules/`
+  (default `~/.lola/modules/<module-name>`). Provider writes the module tree
+  there.
+
+**TargetProvider** — install / uninstall assistant files:
+
+- `Install(ctx, req) → result`  
+  Host passes module path, project/user roots, selection, scope. Provider
+  writes assistant files however that target requires.
+- `Uninstall(ctx, req) → result`  
+  Provider removes or reverts what it owns under the given roots.
+
+`Update` may reuse `Install` (replace) in v1; a dedicated RPC can be added later
+if needed.
+
+### Extending with new kinds
+
+When a feature needs a new kind (e.g. `repo`, `runtime`, `scan`):
+
+1. Add a typed Go interface + gRPC service for that kind
+2. Teach the host to filter providers whose `Describe.kind` matches
+3. Add default and/or community providers named `lola-provider-<name>`
+4. No change to discovery directory, manifest shape, or go-plugin lifecycle
+
+## Install flow
+
+`lola install <module> -a cursor`:
+
+1. Resolve module identity (local registry / repo config)
+2. If content is not local, select a `source` provider and call `Fetch` into
+   `$LOLA_HOME/modules/`
+3. Resolve `-a cursor` to `lola-provider-cursor` with `Describe.kind == target`
+4. Call `Install` with module path and scope roots
+5. On success, host records the installation in `installed.yml`
+
+Uninstall mirrors step 3–4 with `Uninstall`, then updates the registry.
+
+## Repository layout
+
+```text
+providers/
+  target/
+    claude-code/       # builds lola-provider-claude-code
+    cursor/
+    gemini-cli/
+    openclaw/
+    opencode/
+    …
+  source/
+    git/               # builds lola-provider-git
+    zip/
+    tar/
+    folder/
+    …
+pkg/provider/          # public SDK: Serve(), interfaces, protos, client helpers
+internal/provider/     # host discovery, launch, orchestration
+```
+
+All shipped built-in targets and sources are real providers under `providers/`.
+That tree is the contributor model.
+
+Package names may adjust with the Go scaffold; keep the public SDK vs host
+internal split.
+
+## Authoring language
+
+- Shipped defaults and documentation examples are **Go**
+- Providers call something like `provider.Serve(impl)` in `main` (ComplyTime-shaped)
+- The wire protocol is gRPC, so other languages are possible in principle
+- Point authors at existing go-plugin ecosystems for non-Go patterns:
+  - [hashicorp/go-plugin](https://github.com/hashicorp/go-plugin) (examples, gRPC)
+  - [ComplyTime providers](https://github.com/complytime/complytime-providers)
+  - HashiCorp tools that embed go-plugin (Terraform/Vault provider model)
+
+## Error handling
+
+| Case | Behavior |
+|------|----------|
+| Missing/unreadable manifest | Skip provider; warn |
+| Both `.yml` and `.yaml` | Reject that provider; error |
+| sha256 mismatch | Do not launch; error |
+| Spawn / `Describe` failure | Unhealthy; exclude from selection |
+| Unknown `-a` id | Error; list known target ids |
+| `executablePath` ≠ binary filename | Reject provider |
+| No source provider for URI | Error with install/add hint |
+| RPC / provider failure | Fail the CLI command; surface provider message |
+| Partial writes | No host-invented rollback; providers should be idempotent; `Uninstall` is recovery |
+| Protocol version mismatch | Human-readable too old/new error |
+
+Providers must not write outside host-supplied roots (contract). Stronger
+enforcement can be added later.
+
+## Testing
+
+**Host**
+
+- Unit: discovery, manifest parse, sha256 reject, dual-extension conflict,
+  duplicate ids
+- Integration: test provider binaries implementing go-plugin + minimal RPCs
+- CLI: temp `LOLA_HOME` + project dir through `install` / `uninstall`
+
+**Default providers**
+
+- Table-driven / golden tests per target and source under temp roots
+- One e2e path using a ship-like `~/.lola/providers/` layout
+
+## Relationship to Go migration
+
+Adding `hashicorp/go-plugin` (and protobuf/gRPC as required by that stack) is an
+intentional exception to the Go migration ADR's stdlib-first dependency rule.
+The value is ComplyTime alignment, isolation, and a single contributor-facing
+provider model.
+
+## Open implementation items
+
+- Exact protobuf messages and go-plugin handshake / protocol version numbers
+- How releases copy `providers/` build artifacts into user `~/.lola/providers/`
+- Whether `configuration` in manifests drives interactive prompts in v1
+- Community provider distribution (separate repo vs only local drop-in)


### PR DESCRIPTION
## Summary
- Proposes an **alternative** to [#110](https://github.com/LobsterTrap/lola/pull/110)’s extension ADR: ComplyTime-shaped host/providers via [`hashicorp/go-plugin`](https://github.com/hashicorp/go-plugin) instead of a custom stdin/stdout protocol
- Keeps the same kind taxonomy intent (`target` + `source` in v1; `repo` / `runtime` / `scan` later) with external-only providers and shipped defaults under `providers/`
- Paired design doc covers discovery (`lola-provider-<name>` + YAML manifest), `Describe`/RPCs, install flow, and provider-owned filesystem writes

These two PRs are competing designs for the same problem. I made this to propose an alternative.

cc @mrbrandao — would love your thoughts on this alternative vs #110.

## Test plan
- [ ] Read [`docs/adr/provider-architecture.md`](docs/adr/provider-architecture.md) against #110’s ADR and compare trade-offs (go-plugin vs stdin/stdout; dependency cost vs ComplyTime alignment)
- [ ] Skim [`docs/dev-guide/design/provider-architecture.md`](docs/dev-guide/design/provider-architecture.md) for discovery/RPC/install-flow consistency
- [ ] Confirm ADR stays short (intent + alternatives) with details in the design doc


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Added an architecture decision record outlining Lola’s host/provider plugin model, including default provider behavior and supported provider “kinds.”
  * Added a provider architecture design guide covering manifest discovery/validation, provider responsibilities, installation/uninstallation orchestration, error handling, and testing expectations.
  * Documented planned provider API direction, intended repository layout, packaging considerations, and open implementation items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->