### PR TITLE
fix: APPENG-5812 Lola env var syntax translation for agent configuration

### DIFF
--- a/src/lola/targets/__init__.py
+++ b/src/lola/targets/__init__.py
@@ -18,6 +18,8 @@ from lola.targets.base import (
     ManagedInstructionsTarget,
     ManagedSectionTarget,
     MCPSupportMixin,
+    _convert_env_var_to_cursor_vscode,
+    _convert_env_var_to_opencode,
     _generate_agent_with_frontmatter,
     _generate_passthrough_command,
     _get_content_path,
@@ -25,6 +27,7 @@ from lola.targets.base import (
     _merge_mcps_into_file,
     _remove_mcps_from_file,
     _skill_source_dir,
+    _transform_mcp_env_vars,
 )
 
 # Concrete target implementations
@@ -121,4 +124,7 @@ __all__ = [
     "_generate_agent_with_frontmatter",
     "_merge_mcps_into_file",
     "_remove_mcps_from_file",
+    "_convert_env_var_to_cursor_vscode",
+    "_convert_env_var_to_opencode",
+    "_transform_mcp_env_vars",
 ]

--- a/src/lola/targets/base.py
+++ b/src/lola/targets/base.py
@@ -821,6 +821,62 @@ class MCPSupportMixin:
 
 
 # =============================================================================
+# MCP environment variable syntax converters
+# =============================================================================
+#
+# Lola's canonical mcps.json format uses POSIX-style ``${VAR}`` for env var
+# references. Different assistants expect different substitution syntaxes,
+# so each target converts the canonical form to its own during install.
+
+
+def _convert_env_var_to_opencode(value: str) -> str:
+    """Convert ${VAR} (or ${env:VAR}) syntax to OpenCode's {env:VAR} syntax.
+
+    Accepts both Lola's canonical ``${VAR}`` and Cursor/VS Code's
+    ``${env:VAR}`` so a mis-prefixed input becomes ``{env:VAR}`` rather
+    than ``{env:env:VAR}``. Already-OpenCode ``{env:VAR}`` is untouched
+    (no leading ``$``).
+    """
+    return re.sub(r"\$\{(?:env:)?([^}]+)\}", r"{env:\1}", value)
+
+
+def _convert_env_var_to_cursor_vscode(value: str) -> str:
+    """Convert ${VAR} syntax to Cursor/VS Code's ${env:VAR} syntax."""
+    return re.sub(r"\$\{([^}:]+)\}", r"${env:\1}", value)
+
+
+def _transform_mcp_env_vars(
+    server_config: dict[str, Any],
+    converter: Callable[[str], str],
+) -> dict[str, Any]:
+    """Apply an env var syntax converter to a server config's env/url/headers.
+
+    Leaves the rest of the config structure (command, args, type, etc.)
+    untouched; only string values in ``env``, ``url``, and ``headers`` are
+    passed through ``converter``.
+    """
+    result = dict(server_config)
+
+    env = result.get("env")
+    if isinstance(env, dict):
+        result["env"] = {
+            k: converter(v) if isinstance(v, str) else v for k, v in env.items()
+        }
+
+    url = result.get("url")
+    if isinstance(url, str):
+        result["url"] = converter(url)
+
+    headers = result.get("headers")
+    if isinstance(headers, dict):
+        result["headers"] = {
+            k: converter(v) if isinstance(v, str) else v for k, v in headers.items()
+        }
+
+    return result
+
+
+# =============================================================================
 # Shared helper functions
 # =============================================================================
 

--- a/src/lola/targets/copilot.py
+++ b/src/lola/targets/copilot.py
@@ -12,7 +12,9 @@ from .base import (
     BaseAssistantTarget,
     ManagedInstructionsTarget,
     MCPSupportMixin,
+    _convert_env_var_to_cursor_vscode,
     _generate_passthrough_command,
+    _transform_mcp_env_vars,
 )
 
 
@@ -229,8 +231,10 @@ def _transform_mcp_to_vscode(server_config: dict[str, Any]) -> dict[str, Any]:
     VS Code expects an explicit ``type`` field: ``stdio`` for command-based
     servers and ``http``/``sse`` for remote servers. Remote configs already
     carry their ``type``; command-based (stdio) configs do not, so it is added.
+    Env var references are converted from Lola's ``${VAR}`` syntax to VS
+    Code's ``${env:VAR}`` syntax.
     """
-    result = dict(server_config)
+    result = _transform_mcp_env_vars(server_config, _convert_env_var_to_cursor_vscode)
     if "type" not in result:
         result["type"] = "http" if "url" in result else "stdio"
     return result

--- a/src/lola/targets/cursor.py
+++ b/src/lola/targets/cursor.py
@@ -11,14 +11,18 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
+from typing import Any
 
 import lola.config as config
 from .base import (
     MCPSupportMixin,
     BaseAssistantTarget,
+    _convert_env_var_to_cursor_vscode,
     _generate_passthrough_command,
     _generate_agent_with_frontmatter,
+    _merge_mcps_into_file,
     _transform_claude_agent_frontmatter,
+    _transform_mcp_env_vars,
 )
 
 
@@ -47,6 +51,21 @@ class CursorTarget(MCPSupportMixin, BaseAssistantTarget):
     def get_mcp_path(self, project_path: str, scope: str = "project") -> Path:
         base = Path.home() if scope == "user" else Path(project_path)
         return base / ".cursor" / "mcp.json"
+
+    def generate_mcps(
+        self,
+        mcps: dict[str, dict[str, Any]],
+        dest_path: Path,
+        module_name: str,
+    ) -> bool:
+        """Merge MCP servers, converting env var refs to Cursor's ${env:VAR} syntax."""
+        if not mcps:
+            return False
+        transformed = {
+            name: _transform_mcp_env_vars(cfg, _convert_env_var_to_cursor_vscode)
+            for name, cfg in mcps.items()
+        }
+        return _merge_mcps_into_file(dest_path, module_name, transformed)
 
     def generate_skill(
         self,

--- a/src/lola/targets/opencode.py
+++ b/src/lola/targets/opencode.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import re
 from pathlib import Path
 from typing import Any
 
@@ -13,6 +12,7 @@ import lola.config as config
 from .base import (
     BaseAssistantTarget,
     ManagedInstructionsTarget,
+    _convert_env_var_to_opencode,
     _generate_agent_with_frontmatter,
     _generate_passthrough_command,
 )
@@ -21,11 +21,6 @@ from .base import (
 # =============================================================================
 # OpenCode-specific MCP helpers
 # =============================================================================
-
-
-def _convert_env_var_syntax(value: str) -> str:
-    """Convert ${VAR} syntax to OpenCode's {env:VAR} syntax."""
-    return re.sub(r"\$\{([^}]+)\}", r"{env:\1}", value)
 
 
 # Lola standard: http and sse only. OpenCode uses "remote" as its canonical type.
@@ -102,7 +97,7 @@ def _transform_mcp_to_opencode(server_config: dict[str, Any]) -> dict[str, Any]:
         # Remote server: convert to OpenCode's "remote" type
         url = server_config.get("url")
         if isinstance(url, str):
-            url = _convert_env_var_syntax(url)
+            url = _convert_env_var_to_opencode(url)
         remote_result: dict[str, Any] = {
             "type": "remote",
         }
@@ -111,7 +106,7 @@ def _transform_mcp_to_opencode(server_config: dict[str, Any]) -> dict[str, Any]:
         headers = server_config.get("headers", {})
         if headers:
             remote_result["headers"] = {
-                k: _convert_env_var_syntax(v) if isinstance(v, str) else v
+                k: _convert_env_var_to_opencode(v) if isinstance(v, str) else v
                 for k, v in headers.items()
             }
         return remote_result
@@ -126,7 +121,7 @@ def _transform_mcp_to_opencode(server_config: dict[str, Any]) -> dict[str, Any]:
     env = server_config.get("env", {})
     if env:
         result["environment"] = {
-            k: _convert_env_var_syntax(v) if isinstance(v, str) else v
+            k: _convert_env_var_to_opencode(v) if isinstance(v, str) else v
             for k, v in env.items()
         }
 

--- a/tests/test_mcps.py
+++ b/tests/test_mcps.py
@@ -9,6 +9,7 @@ from lola import frontmatter as fm
 from lola.models import Installation, Module
 from lola.targets import (
     ClaudeCodeTarget,
+    CopilotVSCodeTarget,
     CursorTarget,
     GeminiTarget,
     OpenCodeTarget,
@@ -384,6 +385,76 @@ class TestTargetMCPGeneration:
         content = json.loads(mcp_path.read_text())
         assert "github" in content["mcpServers"]
 
+    def test_cursor_converts_env_var_syntax(self, tmp_path):
+        """CursorTarget converts ${VAR} to ${env:VAR} syntax in env values."""
+        target = CursorTarget()
+        cursor_dir = tmp_path / ".cursor"
+        cursor_dir.mkdir()
+        mcp_path = cursor_dir / "mcp.json"
+
+        servers = {
+            "jira": {
+                "command": "uv",
+                "args": ["run", "jira-mcp"],
+                "env": {
+                    "JIRA_URL": "https://issues.example.com",
+                    "JIRA_TOKEN": "${JIRA_TOKEN}",
+                },
+            },
+        }
+
+        result = target.generate_mcps(servers, mcp_path, "tools")
+
+        assert result is True
+        content = json.loads(mcp_path.read_text())
+        server = content["mcpServers"]["jira"]
+        # Static values preserved, ${VAR} converted to ${env:VAR}
+        assert server["env"]["JIRA_URL"] == "https://issues.example.com"
+        assert server["env"]["JIRA_TOKEN"] == "${env:JIRA_TOKEN}"
+
+    def test_cursor_converts_env_var_syntax_in_remote_headers_and_url(self, tmp_path):
+        """CursorTarget converts ${VAR} in url/headers for remote HTTP servers."""
+        target = CursorTarget()
+        cursor_dir = tmp_path / ".cursor"
+        cursor_dir.mkdir()
+        mcp_path = cursor_dir / "mcp.json"
+
+        servers = {
+            "aap-mcp": {
+                "type": "http",
+                "url": "https://${AAP_MCP_SERVER}/job_management/mcp",
+                "headers": {"Authorization": "Bearer ${AAP_API_TOKEN}"},
+            },
+        }
+
+        result = target.generate_mcps(servers, mcp_path, "tools")
+
+        assert result is True
+        content = json.loads(mcp_path.read_text())
+        server = content["mcpServers"]["aap-mcp"]
+        assert server["url"] == "https://${env:AAP_MCP_SERVER}/job_management/mcp"
+        assert server["headers"]["Authorization"] == "Bearer ${env:AAP_API_TOKEN}"
+
+    def test_cursor_preserves_already_converted_env_var(self, tmp_path):
+        """CursorTarget doesn't double-convert an already-${env:VAR} reference."""
+        target = CursorTarget()
+        cursor_dir = tmp_path / ".cursor"
+        cursor_dir.mkdir()
+        mcp_path = cursor_dir / "mcp.json"
+
+        servers = {
+            "server": {
+                "command": "npx",
+                "args": [],
+                "env": {"TOKEN": "${env:TOKEN}"},
+            },
+        }
+
+        target.generate_mcps(servers, mcp_path, "tools")
+
+        content = json.loads(mcp_path.read_text())
+        assert content["mcpServers"]["server"]["env"]["TOKEN"] == "${env:TOKEN}"
+
     def test_gemini_generates_settings_json(self, tmp_path):
         """GeminiTarget creates .gemini/settings.json correctly."""
         target = GeminiTarget()
@@ -475,6 +546,122 @@ class TestTargetMCPGeneration:
         assert server["environment"]["JIRA_URL"] == "https://issues.example.com"
         assert server["environment"]["JIRA_TOKEN"] == "{env:JIRA_TOKEN}"
         assert server["environment"]["API_KEY"] == "{env:API_KEY}"
+
+    def test_opencode_normalizes_cursor_style_env_var(self, tmp_path):
+        """OpenCodeTarget maps ${env:VAR} to {env:VAR}, not {env:env:VAR}."""
+        target = OpenCodeTarget()
+        mcp_path = tmp_path / "opencode.json"
+
+        servers = {
+            "server": {
+                "command": "npx",
+                "args": [],
+                "env": {"TOKEN": "${env:TOKEN}"},
+            },
+        }
+
+        target.generate_mcps(servers, mcp_path, "tools")
+
+        content = json.loads(mcp_path.read_text())
+        assert content["mcp"]["server"]["environment"]["TOKEN"] == "{env:TOKEN}"
+
+    def test_opencode_preserves_already_converted_env_var(self, tmp_path):
+        """OpenCodeTarget leaves an already-{env:VAR} reference unchanged."""
+        target = OpenCodeTarget()
+        mcp_path = tmp_path / "opencode.json"
+
+        servers = {
+            "server": {
+                "command": "npx",
+                "args": [],
+                "env": {"TOKEN": "{env:TOKEN}"},
+            },
+        }
+
+        target.generate_mcps(servers, mcp_path, "tools")
+
+        content = json.loads(mcp_path.read_text())
+        assert content["mcp"]["server"]["environment"]["TOKEN"] == "{env:TOKEN}"
+
+
+# =============================================================================
+# VS Code (Copilot) MCP Env Var Conversion Tests
+# =============================================================================
+
+
+class TestVSCodeMCPGeneration:
+    """Tests for CopilotVSCodeTarget's env var syntax conversion."""
+
+    def test_vscode_converts_env_var_syntax(self, tmp_path):
+        """CopilotVSCodeTarget converts ${VAR} to ${env:VAR} syntax in env values."""
+        target = CopilotVSCodeTarget()
+        vscode_dir = tmp_path / ".vscode"
+        vscode_dir.mkdir()
+        mcp_path = vscode_dir / "mcp.json"
+
+        servers = {
+            "jira": {
+                "command": "uv",
+                "args": ["run", "jira-mcp"],
+                "env": {
+                    "JIRA_URL": "https://issues.example.com",
+                    "JIRA_TOKEN": "${JIRA_TOKEN}",
+                },
+            },
+        }
+
+        result = target.generate_mcps(servers, mcp_path, "tools")
+
+        assert result is True
+        content = json.loads(mcp_path.read_text())
+        server = content["servers"]["jira"]
+        assert server["type"] == "stdio"
+        assert server["env"]["JIRA_URL"] == "https://issues.example.com"
+        assert server["env"]["JIRA_TOKEN"] == "${env:JIRA_TOKEN}"
+
+    def test_vscode_converts_env_var_syntax_in_remote_headers_and_url(self, tmp_path):
+        """CopilotVSCodeTarget converts ${VAR} in url/headers for remote servers."""
+        target = CopilotVSCodeTarget()
+        vscode_dir = tmp_path / ".vscode"
+        vscode_dir.mkdir()
+        mcp_path = vscode_dir / "mcp.json"
+
+        servers = {
+            "aap-mcp": {
+                "type": "http",
+                "url": "https://${AAP_MCP_SERVER}/job_management/mcp",
+                "headers": {"Authorization": "Bearer ${AAP_API_TOKEN}"},
+            },
+        }
+
+        result = target.generate_mcps(servers, mcp_path, "tools")
+
+        assert result is True
+        content = json.loads(mcp_path.read_text())
+        server = content["servers"]["aap-mcp"]
+        assert server["type"] == "http"
+        assert server["url"] == "https://${env:AAP_MCP_SERVER}/job_management/mcp"
+        assert server["headers"]["Authorization"] == "Bearer ${env:AAP_API_TOKEN}"
+
+    def test_vscode_preserves_already_converted_env_var(self, tmp_path):
+        """CopilotVSCodeTarget doesn't double-convert an already-${env:VAR} ref."""
+        target = CopilotVSCodeTarget()
+        vscode_dir = tmp_path / ".vscode"
+        vscode_dir.mkdir()
+        mcp_path = vscode_dir / "mcp.json"
+
+        servers = {
+            "server": {
+                "command": "npx",
+                "args": [],
+                "env": {"TOKEN": "${env:TOKEN}"},
+            },
+        }
+
+        target.generate_mcps(servers, mcp_path, "tools")
+
+        content = json.loads(mcp_path.read_text())
+        assert content["servers"]["server"]["env"]["TOKEN"] == "${env:TOKEN}"
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Translate Lola's canonical MCP env-var placeholders (`${VAR}`) into each assistant's native syntax at install time: Cursor/VS Code → `${env:VAR}`, OpenCode → `{env:VAR}`.
- Apply conversion to MCP `env`, `url`, and `headers` string values so remote servers and auth headers work correctly across targets.
- Preserve already-native forms and normalize Cursor-style `${env:VAR}` when writing OpenCode config (avoids `{env:env:VAR}`).

## Related Issues

- Fixes APPENG-5812

## Test Plan

- [x] `pytest` (including new cases in `tests/test_mcps.py` for Cursor, VS Code/Copilot, and OpenCode env-var conversion, remote headers/url, and already-converted preservation)
- [X ] Install a module with `mcps.json` using `${VAR}` into Cursor and confirm generated MCP config uses `${env:VAR}`
- [ ] Install the same module into OpenCode and confirm generated config uses `{env:VAR}`
- [ ] Re-install / update and confirm already-converted values are left unchanged (no double-prefix)

## Checklist

- [x] Tests pass (`pytest`)
- [x] Linting passes (`ruff check src tests`)
- [x] Type checking passes (`ty check`)

## AI Disclosure

AI-assisted with Cursor (drafting/review support); changes reviewed and verified locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP configuration generation for Cursor.
  * Added consistent environment-variable syntax conversion across Cursor, OpenCode, and Copilot in VS Code.
  * Remote MCP URLs, headers, and local environment values are now handled consistently.

* **Bug Fixes**
  * Preserved already-converted environment references and non-string configuration values.
  * Empty MCP configurations are handled without generating output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->