### PR TITLE
ci: bump gh-action-pypi-publish to v1.14.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
           path: dist/
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -81,4 +81,4 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2


### PR DESCRIPTION
## Problem

The `Publish to TestPyPI` job [fails](https://github.com/LobsterTrap/lola/actions/runs/31730530350/job/94549669340) with:

```
Checking dist/lola_ai-0.7.1.dev34-py3-none-any.whl: ERROR InvalidDistribution:
Invalid distribution metadata: '2.5' is not a valid metadata version
```

Nothing in this repo changed. `hatchling` is unpinned in `[build-system].requires`, and hatchling 1.30+ (now 1.32.0) emits `Metadata-Version: 2.5`. The pinned `gh-action-pypi-publish@v1.13.0` image ships twine 6, which rejects that metadata version.

Reproduced locally: `uv build` in this repo produces a wheel with `Metadata-Version: 2.5`.

## Fix

Bump both publish steps to `v1.14.2` (`dc37677`), the release that [adds Metadata 2.5 support](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.14.2) via twine 7.

Pinning `hatchling<1.30` was considered and rejected — twine 7, flit 4, and this action all support 2.5 now, so pinning just defers the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package publishing workflow to use the latest publishing action version.
  * No end-user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->