### PR TITLE
fix: use UTF-8 encodings for module file read/write on Windows

### DIFF
--- a/src/lola/cli/install.py
+++ b/src/lola/cli/install.py
@@ -613,7 +613,7 @@ def _update_mcps(ctx: UpdateContext, verbose: bool) -> tuple[int, int]:
         return 0, len(ctx.global_module.mcps)
 
     try:
-        mcps_data = json.loads(mcps_file.read_text())
+        mcps_data = json.loads(mcps_file.read_text(encoding="utf-8-sig"))
         servers = mcps_data.get("mcpServers", {})
     except json.JSONDecodeError:
         return 0, len(ctx.global_module.mcps)

--- a/src/lola/cli/mod.py
+++ b/src/lola/cli/mod.py
@@ -1036,7 +1036,9 @@ def module_info(module_name_or_path: str | None):
         mcps_data = {}
         if mcps_file.exists():
             try:
-                mcps_data = json.loads(mcps_file.read_text(encoding="utf-8-sig")).get("mcpServers", {})
+                mcps_data = json.loads(mcps_file.read_text(encoding="utf-8-sig")).get(
+                    "mcpServers", {}
+                )
             except (json.JSONDecodeError, OSError):
                 pass
 

--- a/src/lola/cli/mod.py
+++ b/src/lola/cli/mod.py
@@ -463,7 +463,7 @@ description: [REPLACE: Brief description of what this skill does and when to use
 
 [REPLACE: Tips and guidelines for effective skill usage]
 """
-            (skill_dir / "SKILL.md").write_text(skill_content)
+            (skill_dir / "SKILL.md").write_text(skill_content, encoding="utf-8")
 
     # Create initial command if requested
     if final_command_name:
@@ -494,7 +494,7 @@ Use `$ARGUMENTS` to access any arguments passed to this command.
 
 [REPLACE: Describe what the command should produce or accomplish]
 """
-            command_file.write_text(command_content)
+            command_file.write_text(command_content, encoding="utf-8")
 
     # Create initial agent if requested
     if final_agent_name:
@@ -529,7 +529,7 @@ description: [REPLACE: Brief description of what this agent does and when to del
 1. [REPLACE: Describe the agent's typical workflow]
 2. [REPLACE: Continue as needed]
 """
-            agent_file.write_text(agent_content)
+            agent_file.write_text(agent_content, encoding="utf-8")
 
     # Create mcps.json if not skipped (in module/)
     if not no_mcps:
@@ -554,7 +554,7 @@ description: [REPLACE: Brief description of what this agent does and when to del
   }
 }
 """
-            mcps_file.write_text(mcps_content)
+            mcps_file.write_text(mcps_content, encoding="utf-8")
 
     # Create AGENTS.md if not skipped (in module/)
     if not no_instructions:
@@ -601,7 +601,7 @@ description: [REPLACE: Brief description of what this agent does and when to del
 
 [REPLACE: Additional guidance for AI assistants using this module]
 """
-            agents_md_file.write_text(agents_md_content)
+            agents_md_file.write_text(agents_md_content, encoding="utf-8")
 
     # Create README.md at repo root
     readme_file = repo_dir / "README.md"
@@ -673,7 +673,7 @@ Edit files in `module/` (or `lola-module/`) to customize the content that gets i
 
 [REPLACE: Your license here]
 """
-        readme_file.write_text(readme_content)
+        readme_file.write_text(readme_content, encoding="utf-8")
 
     console.print(f"[green]Initialized module {module_name}[/green]")
     console.print(f"  [dim]Path:[/dim] {repo_dir}")
@@ -1036,7 +1036,7 @@ def module_info(module_name_or_path: str | None):
         mcps_data = {}
         if mcps_file.exists():
             try:
-                mcps_data = json.loads(mcps_file.read_text()).get("mcpServers", {})
+                mcps_data = json.loads(mcps_file.read_text(encoding="utf-8-sig")).get("mcpServers", {})
             except (json.JSONDecodeError, OSError):
                 pass
 

--- a/src/lola/frontmatter.py
+++ b/src/lola/frontmatter.py
@@ -47,7 +47,7 @@ def parse_file(file_path: Path) -> tuple[dict, str]:
     except Exception:
         # If parsing fails, return empty frontmatter and file content
         try:
-            return {}, file_path.read_text()
+            return {}, file_path.read_text(encoding="utf-8-sig")
         except Exception:
             return {}, ""
 
@@ -65,7 +65,7 @@ def validate_command(command_file: Path) -> list[str]:
     errors = []
 
     try:
-        content = command_file.read_text()
+        content = command_file.read_text(encoding="utf-8-sig")
     except Exception as e:
         return [f"Cannot read file: {e}"]
 
@@ -109,7 +109,7 @@ def validate_skill(skill_file: Path) -> list[str]:
     errors = []
 
     try:
-        content = skill_file.read_text()
+        content = skill_file.read_text(encoding="utf-8-sig")
     except Exception as e:
         return [f"Cannot read file: {e}"]
 
@@ -143,7 +143,7 @@ def validate_agent(agent_file: Path) -> list[str]:
     errors = []
 
     try:
-        content = agent_file.read_text()
+        content = agent_file.read_text(encoding="utf-8-sig")
     except Exception as e:
         return [f"Cannot read file: {e}"]
 
@@ -177,7 +177,7 @@ def validate_mcps(mcps_file: Path) -> list[str]:
     errors = []
 
     try:
-        content = mcps_file.read_text()
+        content = mcps_file.read_text(encoding="utf-8-sig")
     except Exception as e:
         return [f"Cannot read file: {e}"]
 

--- a/src/lola/frontmatter.py
+++ b/src/lola/frontmatter.py
@@ -42,14 +42,13 @@ def parse_file(file_path: Path) -> tuple[dict, str]:
         Tuple of (frontmatter dict, body content)
     """
     try:
-        post = frontmatter.load(str(file_path))
-        return dict(post.metadata), post.content
+        # Read with utf-8-sig so a leading BOM is stripped before delimiter
+        # detection. frontmatter.load() leaves the BOM in place and then misses
+        # the --- fence, returning empty metadata without raising.
+        content = file_path.read_text(encoding="utf-8-sig")
     except Exception:
-        # If parsing fails, return empty frontmatter and file content
-        try:
-            return {}, file_path.read_text(encoding="utf-8-sig")
-        except Exception:
-            return {}, ""
+        return {}, ""
+    return parse(content)
 
 
 def validate_command(command_file: Path) -> list[str]:

--- a/src/lola/models.py
+++ b/src/lola/models.py
@@ -231,7 +231,7 @@ class Module:
         mcps_file = content_path / MCPS_FILE
         if mcps_file.exists():
             try:
-                data = json.loads(mcps_file.read_text())
+                data = json.loads(mcps_file.read_text(encoding="utf-8-sig"))
                 mcps = sorted(data.get("mcpServers", {}).keys())
             except (json.JSONDecodeError, OSError):
                 pass

--- a/src/lola/models.py
+++ b/src/lola/models.py
@@ -244,7 +244,7 @@ class Module:
             lola_yaml = content_path / "lola.yml"
         if lola_yaml.exists():
             try:
-                with open(lola_yaml) as f:
+                with open(lola_yaml, encoding="utf-8") as f:
                     config = yaml.safe_load(f) or {}
                 hooks = config.get("hooks", {})
                 pre_install_hook = (

--- a/src/lola/targets/base.py
+++ b/src/lola/targets/base.py
@@ -1028,5 +1028,7 @@ def _remove_mcps_from_file(
     if not existing_config["mcpServers"] and remaining_keys == {"mcpServers"}:
         dest_path.unlink()
     else:
-        dest_path.write_text(json.dumps(existing_config, indent=2) + "\n", encoding="utf-8")
+        dest_path.write_text(
+            json.dumps(existing_config, indent=2) + "\n", encoding="utf-8"
+        )
     return True

--- a/src/lola/targets/base.py
+++ b/src/lola/targets/base.py
@@ -98,7 +98,7 @@ def _resolve_source_content(source: Path | str | list[str]) -> str | None:
     if isinstance(source, Path):
         if not source.exists():
             return None
-        return source.read_text().strip()
+        return source.read_text(encoding="utf-8-sig").strip()
     elif isinstance(source, str):
         return source.strip()
     return None
@@ -529,7 +529,7 @@ to learn the detailed instructions and workflows.
     ) -> bool:
         """Update managed markdown file with skill listings for a module."""
         if dest_file.exists():
-            content = dest_file.read_text()
+            content = dest_file.read_text(encoding="utf-8-sig")
         else:
             dest_file.parent.mkdir(parents=True, exist_ok=True)
             content = ""
@@ -586,7 +586,7 @@ to learn the detailed instructions and workflows.
             lola_section = f"\n\n{self.HEADER}{self.START_MARKER}\n{skills_block}{self.END_MARKER}\n"
             content = content.rstrip() + lola_section
 
-        dest_file.write_text(content)
+        dest_file.write_text(content, encoding="utf-8")
         return True
 
     def remove_skill(self, dest_path: Path, skill_name: str) -> bool:
@@ -598,7 +598,7 @@ to learn the detailed instructions and workflows.
         if not dest_path.exists():
             return True
 
-        content = dest_path.read_text()
+        content = dest_path.read_text(encoding="utf-8-sig")
         if self.START_MARKER not in content or self.END_MARKER not in content:
             return True
 
@@ -625,7 +625,7 @@ to learn the detailed instructions and workflows.
 
         new_section = self.START_MARKER + "\n".join(new_lines) + self.END_MARKER
         content = content[:start_idx] + new_section + content[end_idx:]
-        dest_path.write_text(content)
+        dest_path.write_text(content, encoding="utf-8")
         return True
 
 
@@ -665,7 +665,7 @@ class ManagedInstructionsTarget:
 
         # Read existing file content
         if dest_path.exists():
-            content = dest_path.read_text()
+            content = dest_path.read_text(encoding="utf-8-sig")
         else:
             dest_path.parent.mkdir(parents=True, exist_ok=True)
             content = ""
@@ -723,7 +723,7 @@ class ManagedInstructionsTarget:
             )
             content = content.rstrip() + new_section
 
-        dest_path.write_text(content)
+        dest_path.write_text(content, encoding="utf-8")
         return True
 
     def _extract_module_blocks(self, section_content: str) -> dict[str, str]:
@@ -741,7 +741,7 @@ class ManagedInstructionsTarget:
         if not dest_path.exists():
             return True
 
-        content = dest_path.read_text()
+        content = dest_path.read_text(encoding="utf-8-sig")
         if (
             self.INSTRUCTIONS_START_MARKER not in content
             or self.INSTRUCTIONS_END_MARKER not in content
@@ -784,7 +784,7 @@ class ManagedInstructionsTarget:
             suffix = content[end_idx:]
             content = prefix + suffix
 
-        dest_path.write_text(content)
+        dest_path.write_text(content, encoding="utf-8")
         return True
 
 
@@ -848,8 +848,8 @@ def _generate_passthrough_command(
     if not source_path.exists():
         return False
     dest_dir.mkdir(parents=True, exist_ok=True)
-    content = source_path.read_text()
-    (dest_dir / filename).write_text(content)
+    content = source_path.read_text(encoding="utf-8-sig")
+    (dest_dir / filename).write_text(content, encoding="utf-8")
 
     # Copy co-named sidecar directory (e.g. commands/deploy/ alongside
     # commands/deploy.md).
@@ -881,7 +881,7 @@ def _generate_agent_with_frontmatter(
         return False
     dest_dir.mkdir(parents=True, exist_ok=True)
 
-    content = source_path.read_text()
+    content = source_path.read_text(encoding="utf-8-sig")
     frontmatter, body = fm.parse(content)
     frontmatter.update(frontmatter_additions)
 
@@ -893,7 +893,7 @@ def _generate_agent_with_frontmatter(
     ).rstrip()
     content = f"---\n{frontmatter_str}\n---\n{body}"
 
-    (dest_dir / filename).write_text(content)
+    (dest_dir / filename).write_text(content, encoding="utf-8")
     return True
 
 
@@ -972,7 +972,7 @@ def _merge_mcps_into_file(
     # Read existing config
     if dest_path.exists():
         try:
-            existing_config = json.loads(dest_path.read_text())
+            existing_config = json.loads(dest_path.read_text(encoding="utf-8-sig"))
         except json.JSONDecodeError:
             existing_config = {}
     else:
@@ -988,7 +988,7 @@ def _merge_mcps_into_file(
 
     # Write back
     dest_path.parent.mkdir(parents=True, exist_ok=True)
-    dest_path.write_text(json.dumps(existing_config, indent=2) + "\n")
+    dest_path.write_text(json.dumps(existing_config, indent=2) + "\n", encoding="utf-8")
     return True
 
 
@@ -1013,7 +1013,7 @@ def _remove_mcps_from_file(
         return True
 
     try:
-        existing_config = json.loads(dest_path.read_text())
+        existing_config = json.loads(dest_path.read_text(encoding="utf-8-sig"))
     except json.JSONDecodeError:
         return True
 
@@ -1028,5 +1028,5 @@ def _remove_mcps_from_file(
     if not existing_config["mcpServers"] and remaining_keys == {"mcpServers"}:
         dest_path.unlink()
     else:
-        dest_path.write_text(json.dumps(existing_config, indent=2) + "\n")
+        dest_path.write_text(json.dumps(existing_config, indent=2) + "\n", encoding="utf-8")
     return True

--- a/src/lola/targets/claude_code.py
+++ b/src/lola/targets/claude_code.py
@@ -61,7 +61,7 @@ class ClaudeCodeTarget(MCPSupportMixin, ManagedInstructionsTarget, BaseAssistant
         # Copy SKILL.md
         skill_file = source_path / config.SKILL_FILE
         if skill_file.exists():
-            (skill_dest / "SKILL.md").write_text(skill_file.read_text())
+            (skill_dest / "SKILL.md").write_text(skill_file.read_text(encoding="utf-8-sig"))
 
         # Copy supporting files
         for item in source_path.iterdir():

--- a/src/lola/targets/claude_code.py
+++ b/src/lola/targets/claude_code.py
@@ -61,7 +61,9 @@ class ClaudeCodeTarget(MCPSupportMixin, ManagedInstructionsTarget, BaseAssistant
         # Copy SKILL.md
         skill_file = source_path / config.SKILL_FILE
         if skill_file.exists():
-            (skill_dest / "SKILL.md").write_text(skill_file.read_text(encoding="utf-8-sig"))
+            (skill_dest / "SKILL.md").write_text(
+                skill_file.read_text(encoding="utf-8-sig"), encoding="utf-8"
+            )
 
         # Copy supporting files
         for item in source_path.iterdir():

--- a/src/lola/targets/copilot.py
+++ b/src/lola/targets/copilot.py
@@ -292,7 +292,9 @@ def _remove_mcps_from_vscode_file(
     if not existing_config["servers"] and remaining_keys == {"servers"}:
         dest_path.unlink()
     else:
-        dest_path.write_text(json.dumps(existing_config, indent=2) + "\n", encoding="utf-8")
+        dest_path.write_text(
+            json.dumps(existing_config, indent=2) + "\n", encoding="utf-8"
+        )
     return True
 
 

--- a/src/lola/targets/copilot.py
+++ b/src/lola/targets/copilot.py
@@ -78,7 +78,7 @@ class CopilotCliTarget(MCPSupportMixin, ManagedInstructionsTarget, BaseAssistant
         if not skill_file.exists():
             return False
 
-        content = skill_file.read_text()
+        content = skill_file.read_text(encoding="utf-8-sig")
         frontmatter, body = fm.parse(content)
 
         description = frontmatter.get("description")
@@ -106,7 +106,7 @@ class CopilotCliTarget(MCPSupportMixin, ManagedInstructionsTarget, BaseAssistant
         output = f"---\n{fm_str}\n---\n{body}"
 
         dest_file = skill_dir / "SKILL.md"
-        dest_file.write_text(output)
+        dest_file.write_text(output, encoding="utf-8")
 
         # Copy supporting files (scripts, examples, etc.)
         import shutil
@@ -174,9 +174,9 @@ class CopilotCliTarget(MCPSupportMixin, ManagedInstructionsTarget, BaseAssistant
         dest_dir.mkdir(parents=True, exist_ok=True)
 
         filename = self.get_agent_filename(module_name, agent_name)
-        content = source_path.read_text()
+        content = source_path.read_text(encoding="utf-8-sig")
 
-        (dest_dir / filename).write_text(content)
+        (dest_dir / filename).write_text(content, encoding="utf-8")
         return True
 
     def get_agent_filename(self, module_name: str, agent_name: str) -> str:  # noqa: ARG002
@@ -248,7 +248,7 @@ def _merge_mcps_into_vscode_file(
     """
     if dest_path.exists():
         try:
-            existing_config = json.loads(dest_path.read_text())
+            existing_config = json.loads(dest_path.read_text(encoding="utf-8-sig"))
         except json.JSONDecodeError:
             existing_config = {}
     else:
@@ -261,7 +261,7 @@ def _merge_mcps_into_vscode_file(
         existing_config["servers"][name] = _transform_mcp_to_vscode(server_config)
 
     dest_path.parent.mkdir(parents=True, exist_ok=True)
-    dest_path.write_text(json.dumps(existing_config, indent=2) + "\n")
+    dest_path.write_text(json.dumps(existing_config, indent=2) + "\n", encoding="utf-8")
     return True
 
 
@@ -278,7 +278,7 @@ def _remove_mcps_from_vscode_file(
         return True
 
     try:
-        existing_config = json.loads(dest_path.read_text())
+        existing_config = json.loads(dest_path.read_text(encoding="utf-8-sig"))
     except json.JSONDecodeError:
         return True
 
@@ -292,7 +292,7 @@ def _remove_mcps_from_vscode_file(
     if not existing_config["servers"] and remaining_keys == {"servers"}:
         dest_path.unlink()
     else:
-        dest_path.write_text(json.dumps(existing_config, indent=2) + "\n")
+        dest_path.write_text(json.dumps(existing_config, indent=2) + "\n", encoding="utf-8")
     return True
 
 

--- a/src/lola/targets/cursor.py
+++ b/src/lola/targets/cursor.py
@@ -70,7 +70,7 @@ class CursorTarget(MCPSupportMixin, BaseAssistantTarget):
         if not skill_file.exists():
             return False
 
-        (skill_dest / "SKILL.md").write_text(skill_file.read_text())
+        (skill_dest / "SKILL.md").write_text(skill_file.read_text(encoding="utf-8-sig"))
 
         # Copy supporting files
         for item in source_path.iterdir():
@@ -145,7 +145,7 @@ class CursorTarget(MCPSupportMixin, BaseAssistantTarget):
         ]
 
         mdc_file = dest_path / f"{module_name}-instructions.mdc"
-        mdc_file.write_text("\n".join(mdc_lines))
+        mdc_file.write_text("\n".join(mdc_lines), encoding="utf-8")
         return True
 
     def remove_instructions(self, dest_path: Path, module_name: str) -> bool:

--- a/src/lola/targets/cursor.py
+++ b/src/lola/targets/cursor.py
@@ -70,7 +70,9 @@ class CursorTarget(MCPSupportMixin, BaseAssistantTarget):
         if not skill_file.exists():
             return False
 
-        (skill_dest / "SKILL.md").write_text(skill_file.read_text(encoding="utf-8-sig"))
+        (skill_dest / "SKILL.md").write_text(
+            skill_file.read_text(encoding="utf-8-sig"), encoding="utf-8"
+        )
 
         # Copy supporting files
         for item in source_path.iterdir():

--- a/src/lola/targets/gemini.py
+++ b/src/lola/targets/gemini.py
@@ -52,7 +52,7 @@ class GeminiTarget(MCPSupportMixin, ManagedInstructionsTarget, ManagedSectionTar
             return False
         dest_dir.mkdir(parents=True, exist_ok=True)
 
-        content = source_path.read_text()
+        content = source_path.read_text(encoding="utf-8-sig")
         frontmatter, body = fm.parse(content)
         description = frontmatter.get("description", "")
         prompt = _convert_to_gemini_args(body)
@@ -68,7 +68,7 @@ class GeminiTarget(MCPSupportMixin, ManagedInstructionsTarget, ManagedSectionTar
         ]
 
         filename = self.get_command_filename(module_name, cmd_name)
-        (dest_dir / filename).write_text("\n".join(toml_lines))
+        (dest_dir / filename).write_text("\n".join(toml_lines), encoding="utf-8")
         return True
 
     def get_command_filename(self, module_name: str, cmd_name: str) -> str:  # noqa: ARG002

--- a/src/lola/targets/install.py
+++ b/src/lola/targets/install.py
@@ -542,7 +542,7 @@ def _install_mcps(
         return [], list(module.mcps)
 
     try:
-        mcps_data = json.loads(mcps_file.read_text())
+        mcps_data = json.loads(mcps_file.read_text(encoding="utf-8-sig"))
         servers = mcps_data.get("mcpServers", {})
     except json.JSONDecodeError:
         return [], list(module.mcps)

--- a/src/lola/targets/openclaw.py
+++ b/src/lola/targets/openclaw.py
@@ -70,7 +70,7 @@ class OpenClawTarget(BaseAssistantTarget):
         if not skill_file.exists():
             return False
 
-        (skill_dest / "SKILL.md").write_text(skill_file.read_text())
+        (skill_dest / "SKILL.md").write_text(skill_file.read_text(encoding="utf-8-sig"))
 
         for item in source_path.iterdir():
             if item.name == "SKILL.md":

--- a/src/lola/targets/openclaw.py
+++ b/src/lola/targets/openclaw.py
@@ -70,7 +70,9 @@ class OpenClawTarget(BaseAssistantTarget):
         if not skill_file.exists():
             return False
 
-        (skill_dest / "SKILL.md").write_text(skill_file.read_text(encoding="utf-8-sig"))
+        (skill_dest / "SKILL.md").write_text(
+            skill_file.read_text(encoding="utf-8-sig"), encoding="utf-8"
+        )
 
         for item in source_path.iterdir():
             if item.name == "SKILL.md":

--- a/src/lola/targets/opencode.py
+++ b/src/lola/targets/opencode.py
@@ -208,7 +208,9 @@ def _remove_mcps_from_opencode_file(
     if not existing_config["mcp"] and remaining_keys == {"mcp"}:
         dest_path.unlink()
     else:
-        dest_path.write_text(json.dumps(existing_config, indent=2) + "\n", encoding="utf-8")
+        dest_path.write_text(
+            json.dumps(existing_config, indent=2) + "\n", encoding="utf-8"
+        )
     return True
 
 

--- a/src/lola/targets/opencode.py
+++ b/src/lola/targets/opencode.py
@@ -153,7 +153,7 @@ def _merge_mcps_into_opencode_file(
     # Read existing config
     if dest_path.exists():
         try:
-            existing_config = json.loads(dest_path.read_text())
+            existing_config = json.loads(dest_path.read_text(encoding="utf-8-sig"))
         except json.JSONDecodeError:
             existing_config = {}
     else:
@@ -176,7 +176,7 @@ def _merge_mcps_into_opencode_file(
     # Ensure $schema is first by rebuilding dict
     ordered_config: dict[str, Any] = {"$schema": existing_config.pop("$schema")}
     ordered_config.update(existing_config)
-    dest_path.write_text(json.dumps(ordered_config, indent=2) + "\n")
+    dest_path.write_text(json.dumps(ordered_config, indent=2) + "\n", encoding="utf-8")
     return True
 
 
@@ -193,7 +193,7 @@ def _remove_mcps_from_opencode_file(
         return True
 
     try:
-        existing_config = json.loads(dest_path.read_text())
+        existing_config = json.loads(dest_path.read_text(encoding="utf-8-sig"))
     except json.JSONDecodeError:
         return True
 
@@ -208,7 +208,7 @@ def _remove_mcps_from_opencode_file(
     if not existing_config["mcp"] and remaining_keys == {"mcp"}:
         dest_path.unlink()
     else:
-        dest_path.write_text(json.dumps(existing_config, indent=2) + "\n")
+        dest_path.write_text(json.dumps(existing_config, indent=2) + "\n", encoding="utf-8")
     return True
 
 

--- a/tests/test_utf8_encoding.py
+++ b/tests/test_utf8_encoding.py
@@ -1,0 +1,26 @@
+"""Windows-safe UTF-8 (and BOM) reads for module files (#224)."""
+
+from pathlib import Path
+
+from lola.frontmatter import parse_file, validate_skill
+
+
+def test_parse_file_with_emoji(tmp_path: Path):
+    skill = tmp_path / "SKILL.md"
+    skill.write_bytes(
+        "---\nname: example\ndescription: test skill\n---\n⚠️ warning\n".encode("utf-8")
+    )
+    meta, body = parse_file(skill)
+    assert meta.get("name") == "example"
+    assert "warning" in body
+
+
+def test_parse_file_with_utf8_bom(tmp_path: Path):
+    skill = tmp_path / "SKILL.md"
+    # BOM + frontmatter — without utf-8-sig, startswith("---") fails
+    skill.write_bytes(
+        "\ufeff---\nname: example\ndescription: test skill\n---\nbody\n".encode("utf-8")
+    )
+    # validate_skill uses read_text + startswith("---")
+    errors = validate_skill(skill)
+    assert not any("Missing YAML frontmatter" in e for e in errors), errors

--- a/tests/test_utf8_encoding.py
+++ b/tests/test_utf8_encoding.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from lola.frontmatter import parse_file, validate_skill
+from lola.frontmatter import get_metadata, parse_file, validate_skill
 
 
 def test_parse_file_with_emoji(tmp_path: Path):
@@ -12,15 +12,24 @@ def test_parse_file_with_emoji(tmp_path: Path):
     )
     meta, body = parse_file(skill)
     assert meta.get("name") == "example"
+    assert "⚠️" in body
     assert "warning" in body
 
 
 def test_parse_file_with_utf8_bom(tmp_path: Path):
     skill = tmp_path / "SKILL.md"
-    # BOM + frontmatter — without utf-8-sig, startswith("---") fails
+    # BOM + frontmatter — without utf-8-sig, startswith("---") fails and
+    # frontmatter.load() returns empty metadata without raising.
     skill.write_bytes(
         "\ufeff---\nname: example\ndescription: test skill\n---\nbody\n".encode("utf-8")
     )
     # validate_skill uses read_text + startswith("---")
     errors = validate_skill(skill)
     assert not any("Missing YAML frontmatter" in e for e in errors), errors
+
+    # parse_file / get_metadata must also see the frontmatter fields
+    meta, body = parse_file(skill)
+    assert meta.get("name") == "example"
+    assert meta.get("description") == "test skill"
+    assert "body" in body
+    assert get_metadata(skill).get("name") == "example"


### PR DESCRIPTION
## Summary
On Windows, `Path.read_text()` / `write_text()` without an explicit `encoding` use the locale codec (typically `cp1252`). Module files with emoji or other non-ASCII UTF-8 content then raise `UnicodeDecodeError` during `lola mod info` / `lola install`. A UTF-8 BOM also breaks the `startswith("---")` frontmatter check.

## Changes
- Read module/config text with `encoding="utf-8-sig"` (strips BOM when present).
- Write with `encoding="utf-8"`.
- Cover emoji + BOM cases with unit tests on frontmatter validation.

Closes #224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with UTF-8 files that include a byte-order mark.
  * Generated and updated configuration, skill, command, agent, and instruction files now consistently use UTF-8 encoding.
  * Preserved existing parsing, validation, sorting, and error-handling behavior.
  * Improved reliable reading and writing of configuration files across supported integrations.

* **Tests**
  * Added coverage for UTF-8 content, including emoji and BOM-prefixed files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->