### PR TITLE
docs: match ADR naming rule to practice

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -7,11 +7,12 @@ to create, update, and deprecate ADRs.
 ## Quick Start
 
 ```bash
-make adr-new topic-name
+make adr-new 0012-topic-name
 ```
 
-This copies the template to `docs/adr/topic-name.md`. Fill in the sections and
-open a pull request.
+This copies the template to `docs/adr/0012-topic-name.md`. Take the next unused
+number; see [use-adrs.md](use-adrs.md) for the naming rule. Fill in the sections
+and open a pull request.
 
 ## ADR Statuses
 

--- a/docs/adr/use-adrs.md
+++ b/docs/adr/use-adrs.md
@@ -2,7 +2,7 @@
 
 **Status**: Accepted
 **Date**: 2026-04-28
-**Last Updated**: 2026-05-25
+**Last Updated**: 2026-08-26
 **Authors**: Igor Brandao
 **Reviewers**:
 
@@ -22,8 +22,10 @@ Each ADR documents one architectural decision and lives as a single markdown fil
 ## How We Use ADRs
 
 **Creating an ADR:**
-Copy `docs/adr/template.md` to `docs/adr/topic-name.md`, fill in all sections, and
-open a pull request. Use `make adr-new topic-name` for convenience.
+Copy `docs/adr/template.md` to `docs/adr/<nnnn>-<topic-name>.md`, taking the
+next unused number, fill in all sections, and open a pull request. Use
+`make adr-new 0012-topic-name` for convenience; the target writes whatever
+filename you give it.
 
 **Updating an ADR:**
 If a decision changes, update the existing ADR in place and bump `Last Updated` to
@@ -43,13 +45,17 @@ If a decision is no longer relevant, set `Status` to `Deprecated` and update
 
 ## Naming Convention
 
-ADR files use descriptive kebab-case names — no sequential numbers, no date prefix.
-The date lives inside the document. Topic names must be unique.
+ADR files use a sequential number prefix followed by a descriptive kebab-case
+name. The number is allocated when the ADR is opened. The date lives inside the
+document, and topic names must be unique.
 
 ```text
-docs/adr/use-adrs.md
-docs/adr/go-migration.md
+docs/adr/<nnnn>-<topic-name>.md
 ```
+
+ADRs written before this rule keep their existing unnumbered filenames. Nothing
+is renamed retroactively, so cite an older ADR by its actual filename and put
+the number in the link text.
 
 ## Template Changes
 
@@ -59,23 +65,25 @@ approval. Existing ADRs are not retroactively reformatted.
 
 ## Rationale
 
-Topic-based names avoid merge conflicts from sequential numbering and make the ADR
-subject immediately clear from the filename. Updating ADRs in place keeps one file per
-topic with git as the audit trail.
+A number gives every decision a short, stable handle to cite in review and from
+other ADRs, and the kebab-case suffix keeps the subject clear from the filename.
+Updating ADRs in place keeps one file per topic with git as the audit trail.
 
 ## Consequences
 
 ### Positive Consequences
 
-- No merge conflicts from sequential numbering
+- Every ADR has a short, stable identifier to cite
 - ADR filenames are self-describing
 - No external tooling dependency
 - One file per topic
 
 ### Negative Consequences
 
-- ADRs are not ordered by creation date from the filename; use `git log docs/adr/` for
-  chronological ordering
+- Two ADRs drafted concurrently can claim the same number; the later one is
+  renumbered before merge
+- Numbers record allocation order, not the date inside the document; use
+  `git log docs/adr/` for true chronological ordering
 
 ## References
 

--- a/mk/adr.mk
+++ b/mk/adr.mk
@@ -5,10 +5,10 @@ ADR_TEMPLATE := $(ADR_DIR)/template.md
 
 .PHONY: adr-new adr-list adr-help
 
-adr-new: ## - Create new ADR: make adr-new topic-name
+adr-new: ## - Create new ADR: make adr-new 0012-topic-name
 	@if [ -z "$(filter-out $@,$(MAKECMDGOALS))" ]; then \
-		echo "Usage: make adr-new topic-name"; \
-		echo "Example: make adr-new go-migration"; \
+		echo "Usage: make adr-new <nnnn-topic-name>"; \
+		echo "Example: make adr-new 0012-topic-name"; \
 		exit 1; \
 	fi
 	@NAME=$(filter-out $@,$(MAKECMDGOALS)); \
