### PR TITLE
fix: [BUG] - Behavior with existing symlinks is unexpected

### DIFF
--- a/src/lola/targets/base.py
+++ b/src/lola/targets/base.py
@@ -357,6 +357,9 @@ class BaseAssistantTarget(AssistantTarget):
     def remove_skill(self, dest_path: Path, skill_name: str) -> bool:
         """Default: remove skill directory."""
         skill_dir = dest_path / skill_name
+        if skill_dir.is_symlink():
+            skill_dir.unlink()
+            return True
         if skill_dir.exists():
             shutil.rmtree(skill_dir)
             return True

--- a/src/lola/targets/base.py
+++ b/src/lola/targets/base.py
@@ -26,6 +26,20 @@ import yaml
 import lola.frontmatter as fm
 
 
+def unlink_symlink_if_present(path: Path) -> None:
+    """Remove ``path`` if it is a symlink, so a later write lands at a real
+    location rather than following the link to its target.
+
+    A pre-existing symlink (for example a user manually ``ln -s``ing a skill
+    directory into a separate checkout) must not be written through: Lola
+    would silently rewrite the external target instead of the destination
+    the user asked for. Idempotent - no-op when ``path`` does not exist or is
+    not a symlink.
+    """
+    if path.is_symlink():
+        path.unlink()
+
+
 _CLAUDE_TOOL_NAME_MAP: dict[str, str] = {
     "lsp": "LSP",
     "webfetch": "WebFetch",

--- a/src/lola/targets/claude_code.py
+++ b/src/lola/targets/claude_code.py
@@ -13,6 +13,7 @@ from .base import (
     _generate_agent_with_frontmatter,
     _generate_passthrough_command,
     _transform_claude_agent_frontmatter,
+    unlink_symlink_if_present,
 )
 
 
@@ -59,14 +60,18 @@ class ClaudeCodeTarget(MCPSupportMixin, ManagedInstructionsTarget, BaseAssistant
         # Replace a pre-existing symlink (e.g. a user's manual ln -s into a
         # separate checkout) with a real directory instead of writing through
         # it or failing to create a directory over a file symlink.
-        if skill_dest.is_symlink():
-            skill_dest.unlink()
+        unlink_symlink_if_present(skill_dest)
         skill_dest.mkdir(parents=True, exist_ok=True)
 
         # Copy SKILL.md
         skill_file = source_path / config.SKILL_FILE
         if skill_file.exists():
-            (skill_dest / "SKILL.md").write_text(skill_file.read_text())
+            skill_file_dest = skill_dest / "SKILL.md"
+            # Write must not follow a symlink that shadows the skill file
+            # (written before by a manual ln -s or a previous target): the
+            # link points at an external file Lola should not overwrite.
+            unlink_symlink_if_present(skill_file_dest)
+            skill_file_dest.write_text(skill_file.read_text())
 
         # Copy supporting files
         for item in source_path.iterdir():
@@ -80,6 +85,9 @@ class ClaudeCodeTarget(MCPSupportMixin, ManagedInstructionsTarget, BaseAssistant
                     shutil.rmtree(dest_item)
                 shutil.copytree(item, dest_item)
             else:
+                # Regular file: copy2 follows a pre-existing symlink and
+                # rewrites its target, so unlink the link first.
+                unlink_symlink_if_present(dest_item)
                 shutil.copy2(item, dest_item)
         return True
 

--- a/src/lola/targets/claude_code.py
+++ b/src/lola/targets/claude_code.py
@@ -56,6 +56,11 @@ class ClaudeCodeTarget(MCPSupportMixin, ManagedInstructionsTarget, BaseAssistant
             return False
 
         skill_dest = dest_path / skill_name
+        # Replace a pre-existing symlink (e.g. a user's manual ln -s into a
+        # separate checkout) with a real directory instead of writing through
+        # it or failing to create a directory over a file symlink.
+        if skill_dest.is_symlink():
+            skill_dest.unlink()
         skill_dest.mkdir(parents=True, exist_ok=True)
 
         # Copy SKILL.md

--- a/src/lola/targets/claude_code.py
+++ b/src/lola/targets/claude_code.py
@@ -74,7 +74,9 @@ class ClaudeCodeTarget(MCPSupportMixin, ManagedInstructionsTarget, BaseAssistant
                 continue
             dest_item = skill_dest / item.name
             if item.is_dir():
-                if dest_item.exists():
+                if dest_item.is_symlink():
+                    dest_item.unlink()
+                elif dest_item.exists():
                     shutil.rmtree(dest_item)
                 shutil.copytree(item, dest_item)
             else:

--- a/src/lola/targets/copilot.py
+++ b/src/lola/targets/copilot.py
@@ -15,6 +15,7 @@ from .base import (
     _convert_env_var_to_cursor_vscode,
     _generate_passthrough_command,
     _transform_mcp_env_vars,
+    unlink_symlink_if_present,
 )
 
 
@@ -91,8 +92,7 @@ class CopilotCliTarget(MCPSupportMixin, ManagedInstructionsTarget, BaseAssistant
         # Replace a pre-existing symlink (e.g. a user's manual ln -s into a
         # separate checkout) with a real directory instead of writing through
         # it or failing to create a directory over a file symlink.
-        if skill_dir.is_symlink():
-            skill_dir.unlink()
+        unlink_symlink_if_present(skill_dir)
         skill_dir.mkdir(parents=True, exist_ok=True)
 
         # Build Copilot-compatible frontmatter (requires name + description)
@@ -113,6 +113,10 @@ class CopilotCliTarget(MCPSupportMixin, ManagedInstructionsTarget, BaseAssistant
         output = f"---\n{fm_str}\n---\n{body}"
 
         dest_file = skill_dir / "SKILL.md"
+        # Write must not follow a symlink that shadows the skill file (a
+        # manual ln -s or an earlier target): the link points at an external
+        # file Lola should not overwrite.
+        unlink_symlink_if_present(dest_file)
         dest_file.write_text(output)
 
         # Copy supporting files (scripts, examples, etc.)
@@ -129,6 +133,9 @@ class CopilotCliTarget(MCPSupportMixin, ManagedInstructionsTarget, BaseAssistant
                     shutil.rmtree(dest_item)
                 shutil.copytree(item, dest_item)
             else:
+                # copy2 follows a pre-existing symlink and rewrites its
+                # target; unlink the link first so the write stays local.
+                unlink_symlink_if_present(dest_item)
                 shutil.copy2(item, dest_item)
 
         return True

--- a/src/lola/targets/copilot.py
+++ b/src/lola/targets/copilot.py
@@ -88,6 +88,11 @@ class CopilotCliTarget(MCPSupportMixin, ManagedInstructionsTarget, BaseAssistant
             return False
 
         skill_dir = dest_path / skill_name
+        # Replace a pre-existing symlink (e.g. a user's manual ln -s into a
+        # separate checkout) with a real directory instead of writing through
+        # it or failing to create a directory over a file symlink.
+        if skill_dir.is_symlink():
+            skill_dir.unlink()
         skill_dir.mkdir(parents=True, exist_ok=True)
 
         # Build Copilot-compatible frontmatter (requires name + description)

--- a/src/lola/targets/copilot.py
+++ b/src/lola/targets/copilot.py
@@ -123,7 +123,9 @@ class CopilotCliTarget(MCPSupportMixin, ManagedInstructionsTarget, BaseAssistant
                 continue
             dest_item = skill_dir / item.name
             if item.is_dir():
-                if dest_item.exists():
+                if dest_item.is_symlink():
+                    dest_item.unlink()
+                elif dest_item.exists():
                     shutil.rmtree(dest_item)
                 shutil.copytree(item, dest_item)
             else:
@@ -137,7 +139,10 @@ class CopilotCliTarget(MCPSupportMixin, ManagedInstructionsTarget, BaseAssistant
 
         removed = False
         skill_dir = dest_path / skill_name
-        if skill_dir.exists():
+        if skill_dir.is_symlink():
+            skill_dir.unlink()
+            removed = True
+        elif skill_dir.exists():
             shutil.rmtree(skill_dir)
             removed = True
         # Legacy cleanup: old .instructions.md format

--- a/src/lola/targets/cursor.py
+++ b/src/lola/targets/cursor.py
@@ -23,6 +23,7 @@ from .base import (
     _merge_mcps_into_file,
     _transform_claude_agent_frontmatter,
     _transform_mcp_env_vars,
+    unlink_symlink_if_present,
 )
 
 
@@ -82,6 +83,9 @@ class CursorTarget(MCPSupportMixin, BaseAssistantTarget):
             return False
 
         skill_dest = dest_path / skill_name
+        # Never mkdir or write through a pre-existing symlink; unlink first so
+        # a manual ln -s into an external checkout is replaced with a real dir.
+        unlink_symlink_if_present(skill_dest)
         skill_dest.mkdir(parents=True, exist_ok=True)
 
         # Copy SKILL.md
@@ -89,7 +93,9 @@ class CursorTarget(MCPSupportMixin, BaseAssistantTarget):
         if not skill_file.exists():
             return False
 
-        (skill_dest / "SKILL.md").write_text(skill_file.read_text())
+        skill_file_dest = skill_dest / "SKILL.md"
+        unlink_symlink_if_present(skill_file_dest)
+        skill_file_dest.write_text(skill_file.read_text())
 
         # Copy supporting files
         for item in source_path.iterdir():
@@ -97,10 +103,14 @@ class CursorTarget(MCPSupportMixin, BaseAssistantTarget):
                 continue
             dest_item = skill_dest / item.name
             if item.is_dir():
-                if dest_item.exists():
+                if dest_item.is_symlink():
+                    dest_item.unlink()
+                elif dest_item.exists():
                     shutil.rmtree(dest_item)
                 shutil.copytree(item, dest_item)
             else:
+                # copy2 follows a pre-existing symlink; unlink first.
+                unlink_symlink_if_present(dest_item)
                 shutil.copy2(item, dest_item)
         return True
 

--- a/src/lola/targets/cursor.py
+++ b/src/lola/targets/cursor.py
@@ -82,6 +82,11 @@ class CursorTarget(MCPSupportMixin, BaseAssistantTarget):
         if not source_path.exists():
             return False
 
+        # Validate the source before replacing any existing destination link.
+        skill_file = source_path / config.SKILL_FILE
+        if not skill_file.exists():
+            return False
+
         skill_dest = dest_path / skill_name
         # Never mkdir or write through a pre-existing symlink; unlink first so
         # a manual ln -s into an external checkout is replaced with a real dir.
@@ -89,10 +94,6 @@ class CursorTarget(MCPSupportMixin, BaseAssistantTarget):
         skill_dest.mkdir(parents=True, exist_ok=True)
 
         # Copy SKILL.md
-        skill_file = source_path / config.SKILL_FILE
-        if not skill_file.exists():
-            return False
-
         skill_file_dest = skill_dest / "SKILL.md"
         unlink_symlink_if_present(skill_file_dest)
         skill_file_dest.write_text(skill_file.read_text())

--- a/src/lola/targets/install.py
+++ b/src/lola/targets/install.py
@@ -48,6 +48,8 @@ def _path_contains_symlink(base: Path, child: Path) -> bool:
     ``ln -s`` into a separate checkout) was not written by Lola, so it must
     not be treated as an idempotent re-install.
     """
+    if base.is_symlink():
+        return True
     try:
         rel = child.relative_to(base)
     except ValueError:
@@ -252,9 +254,10 @@ def _check_skill_exists(
     else:
         # For file-based targets, check if directory/file exists
         if target.name == "cursor":
-            return (skill_dest / f"{skill_name}.mdc").exists()
+            candidate = skill_dest / f"{skill_name}.mdc"
         else:
-            return (skill_dest / skill_name).exists()
+            candidate = skill_dest / skill_name
+        return candidate.is_symlink() or candidate.exists()
 
 
 def _install_skills(

--- a/src/lola/targets/install.py
+++ b/src/lola/targets/install.py
@@ -315,6 +315,13 @@ def _install_skills(
                     # variant wrote it): treat as an installed no-op.
                     installed.append(skill_name)
                     continue
+                elif not is_interactive():
+                    console.print(
+                        f"  [yellow]Skill '{skill_name}' already exists; "
+                        "use --force to overwrite in non-interactive mode.[/yellow]"
+                    )
+                    failed.append(skill_name)
+                    continue
                 elif click.confirm(
                     f"Skill '{skill_name}' already exists. Overwrite?", default=False
                 ):

--- a/src/lola/targets/install.py
+++ b/src/lola/targets/install.py
@@ -41,6 +41,25 @@ console = Console()
 # =============================================================================
 
 
+def _path_contains_symlink(base: Path, child: Path) -> bool:
+    """Return True if any component of ``child`` below ``base`` is a symlink.
+
+    A destination that only exists through a symlink (e.g. a user's manual
+    ``ln -s`` into a separate checkout) was not written by Lola, so it must
+    not be treated as an idempotent re-install.
+    """
+    try:
+        rel = child.relative_to(base)
+    except ValueError:
+        return True
+    current = base
+    for part in rel.parts:
+        current = current / part
+        if current.is_symlink():
+            return True
+    return False
+
+
 def _generation_is_idempotent(
     generate_fn: Callable[[Path], bool], real_dest: Path
 ) -> bool:
@@ -55,6 +74,10 @@ def _generation_is_idempotent(
     This lets two targets that write identical output to the same path (for
     example copilot-cli and copilot-vscode sharing ``.github/``) coexist
     without a spurious overwrite conflict.
+
+    Files that are only reachable through a symlink are never considered a
+    no-op: Lola did not create them, so the normal overwrite prompt should
+    apply instead of silently skipping.
     """
     import tempfile
 
@@ -73,6 +96,8 @@ def _generation_is_idempotent(
             produced_any = True
             rel = gen_file.relative_to(tmp_dest)
             real_file = real_dest / rel
+            if _path_contains_symlink(real_dest, real_file):
+                return False
             if not real_file.exists() or real_file.is_dir():
                 return False
             if gen_file.read_bytes() != real_file.read_bytes():

--- a/src/lola/targets/openclaw.py
+++ b/src/lola/targets/openclaw.py
@@ -63,15 +63,16 @@ class OpenClawTarget(BaseAssistantTarget):
         if not source_path.exists():
             return False
 
+        # Validate the source before replacing any existing destination link.
+        skill_file = source_path / config.SKILL_FILE
+        if not skill_file.exists():
+            return False
+
         skill_dest = dest_path / skill_name
         # Never mkdir or write through a pre-existing symlink; unlink first so
         # a manual ln -s into an external checkout is replaced with a real dir.
         unlink_symlink_if_present(skill_dest)
         skill_dest.mkdir(parents=True, exist_ok=True)
-
-        skill_file = source_path / config.SKILL_FILE
-        if not skill_file.exists():
-            return False
 
         skill_file_dest = skill_dest / "SKILL.md"
         unlink_symlink_if_present(skill_file_dest)

--- a/src/lola/targets/openclaw.py
+++ b/src/lola/targets/openclaw.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path
 
 import lola.config as config
-from .base import BaseAssistantTarget
+from .base import BaseAssistantTarget, unlink_symlink_if_present
 
 
 class OpenClawTarget(BaseAssistantTarget):
@@ -64,23 +64,32 @@ class OpenClawTarget(BaseAssistantTarget):
             return False
 
         skill_dest = dest_path / skill_name
+        # Never mkdir or write through a pre-existing symlink; unlink first so
+        # a manual ln -s into an external checkout is replaced with a real dir.
+        unlink_symlink_if_present(skill_dest)
         skill_dest.mkdir(parents=True, exist_ok=True)
 
         skill_file = source_path / config.SKILL_FILE
         if not skill_file.exists():
             return False
 
-        (skill_dest / "SKILL.md").write_text(skill_file.read_text())
+        skill_file_dest = skill_dest / "SKILL.md"
+        unlink_symlink_if_present(skill_file_dest)
+        skill_file_dest.write_text(skill_file.read_text())
 
         for item in source_path.iterdir():
             if item.name == "SKILL.md":
                 continue
             dest_item = skill_dest / item.name
             if item.is_dir():
-                if dest_item.exists():
+                if dest_item.is_symlink():
+                    dest_item.unlink()
+                elif dest_item.exists():
                     shutil.rmtree(dest_item)
                 shutil.copytree(item, dest_item)
             else:
+                # copy2 follows a pre-existing symlink; unlink first.
+                unlink_symlink_if_present(dest_item)
                 shutil.copy2(item, dest_item)
 
         return True

--- a/src/lola/targets/opencode.py
+++ b/src/lola/targets/opencode.py
@@ -15,6 +15,7 @@ from .base import (
     _convert_env_var_to_opencode,
     _generate_agent_with_frontmatter,
     _generate_passthrough_command,
+    unlink_symlink_if_present,
 )
 
 
@@ -271,10 +272,15 @@ class OpenCodeTarget(ManagedInstructionsTarget, BaseAssistantTarget):
             return False
 
         skill_dest = dest_path / skill_name
+        # Never mkdir or write through a pre-existing symlink; unlink first so
+        # a manual ln -s into an external checkout is replaced with a real dir.
+        unlink_symlink_if_present(skill_dest)
         skill_dest.mkdir(parents=True, exist_ok=True)
 
-        # Copy SKILL.md
-        shutil.copy2(skill_file, skill_dest / config.SKILL_FILE)
+        # Copy SKILL.md; copy2 follows a pre-existing symlink, so unlink it.
+        skill_file_dest = skill_dest / config.SKILL_FILE
+        unlink_symlink_if_present(skill_file_dest)
+        shutil.copy2(skill_file, skill_file_dest)
 
         # Copy supporting files (scripts, references, assets, etc.)
         for item in source_path.iterdir():
@@ -282,10 +288,14 @@ class OpenCodeTarget(ManagedInstructionsTarget, BaseAssistantTarget):
                 continue
             dest_item = skill_dest / item.name
             if item.is_dir():
-                if dest_item.exists():
+                if dest_item.is_symlink():
+                    dest_item.unlink()
+                elif dest_item.exists():
                     shutil.rmtree(dest_item)
                 shutil.copytree(item, dest_item)
             else:
+                # copy2 follows a pre-existing symlink; unlink first.
+                unlink_symlink_if_present(dest_item)
                 shutil.copy2(item, dest_item)
         return True
 

--- a/tests/test_copilot_target.py
+++ b/tests/test_copilot_target.py
@@ -136,6 +136,32 @@ def test_generate_skill_basic(tmp_path):
     assert "Do the thing." in content
 
 
+def test_generate_skill_replaces_nested_directory_symlink(tmp_path):
+    """Supporting directory symlinks are replaced without touching targets."""
+    target = CopilotTarget()
+    source = tmp_path / "my-skill"
+    source.mkdir()
+    (source / "SKILL.md").write_text(
+        "---\ndescription: Does the thing\n---\n\nDo the thing.\n"
+    )
+    (source / "scripts").mkdir()
+    (source / "scripts" / "helper.py").write_text("new")
+
+    dest = tmp_path / "skills"
+    skill_dest = dest / "my-skill"
+    skill_dest.mkdir(parents=True)
+    external = tmp_path / "external"
+    external.mkdir()
+    (external / "old.py").write_text("old")
+    (skill_dest / "scripts").symlink_to(external, target_is_directory=True)
+
+    assert target.generate_skill(source, dest, "my-skill") is True
+
+    assert not (skill_dest / "scripts").is_symlink()
+    assert (skill_dest / "scripts" / "helper.py").exists()
+    assert (external / "old.py").read_text() == "old"
+
+
 def test_generate_skill_missing_description(tmp_path):
     """Return False if SKILL.md has no description (required by Copilot)."""
     target = CopilotTarget()
@@ -234,6 +260,18 @@ def test_remove_skill_not_found(tmp_path):
 
     result = target.remove_skill(dest, "missing")
     assert result is False
+
+
+def test_remove_skill_removes_dangling_symlink(tmp_path):
+    """Removing a dangling symlink unlinks it instead of ignoring it."""
+    target = CopilotTarget()
+    dest = tmp_path / "skills"
+    dest.mkdir()
+    link = dest / "missing"
+    link.symlink_to(tmp_path / "missing-target", target_is_directory=True)
+
+    assert target.remove_skill(dest, "missing") is True
+    assert not link.is_symlink()
 
 
 # --- copilot-vscode variant tests ---

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -346,7 +346,7 @@ class TestGenerationIsIdempotent:
         assert installed_vscode == ["skill1"]
         assert failed_vscode == []
 
-    def test_returns_false_when_destination_is_symlink(self, tmp_path):
+    def test_returns_false_when_destination_is_symlink(self, tmp_path: Path) -> None:
         """A skill that exists only via a symlink (e.g. a user's manual ln -s
         into a separate checkout) must not be treated as an idempotent
         re-install: the overwrite prompt should apply instead."""
@@ -360,7 +360,7 @@ class TestGenerationIsIdempotent:
         (external / "f.txt").write_text("same")
         (real / "link").symlink_to(external, target_is_directory=True)
 
-        def generate(d):
+        def generate(d: Path) -> bool:
             (d / "link").mkdir(parents=True)
             (d / "link" / "f.txt").write_text("same")
             return True
@@ -419,7 +419,10 @@ class TestInstallSkillsSymlink:
         link.symlink_to(external, target_is_directory=True)
 
         module = self._make_module(tmp_path, content="new")
-        with mock.patch("click.confirm", return_value=True):
+        with (
+            mock.patch("lola.targets.install.is_interactive", return_value=True),
+            mock.patch("click.confirm", return_value=True),
+        ):
             installed, failed = _install_skills(
                 ClaudeCodeTarget(), module, module.path, str(proj), "project"
             )
@@ -453,7 +456,10 @@ class TestInstallSkillsSymlink:
         link.symlink_to(external / "SKILL.md")
 
         module = self._make_module(tmp_path, content="new")
-        with mock.patch("click.confirm", return_value=True):
+        with (
+            mock.patch("lola.targets.install.is_interactive", return_value=True),
+            mock.patch("click.confirm", return_value=True),
+        ):
             installed, failed = _install_skills(
                 ClaudeCodeTarget(), module, module.path, str(proj), "project"
             )
@@ -477,7 +483,10 @@ class TestInstallSkillsSymlink:
         link.symlink_to(tmp_path / "missing-target", target_is_directory=True)
 
         module = self._make_module(tmp_path, content="new")
-        with mock.patch("click.confirm", return_value=True):
+        with (
+            mock.patch("lola.targets.install.is_interactive", return_value=True),
+            mock.patch("click.confirm", return_value=True),
+        ):
             installed, failed = _install_skills(
                 ClaudeCodeTarget(), module, module.path, str(proj), "project"
             )
@@ -486,6 +495,41 @@ class TestInstallSkillsSymlink:
         assert failed == []
         assert not link.is_symlink()
         assert (link / "SKILL.md").read_text() == "new"
+
+    def test_non_interactive_symlink_conflict_requires_force(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """Non-interactive installs report the conflict and preserve the link."""
+        from unittest import mock
+
+        from lola.targets.claude_code import ClaudeCodeTarget
+        from lola.targets.install import _install_skills
+
+        proj = tmp_path / "proj"
+        skills_dir = proj / ".claude" / "skills"
+        skills_dir.mkdir(parents=True)
+
+        external = tmp_path / "external"
+        external.mkdir()
+        (external / "SKILL.md").write_text("external")
+        link = skills_dir / "skill1"
+        link.symlink_to(external, target_is_directory=True)
+
+        module = self._make_module(tmp_path, content="new")
+        with (
+            mock.patch("lola.targets.install.is_interactive", return_value=False),
+            mock.patch("lola.targets.install.click.confirm") as confirm,
+        ):
+            installed, failed = _install_skills(
+                ClaudeCodeTarget(), module, module.path, str(proj), "project"
+            )
+
+        assert installed == []
+        assert failed == ["skill1"]
+        assert link.is_symlink()
+        assert (external / "SKILL.md").read_text() == "external"
+        confirm.assert_not_called()
+        assert "use --force" in capsys.readouterr().out
 
 
 class TestRunInstallHook:

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,5 +1,6 @@
 """Tests for the core/installer module."""
 
+from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 
@@ -366,11 +367,27 @@ class TestGenerationIsIdempotent:
 
         assert _generation_is_idempotent(generate, real) is False
 
+    def test_returns_false_when_base_is_symlink(self, tmp_path: Path) -> None:
+        """A symlinked destination root is never treated as idempotent."""
+        from lola.targets.install import _generation_is_idempotent
+
+        external = tmp_path / "external"
+        external.mkdir()
+        (external / "f.txt").write_text("same")
+        real = tmp_path / "dest"
+        real.symlink_to(external, target_is_directory=True)
+
+        def generate(d: Path) -> bool:
+            (d / "f.txt").write_text("same")
+            return True
+
+        assert _generation_is_idempotent(generate, real) is False
+
 
 class TestInstallSkillsSymlink:
     """Skills whose destination is a pre-existing symlink."""
 
-    def _make_module(self, tmp_path, content="new"):
+    def _make_module(self, tmp_path: Path, content: str = "new") -> Module:
         module_dir = tmp_path / "mod"
         skill_dir = module_dir / "skills" / "skill1"
         skill_dir.mkdir(parents=True)
@@ -380,7 +397,9 @@ class TestInstallSkillsSymlink:
             name="mymod", path=module_dir, content_path=module_dir, skills=["skill1"]
         )
 
-    def test_overwrite_replaces_directory_symlink_with_real_copy(self, tmp_path):
+    def test_overwrite_replaces_directory_symlink_with_real_copy(
+        self, tmp_path: Path
+    ) -> None:
         """Overwriting a skill whose directory is a symlink creates a real
         managed copy instead of writing through the link."""
         from unittest import mock
@@ -413,7 +432,9 @@ class TestInstallSkillsSymlink:
         # The external target is left untouched.
         assert (external / "SKILL.md").read_text() == "old"
 
-    def test_overwrite_replaces_file_symlink_with_real_copy(self, tmp_path):
+    def test_overwrite_replaces_file_symlink_with_real_copy(
+        self, tmp_path: Path
+    ) -> None:
         """A skill directory that is a file symlink no longer crashes on
         overwrite; it is replaced with a real directory."""
         from unittest import mock
@@ -441,6 +462,30 @@ class TestInstallSkillsSymlink:
         assert failed == []
         assert not link.is_symlink()
         assert (skills_dir / "skill1" / "SKILL.md").read_text() == "new"
+
+    def test_overwrite_replaces_dangling_skill_symlink(self, tmp_path: Path) -> None:
+        """A dangling skill symlink still triggers the overwrite path."""
+        from unittest import mock
+
+        from lola.targets.claude_code import ClaudeCodeTarget
+        from lola.targets.install import _install_skills
+
+        proj = tmp_path / "proj"
+        skills_dir = proj / ".claude" / "skills"
+        skills_dir.mkdir(parents=True)
+        link = skills_dir / "skill1"
+        link.symlink_to(tmp_path / "missing-target", target_is_directory=True)
+
+        module = self._make_module(tmp_path, content="new")
+        with mock.patch("click.confirm", return_value=True):
+            installed, failed = _install_skills(
+                ClaudeCodeTarget(), module, module.path, str(proj), "project"
+            )
+
+        assert installed == ["skill1"]
+        assert failed == []
+        assert not link.is_symlink()
+        assert (link / "SKILL.md").read_text() == "new"
 
 
 class TestRunInstallHook:

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -345,6 +345,103 @@ class TestGenerationIsIdempotent:
         assert installed_vscode == ["skill1"]
         assert failed_vscode == []
 
+    def test_returns_false_when_destination_is_symlink(self, tmp_path):
+        """A skill that exists only via a symlink (e.g. a user's manual ln -s
+        into a separate checkout) must not be treated as an idempotent
+        re-install: the overwrite prompt should apply instead."""
+        from lola.targets.install import _generation_is_idempotent
+
+        real = tmp_path / "dest"
+        real.mkdir()
+
+        external = tmp_path / "external"
+        external.mkdir()
+        (external / "f.txt").write_text("same")
+        (real / "link").symlink_to(external, target_is_directory=True)
+
+        def generate(d):
+            (d / "link").mkdir(parents=True)
+            (d / "link" / "f.txt").write_text("same")
+            return True
+
+        assert _generation_is_idempotent(generate, real) is False
+
+
+class TestInstallSkillsSymlink:
+    """Skills whose destination is a pre-existing symlink."""
+
+    def _make_module(self, tmp_path, content="new"):
+        module_dir = tmp_path / "mod"
+        skill_dir = module_dir / "skills" / "skill1"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(content)
+        (skill_dir / "data.txt").write_text("data")
+        return Module(
+            name="mymod", path=module_dir, content_path=module_dir, skills=["skill1"]
+        )
+
+    def test_overwrite_replaces_directory_symlink_with_real_copy(self, tmp_path):
+        """Overwriting a skill whose directory is a symlink creates a real
+        managed copy instead of writing through the link."""
+        from unittest import mock
+
+        from lola.targets.claude_code import ClaudeCodeTarget
+        from lola.targets.install import _install_skills
+
+        proj = tmp_path / "proj"
+        skills_dir = proj / ".claude" / "skills"
+        skills_dir.mkdir(parents=True)
+
+        external = tmp_path / "external"
+        external.mkdir()
+        (external / "SKILL.md").write_text("old")
+        (external / "data.txt").write_text("data")
+        link = skills_dir / "skill1"
+        link.symlink_to(external, target_is_directory=True)
+
+        module = self._make_module(tmp_path, content="new")
+        with mock.patch("click.confirm", return_value=True):
+            installed, failed = _install_skills(
+                ClaudeCodeTarget(), module, module.path, str(proj), "project"
+            )
+
+        assert installed == ["skill1"]
+        assert failed == []
+        assert not link.is_symlink()
+        assert (skills_dir / "skill1" / "SKILL.md").is_file()
+        assert (skills_dir / "skill1" / "SKILL.md").read_text() == "new"
+        # The external target is left untouched.
+        assert (external / "SKILL.md").read_text() == "old"
+
+    def test_overwrite_replaces_file_symlink_with_real_copy(self, tmp_path):
+        """A skill directory that is a file symlink no longer crashes on
+        overwrite; it is replaced with a real directory."""
+        from unittest import mock
+
+        from lola.targets.claude_code import ClaudeCodeTarget
+        from lola.targets.install import _install_skills
+
+        proj = tmp_path / "proj"
+        skills_dir = proj / ".claude" / "skills"
+        skills_dir.mkdir(parents=True)
+
+        external = tmp_path / "external"
+        external.mkdir()
+        (external / "SKILL.md").write_text("old")
+        link = skills_dir / "skill1"
+        link.symlink_to(external / "SKILL.md")
+
+        module = self._make_module(tmp_path, content="new")
+        with mock.patch("click.confirm", return_value=True):
+            installed, failed = _install_skills(
+                ClaudeCodeTarget(), module, module.path, str(proj), "project"
+            )
+
+        assert installed == ["skill1"]
+        assert failed == []
+        assert not link.is_symlink()
+        assert (skills_dir / "skill1" / "SKILL.md").read_text() == "new"
+
 
 class TestRunInstallHook:
     """Tests for _run_install_hook()."""

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -26,6 +26,7 @@ from lola.targets import (
     get_target,
 )
 from lola.cli.install import _resolve_install_path
+from lola.targets.copilot import CopilotCliTarget
 
 
 # =============================================================================
@@ -595,6 +596,70 @@ Agent body content.
 # =============================================================================
 # CursorTarget Tests
 # =============================================================================
+
+
+@pytest.mark.parametrize(
+    "target_class",
+    [
+        ClaudeCodeTarget,
+        CopilotCliTarget,
+        CursorTarget,
+        OpenClawTarget,
+        OpenCodeTarget,
+    ],
+)
+def test_file_based_targets_replace_skill_directory_symlink(
+    target_class, skill_source: Path, dest_path: Path, tmp_path: Path
+) -> None:
+    """Every file-based target replaces a skill-directory symlink safely."""
+    target = target_class()
+    external = tmp_path / "external"
+    external.mkdir()
+    (external / "sentinel.txt").write_text("external")
+    skill_dest = dest_path / "mymod-test-skill"
+    skill_dest.symlink_to(external, target_is_directory=True)
+
+    assert target.generate_skill(skill_source, dest_path, "mymod-test-skill") is True
+
+    assert not skill_dest.is_symlink()
+    assert (skill_dest / "SKILL.md").is_file()
+    assert (external / "sentinel.txt").read_text() == "external"
+
+
+@pytest.mark.parametrize(
+    "target_class",
+    [
+        ClaudeCodeTarget,
+        CopilotCliTarget,
+        CursorTarget,
+        OpenClawTarget,
+        OpenCodeTarget,
+    ],
+)
+def test_file_based_targets_replace_skill_file_symlinks(
+    target_class, skill_source: Path, dest_path: Path, tmp_path: Path
+) -> None:
+    """Skill and supporting-file links are replaced without touching targets."""
+    target = target_class()
+    skill_dest = dest_path / "mymod-test-skill"
+    skill_dest.mkdir()
+    external = tmp_path / "external"
+    external.mkdir()
+    external_skill = external / "SKILL.md"
+    external_notes = external / "notes.md"
+    external_skill.write_text("external skill")
+    external_notes.write_text("external notes")
+    (skill_dest / "SKILL.md").symlink_to(external_skill)
+    (skill_dest / "notes.md").symlink_to(external_notes)
+
+    assert target.generate_skill(skill_source, dest_path, "mymod-test-skill") is True
+
+    assert not (skill_dest / "SKILL.md").is_symlink()
+    assert not (skill_dest / "notes.md").is_symlink()
+    assert (skill_dest / "SKILL.md").is_file()
+    assert (skill_dest / "notes.md").is_file()
+    assert external_skill.read_text() == "external skill"
+    assert external_notes.read_text() == "external notes"
 
 
 class TestCursorTarget:

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -662,6 +662,26 @@ def test_file_based_targets_replace_skill_file_symlinks(
     assert external_notes.read_text() == "external notes"
 
 
+@pytest.mark.parametrize("target_class", [CursorTarget, OpenClawTarget])
+def test_invalid_skill_does_not_remove_destination_symlink(
+    target_class, tmp_path: Path, dest_path: Path
+) -> None:
+    """Missing SKILL.md leaves an existing destination link untouched."""
+    target = target_class()
+    source = tmp_path / "invalid-skill"
+    source.mkdir()
+    external = tmp_path / "external"
+    external.mkdir()
+    (external / "sentinel.txt").write_text("external")
+    skill_dest = dest_path / "invalid-skill"
+    skill_dest.symlink_to(external, target_is_directory=True)
+
+    assert target.generate_skill(source, dest_path, "invalid-skill") is False
+
+    assert skill_dest.is_symlink()
+    assert (external / "sentinel.txt").read_text() == "external"
+
+
 class TestCursorTarget:
     """Tests for CursorTarget implementation (Cursor 2.4+)."""
 

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -432,6 +432,22 @@ Agent body content.
         result = target.remove_skill(dest_path, "nonexistent")
         assert result is False
 
+    def test_remove_skill_removes_symlink(self, dest_path: Path):
+        """remove_skill should remove a symlinked skill without touching its
+        target (shutil.rmtree would raise on a symlink)."""
+        target = ClaudeCodeTarget()
+        external = dest_path / "external"
+        external.mkdir()
+        (external / "SKILL.md").write_text("content")
+        link = dest_path / "mymod-skill"
+        link.symlink_to(external, target_is_directory=True)
+
+        result = target.remove_skill(dest_path, "mymod-skill")
+
+        assert result is True
+        assert not link.is_symlink()
+        assert (external / "SKILL.md").read_text() == "content"
+
     def test_get_command_filename(self):
         """Command filename should be cmd.md (no prefix)."""
         target = ClaudeCodeTarget()

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -194,6 +194,25 @@ class TestClaudeCodeTarget:
 
         assert (skill_dest / "scripts" / "new_file.py").exists()
 
+    def test_generate_skill_replaces_nested_directory_symlink(
+        self, skill_source: Path, dest_path: Path, tmp_path: Path
+    ) -> None:
+        """Supporting directory symlinks are replaced without touching targets."""
+        target = ClaudeCodeTarget()
+        skill_dest = dest_path / "mymod-test-skill"
+        skill_dest.mkdir()
+
+        external = tmp_path / "external"
+        external.mkdir()
+        (external / "old.py").write_text("old")
+        (skill_dest / "scripts").symlink_to(external, target_is_directory=True)
+
+        target.generate_skill(skill_source, dest_path, "mymod-test-skill")
+
+        assert not (skill_dest / "scripts").is_symlink()
+        assert (skill_dest / "scripts" / "helper.py").exists()
+        assert (external / "old.py").read_text() == "old"
+
     def test_generate_command_creates_file(self, command_source: Path, dest_path: Path):
         """generate_command should create properly named markdown file."""
         target = ClaudeCodeTarget()


### PR DESCRIPTION
Fixes #226

Fixed silent skipping of symlinked skills during install by excluding symlink-reachable destinations from the idempotent re-install no-op (so the overwrite prompt now fires), and made generate_skill/remove_skill replace or unlink pre-existing symlinks instead of writing through them or crashing.

Local tests pass.

---
This change was prepared with AI assistance under human direction and review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved skill installation and removal when destinations are symbolic links, including dangling links.
  - Prevented generated content from being written into linked external files or directories.
  - Safely replaced linked destinations and nested linked folders with generated files or directories while preserving external targets.
  - Avoided modifying destinations when source skill content is invalid.
  - Improved overwrite handling and warnings for conflicting skills.

- **Tests**
  - Added coverage for symbolic-link installation, replacement, idempotency, validation, and removal scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->