@@ -27,15 +27,15 @@ adr-help: ## - Show ADR usage and examples
 	@echo "Lola ADR (Architecture Decision Records) Management"
 	@echo ""
 	@echo "Commands:"
-	@echo "  make adr-new topic-name  - Create new ADR from template"
+	@echo "  make adr-new nnnn-topic  - Create new ADR from template"
 	@echo "  make adr-list            - List all ADRs"
 	@echo "  make adr-help            - Show this help"
 	@echo ""
 	@echo "Examples:"
-	@echo "  make adr-new go-migration"
-	@echo "  make adr-new use-postgresql"
+	@echo "  make adr-new 0012-topic-name"
+	@echo "  make adr-new 0013-another-topic"
 	@echo ""
-	@echo "ADRs live in $(ADR_DIR)/ as <topic-name>.md"
+	@echo "ADRs live in $(ADR_DIR)/ as <nnnn-topic-name>.md"
 
 # Prevent make from treating arguments as targets
 %:


### PR DESCRIPTION
----
> 🦾 Written with LLM assistance [claude-opus-5]
> 💪 Reviewed by a human before submission
----

## Summary

`use-adrs.md` says ADR filenames carry no sequential number. `template.md`
tells authors to replace XXX with one, and 0004, 0005 and 0006 are all in
flight with numbers. This makes the written rule match what is actually done.

It renames nothing. Files on `main` stay unnumbered.
The trade-off that topic-only naming was chosen to avoid is recorded rather
than dropped: two ADRs drafted at once can claim the same number, and the later
one gets renumbered before merge.

Item #114 asks whether ADRs should be identified by their GitHub issue number
instead of a sequential one. This PR keeps sequential numbering, which is what
every ADR in flight already does, and does not close that question.

<details>
<summary>Why three other files had to change too</summary>

The old rule was stated in more places than the Naming Convention section.
`use-adrs.md`'s own "Creating an ADR" line said `docs/adr/topic-name.md`,
`docs/adr/README.md` described the same output, and `mk/adr.mk` repeated it in
its usage and `adr-help` text. Fixing only the one section would have moved the
contradiction rather than removed it, so all four now show a numbered name.

`use-adrs.md`'s `Last Updated` is bumped to today, which is what its own
"Updating an ADR" rule asks for.

</details>

## Related Issues

Relates to #111, Relates to #112, Relates to #113, Relates to #114.

## Spec / ADR Reference

ADR: `docs/adr/use-adrs.md`
Also touched: `docs/adr/README.md`, `mk/adr.mk` (text only)

## Test Plan

One of the three files is a Makefile fragment, so the diff is worth reading
rather than skimming.

<details>
<summary>Six checks</summary>

- [ ] The Naming Convention section agrees with `docs/adr/template.md`,
      `docs/adr/README.md` and `mk/adr.mk`
- [ ] `git diff` on `mk/adr.mk` touches only `echo` strings and the `##` help
      comment. The `adr-new` recipe is unchanged: `DEST=$(ADR_DIR)/$$NAME.md`
      already writes whatever name it is given, so `make adr-new 0012-topic`
      works today and needs no new logic
- [ ] The Naming Convention section shows the `<nnnn>-<topic-name>.md` shape
      rather than naming specific files. No numbered ADR exists on `main` yet
      and this PR renames nothing, so a concrete example would be a filename
      that 404s
- [ ] `0012` is the next free number. `0004`, `0005` and `0006` are in flight
      on #111, #112 and #113, and `0007` through `0011` are in flight on their
      own branches
- [ ] Files on `main` are still unnumbered, so decide separately whether to
      renumber them or leave the rule applying to new ADRs only
- [ ] `mkdocs build --strict` reports the same two pre-existing
      `dev-guide/contributing.md` warnings as `main`, and no others

</details>

## Checklist

<details>
<summary>Docs plus one Makefile help string, so most items are N/A</summary>

- [x] Tests pass (`pytest` / `go test -race ./...`): N/A, docs and one
      Makefile help string
- [x] Linting passes (`ruff check src tests` / `golangci-lint run`): N/A
- [x] `go vet ./...` passes (Go changes only, N/A otherwise): N/A
- [x] Type checking passes (`uv run ty check`): N/A
- [x] Coverage >80% on changed source files (N/A for docs/config)
- [x] E2E BDD tests added for new CLI commands (N/A if none)
- [x] Commit subjects ≤ 50 chars, body wrapped at 72

</details>

## AI Disclosure

AI-assisted with Claude Code.
